### PR TITLE
Add rustfmt, clippy, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.87.0
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.87.0
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  check:
+    name: cargo check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.87.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --workspace --all-targets

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+msrv = "1.87"
+cognitive-complexity-threshold = 30

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Max"
+newline_style = "Unix"


### PR DESCRIPTION
## Summary
- `rustfmt.toml` pins edition 2021 + 100-char lines + Unix newlines
- `clippy.toml` sets MSRV 1.87 and cognitive-complexity threshold 30
- `.github/workflows/ci.yml` runs fmt / clippy / check as three parallel jobs on push to `main` and every PR, with `Swatinem/rust-cache` on the compiling jobs (`-D warnings` on clippy)

## Test plan
- [x] `cargo fmt --all -- --check` passes locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes locally
- [x] `cargo check --workspace --all-targets` passes locally
- [x] CI runs green on this PR (verifies the workflow itself)

Closes #3
Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established continuous integration pipeline with automated code quality checks, formatting validation, and dependency caching to maintain consistent code standards across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->