### PR TITLE
Land protocol-shaped attestation types and v0 spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,14 @@ jobs:
           toolchain: 1.93.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-targets
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.93.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87.0
+          toolchain: 1.93.0
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87.0
+          toolchain: 1.93.0
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -40,6 +40,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87.0
+          toolchain: 1.93.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,17 @@ dependencies = [
  "anyhow",
  "borsh",
  "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -48,16 +59,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "hashbrown"
@@ -74,6 +130,18 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "ligate-client"
@@ -156,6 +224,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,10 +289,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "winnow"
@@ -210,3 +314,9 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,11 +9,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "ligate-client"
+name = "attestation"
 version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "serde",
+]
 
 [[package]]
-name = "ligate-modules"
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "ligate-client"
 version = "0.0.1"
 
 [[package]]
@@ -21,4 +84,129 @@ name = "ligate-rollup"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde      = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing    = "0.1"
 borsh      = { version = "1.5", features = ["bytes", "derive"] }
+sha2       = "0.10"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
     "crates/rollup",
-    "crates/modules",
+    "crates/modules/attestation",
     "crates/client-rs",
 ]
 
@@ -14,7 +14,7 @@ authors = ["Ligate Labs <hello@ligate.io>"]
 repository = "https://github.com/ligate-io/ligate-chain"
 homepage = "https://ligate.io"
 publish = false
-rust-version = "1.87"
+rust-version = "1.93"
 
 [workspace.dependencies]
 # Sovereign SDK — pinned to nightly rev. Bump alongside module work.
@@ -29,6 +29,7 @@ thiserror  = "1.0"
 serde      = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing    = "0.1"
+borsh      = { version = "1.5", features = ["bytes", "derive"] }
 
 [profile.release]
 lto = "thin"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.87"
+msrv = "1.93"
 cognitive-complexity-threshold = 30

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -14,3 +14,7 @@ rust-version.workspace = true
 anyhow.workspace = true
 borsh.workspace = true
 serde.workspace = true
+sha2.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "ligate-modules"
-description = "Ligate Labs rollup modules (attestation, token, ...)"
+name = "attestation"
+description = "Ligate Themisra attestation module — Proof of Prompt receipts"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,3 +11,6 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+anyhow.workspace = true
+borsh.workspace = true
+serde.workspace = true

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -34,6 +34,7 @@ use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 // ----- Primitive aliases ------------------------------------------------------
 
@@ -121,6 +122,42 @@ pub struct Schema {
     pub fee_routing_addr: Option<Address>,
 }
 
+impl Schema {
+    /// Derive a [`SchemaId`] from its defining tuple.
+    ///
+    /// Formula: `SHA-256(owner ‖ name ‖ version_le_bytes)`. The
+    /// state-transition re-runs this at registration and stores the
+    /// derived id on-chain, so downstream consumers never have to trust
+    /// a submitter-claimed id.
+    pub fn derive_id(owner: &Address, name: &str, version: u32) -> SchemaId {
+        let mut hasher = Sha256::new();
+        hasher.update(owner);
+        hasher.update(name.as_bytes());
+        hasher.update(version.to_le_bytes());
+        hasher.finalize().into()
+    }
+}
+
+impl AttestorSet {
+    /// Derive an [`AttestorSetId`] from members + threshold.
+    ///
+    /// Members are **sorted internally** before hashing so the set id is
+    /// independent of the caller's input order. The state transition
+    /// stores members in the same sorted order it uses for derivation.
+    /// Duplicate pubkeys are preserved (the state transition rejects
+    /// sets with duplicates at registration).
+    pub fn derive_id(members: &[PubKey], threshold: u8) -> AttestorSetId {
+        let mut sorted = members.to_vec();
+        sorted.sort_unstable();
+        let mut hasher = Sha256::new();
+        for m in &sorted {
+            hasher.update(m);
+        }
+        hasher.update([threshold]);
+        hasher.finalize().into()
+    }
+}
+
 // ----- Attestation ------------------------------------------------------------
 
 /// Key used for the attestation store: `(schema_id, payload_hash)`.
@@ -169,6 +206,18 @@ pub struct SignedAttestationPayload {
     pub submitter: Address,
     /// See [`Attestation::timestamp`].
     pub timestamp: u64,
+}
+
+impl SignedAttestationPayload {
+    /// SHA-256 of the canonical Borsh encoding of this payload.
+    ///
+    /// This is the digest each attestor signs over. Exposed as a
+    /// library helper so attestor quorum software and SDKs don't have
+    /// to re-implement the encoding rule.
+    pub fn digest(&self) -> Hash32 {
+        let bytes = borsh::to_vec(self).expect("Borsh serialization of owned data is infallible");
+        Sha256::digest(&bytes).into()
+    }
 }
 
 // ----- Messages ---------------------------------------------------------------
@@ -247,3 +296,237 @@ pub const MAX_BUILDER_BPS: u16 = 5000;
 /// Placeholder constant — real fee sizing is a governance parameter set
 /// at launch. Documented here for reference against the spec.
 pub const DEFAULT_ATTESTATION_FEE_LGT_MICROS: u64 = 1_000; // 0.001 $LGT at 6 decimals
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_address(n: u8) -> Address {
+        [n; 32]
+    }
+
+    fn sample_pubkey(n: u8) -> PubKey {
+        [n; 32]
+    }
+
+    fn sample_schema() -> Schema {
+        Schema {
+            owner: sample_address(42),
+            name: "themisra.proof-of-prompt".to_string(),
+            version: 1,
+            attestor_set: [7u8; 32],
+            fee_routing_bps: 2500,
+            fee_routing_addr: Some(sample_address(99)),
+        }
+    }
+
+    fn sample_attestor_set() -> AttestorSet {
+        AttestorSet {
+            members: vec![sample_pubkey(1), sample_pubkey(2), sample_pubkey(3)],
+            threshold: 2,
+        }
+    }
+
+    fn sample_attestation() -> Attestation {
+        Attestation {
+            schema_id: [3u8; 32],
+            payload_hash: [4u8; 32],
+            submitter: sample_address(5),
+            timestamp: 1_700_000_000,
+            signatures: vec![AttestorSignature { pubkey: sample_pubkey(1), sig: vec![0xab; 64] }],
+        }
+    }
+
+    // ------ Borsh round-trips --------------------------------------------
+
+    #[test]
+    fn schema_borsh_round_trip() {
+        let original = sample_schema();
+        let bytes = borsh::to_vec(&original).expect("encode");
+        let decoded: Schema = borsh::from_slice(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn attestor_set_borsh_round_trip() {
+        let original = sample_attestor_set();
+        let bytes = borsh::to_vec(&original).expect("encode");
+        let decoded: AttestorSet = borsh::from_slice(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn attestation_borsh_round_trip() {
+        let original = sample_attestation();
+        let bytes = borsh::to_vec(&original).expect("encode");
+        let decoded: Attestation = borsh::from_slice(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn call_message_borsh_round_trip() {
+        let msgs = vec![
+            CallMessage::RegisterAttestorSet {
+                members: vec![sample_pubkey(1), sample_pubkey(2)],
+                threshold: 1,
+            },
+            CallMessage::RegisterSchema {
+                name: "foo.bar".into(),
+                version: 3,
+                attestor_set: [8u8; 32],
+                fee_routing_bps: 1000,
+                fee_routing_addr: Some(sample_address(10)),
+            },
+            CallMessage::SubmitAttestation {
+                schema_id: [1u8; 32],
+                payload_hash: [2u8; 32],
+                signatures: vec![AttestorSignature {
+                    pubkey: sample_pubkey(1),
+                    sig: vec![0xcd; 64],
+                }],
+            },
+        ];
+        for msg in msgs {
+            let bytes = borsh::to_vec(&msg).expect("encode");
+            let decoded: CallMessage = borsh::from_slice(&bytes).expect("decode");
+            assert_eq!(msg, decoded);
+        }
+    }
+
+    #[test]
+    fn signed_payload_borsh_round_trip() {
+        let original = SignedAttestationPayload {
+            schema_id: [9u8; 32],
+            payload_hash: [1u8; 32],
+            submitter: sample_address(7),
+            timestamp: 1_234_567_890,
+        };
+        let bytes = borsh::to_vec(&original).expect("encode");
+        let decoded: SignedAttestationPayload = borsh::from_slice(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    // ------ JSON round-trips (serde) -------------------------------------
+
+    #[test]
+    fn schema_json_round_trip() {
+        let original = sample_schema();
+        let json = serde_json::to_string(&original).expect("encode");
+        let decoded: Schema = serde_json::from_str(&json).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn attestation_json_round_trip() {
+        let original = sample_attestation();
+        let json = serde_json::to_string(&original).expect("encode");
+        let decoded: Attestation = serde_json::from_str(&json).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    // ------ Schema::derive_id --------------------------------------------
+
+    #[test]
+    fn schema_derive_id_is_deterministic() {
+        let a = Schema::derive_id(&sample_address(1), "foo", 1);
+        let b = Schema::derive_id(&sample_address(1), "foo", 1);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn schema_derive_id_separates_owners() {
+        // Same name + version, different owner → different schema_id.
+        // This is the core anti-squatting property: namespaces are
+        // owner-scoped, not global.
+        let owner_a = Schema::derive_id(&sample_address(1), "themisra.pop", 1);
+        let owner_b = Schema::derive_id(&sample_address(2), "themisra.pop", 1);
+        assert_ne!(owner_a, owner_b);
+    }
+
+    #[test]
+    fn schema_derive_id_bumps_on_version() {
+        let v1 = Schema::derive_id(&sample_address(1), "foo", 1);
+        let v2 = Schema::derive_id(&sample_address(1), "foo", 2);
+        assert_ne!(v1, v2);
+    }
+
+    #[test]
+    fn schema_derive_id_separates_names() {
+        let a = Schema::derive_id(&sample_address(1), "foo", 1);
+        let b = Schema::derive_id(&sample_address(1), "bar", 1);
+        assert_ne!(a, b);
+    }
+
+    // ------ AttestorSet::derive_id ---------------------------------------
+
+    #[test]
+    fn attestor_set_derive_id_is_deterministic() {
+        let members = vec![sample_pubkey(1), sample_pubkey(2)];
+        let a = AttestorSet::derive_id(&members, 1);
+        let b = AttestorSet::derive_id(&members, 1);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn attestor_set_derive_id_ignores_member_order() {
+        // Member ordering is a canonical-encoding detail; the set id
+        // must be order-independent so SDKs don't have to pre-sort.
+        let a = AttestorSet::derive_id(&[sample_pubkey(1), sample_pubkey(2)], 1);
+        let b = AttestorSet::derive_id(&[sample_pubkey(2), sample_pubkey(1)], 1);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn attestor_set_derive_id_depends_on_threshold() {
+        let members = vec![sample_pubkey(1), sample_pubkey(2)];
+        let t1 = AttestorSet::derive_id(&members, 1);
+        let t2 = AttestorSet::derive_id(&members, 2);
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn attestor_set_derive_id_depends_on_members() {
+        let a = AttestorSet::derive_id(&[sample_pubkey(1)], 1);
+        let b = AttestorSet::derive_id(&[sample_pubkey(2)], 1);
+        assert_ne!(a, b);
+    }
+
+    // ------ SignedAttestationPayload::digest -----------------------------
+
+    #[test]
+    fn signed_payload_digest_is_deterministic() {
+        let payload = SignedAttestationPayload {
+            schema_id: [1u8; 32],
+            payload_hash: [2u8; 32],
+            submitter: sample_address(3),
+            timestamp: 1_000_000,
+        };
+        assert_eq!(payload.digest(), payload.digest());
+    }
+
+    #[test]
+    fn signed_payload_digest_changes_with_fields() {
+        let base = SignedAttestationPayload {
+            schema_id: [1u8; 32],
+            payload_hash: [2u8; 32],
+            submitter: sample_address(3),
+            timestamp: 1_000_000,
+        };
+        let mut mutated = base.clone();
+        mutated.timestamp += 1;
+        assert_ne!(base.digest(), mutated.digest());
+    }
+
+    // ------ Protocol constants -------------------------------------------
+
+    #[test]
+    fn max_builder_bps_is_half() {
+        // Documenting the invariant explicitly so a future refactor
+        // doesn't silently raise the cap without thought.
+        assert_eq!(MAX_BUILDER_BPS, 5000);
+    }
+}

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -1,0 +1,249 @@
+//! Ligate attestation protocol — generic on-chain attestation primitive.
+//!
+//! This crate implements the protocol's data shapes and state layout.
+//! See [`docs/protocol/attestation-v0.md`][spec] for the full specification.
+//!
+//! [spec]: https://github.com/ligate-io/ligate-chain/blob/main/docs/protocol/attestation-v0.md
+//!
+//! # Protocol summary
+//!
+//! Three entities, three `StateMap`s, three call messages:
+//!
+//! | Entity | Identified by | Registered by |
+//! |---|---|---|
+//! | [`AttestorSet`]  | `SHA-256(members ‖ threshold)` | [`CallMessage::RegisterAttestorSet`] |
+//! | [`Schema`]       | `SHA-256(owner ‖ name ‖ version)` | [`CallMessage::RegisterSchema`] |
+//! | [`Attestation`]  | `(schema_id, payload_hash)` | [`CallMessage::SubmitAttestation`] |
+//!
+//! Reads (`get_schema`, `get_attestor_set`, `get_attestation`, listing variants)
+//! are exposed via query RPC and deliberately absent from [`CallMessage`] —
+//! verification is a read, not a state-mutating transaction.
+//!
+//! # Scope of this crate
+//!
+//! **Types + state layout only.** State transitions (`call`), genesis,
+//! query RPC, and fee-split enforcement land in sibling issues once the
+//! Sovereign SDK integration is unblocked. The receipt store is aliased
+//! to [`BTreeMap`] as a stand-in for `sov_modules_api::StateMap` so
+//! downstream crates (Themisra's schema crate, the client SDK, unit
+//! tests) can name the type against a concrete shape.
+
+#![deny(missing_docs)]
+
+use std::collections::BTreeMap;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+// ----- Primitive aliases ------------------------------------------------------
+
+/// 32-byte SHA-256 digest used for every hash field on the protocol.
+pub type Hash32 = [u8; 32];
+
+/// Canonical 32-byte address type. The real chain-level address type will
+/// be an `S::Address` once the Sovereign SDK is wired in; the raw-bytes
+/// alias here lets us carry the same shape without the generic bound.
+pub type Address = Hash32;
+
+/// Public key material. Ed25519 for v0 (32 bytes); the placeholder keeps
+/// the protocol shape flexible for later aggregate schemes (BLS, etc.).
+pub type PubKey = Hash32;
+
+/// Schema identifier: `SHA-256(owner ‖ name ‖ version)`.
+pub type SchemaId = Hash32;
+
+/// AttestorSet identifier: `SHA-256(members ‖ threshold)`.
+pub type AttestorSetId = Hash32;
+
+// ----- AttestorSet ------------------------------------------------------------
+
+/// A quorum of signers. **Immutable once registered** — to "rotate" an
+/// attestor set, register a new one and bump any affected schema to a new
+/// version that points at the new [`AttestorSetId`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct AttestorSet {
+    /// Ordered list of attestor public keys.
+    ///
+    /// Order matters for the derivation of [`AttestorSetId`] — callers
+    /// must supply a canonical (e.g. lexicographic) ordering, and the
+    /// state transition re-hashes to verify before accepting.
+    pub members: Vec<PubKey>,
+    /// M-of-N signatures required. `threshold ≤ members.len()` is an
+    /// invariant the state transition enforces at registration time.
+    pub threshold: u8,
+}
+
+/// Single attestor's co-signature on an [`Attestation`].
+///
+/// `sig` is `Vec<u8>` rather than a fixed-size array so we can support
+/// different signature schemes (ed25519 = 64 bytes, BLS = 48, etc.) under
+/// the same type; exact validation is scheme-specific and lives in the
+/// state transition.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct AttestorSignature {
+    /// Signer's public key. Must appear in the schema's
+    /// [`AttestorSet::members`] for the signature to be accepted.
+    pub pubkey: PubKey,
+    /// Signature over the canonical Borsh encoding of
+    /// [`SignedAttestationPayload`].
+    pub sig: Vec<u8>,
+}
+
+// ----- Schema -----------------------------------------------------------------
+
+/// An app's attestation shape and rules.
+///
+/// Registration is permissionless — anyone with enough $LGT to pay the
+/// registration fee can register a schema. Name collisions across owners
+/// are allowed (different `owner` bytes → different [`SchemaId`]); social
+/// identity of the "real" schema owner lives off-chain.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct Schema {
+    /// Registrant; receives control over schema version upgrades and
+    /// [`Schema::fee_routing_addr`]. Schema fields are otherwise immutable.
+    pub owner: Address,
+    /// Human-readable handle, e.g. `"themisra.proof-of-prompt"`. Only
+    /// unique within an `owner`'s namespace.
+    pub name: String,
+    /// Monotonic per-schema version. Bumping version = new
+    /// [`SchemaId`] = new [`Schema`] entry; no in-place mutation.
+    pub version: u32,
+    /// [`AttestorSetId`] of the quorum that must sign attestations under
+    /// this schema. Must reference a registered [`AttestorSet`].
+    pub attestor_set: AttestorSetId,
+    /// Share of the attestation fee routed to [`Schema::fee_routing_addr`],
+    /// in basis points (1/10,000). Protocol caps this at 5000 (50%) in
+    /// v0; governance-adjustable in v1+.
+    pub fee_routing_bps: u16,
+    /// Destination of the builder's fee share. `None` iff
+    /// `fee_routing_bps == 0` — the state transition rejects dangling
+    /// routing and orphan addresses at registration time.
+    pub fee_routing_addr: Option<Address>,
+}
+
+// ----- Attestation ------------------------------------------------------------
+
+/// Key used for the attestation store: `(schema_id, payload_hash)`.
+///
+/// Each pair is write-once — resubmitting the same pair is rejected by
+/// the state transition. This is also what provides replay protection for
+/// the attestor signatures.
+pub type AttestationKey = (SchemaId, Hash32);
+
+/// Stored attestation record.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct Attestation {
+    /// Schema this attestation is bound to. Dictates payload semantics
+    /// and which attestor set must have signed.
+    pub schema_id: SchemaId,
+    /// Caller-computed digest of the off-chain payload. The chain never
+    /// sees the plaintext.
+    pub payload_hash: Hash32,
+    /// Address that submitted the attestation. Paid the fee; owns the
+    /// record for accounting purposes.
+    pub submitter: Address,
+    /// Unix seconds, sourced from the transaction's block header (not
+    /// submitter-provided, to prevent timestamp games).
+    pub timestamp: u64,
+    /// Quorum signatures over [`SignedAttestationPayload`]. All pubkeys
+    /// must be ∈ `schema.attestor_set.members`; count of valid sigs
+    /// must be ≥ `schema.attestor_set.threshold`.
+    pub signatures: Vec<AttestorSignature>,
+}
+
+/// Canonical payload attestors sign over.
+///
+/// Borsh-encoded, hashed, and signed off-chain by each attestor before
+/// the submitter aggregates signatures and submits to the chain.
+///
+/// Deliberately excludes the [`Attestation::signatures`] field (circular)
+/// and any caller-adversarial data. Replay protection comes from the
+/// write-once `(schema_id, payload_hash)` invariant, not from this struct.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct SignedAttestationPayload {
+    /// See [`Attestation::schema_id`].
+    pub schema_id: SchemaId,
+    /// See [`Attestation::payload_hash`].
+    pub payload_hash: Hash32,
+    /// See [`Attestation::submitter`].
+    pub submitter: Address,
+    /// See [`Attestation::timestamp`].
+    pub timestamp: u64,
+}
+
+// ----- Messages ---------------------------------------------------------------
+
+/// State-changing messages accepted by the attestation module.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub enum CallMessage {
+    /// Register a new [`AttestorSet`].
+    ///
+    /// Costs `ATTESTOR_SET_FEE` $LGT (governance, default 10 $LGT).
+    /// Derivation: `SHA-256(borsh(members) ‖ threshold)`. Rejected if a
+    /// set with the derived id already exists.
+    RegisterAttestorSet {
+        /// See [`AttestorSet::members`].
+        members: Vec<PubKey>,
+        /// See [`AttestorSet::threshold`].
+        threshold: u8,
+    },
+
+    /// Register a new [`Schema`].
+    ///
+    /// Costs `SCHEMA_REGISTRATION_FEE` $LGT (governance, default 100 $LGT).
+    /// Owner is the transaction submitter. `attestor_set` must reference
+    /// an already-registered [`AttestorSet`]. `fee_routing_bps` must be
+    /// ≤ `MAX_BUILDER_BPS` (5000 in v0). `fee_routing_addr` must be
+    /// `Some` iff `fee_routing_bps > 0`.
+    RegisterSchema {
+        /// See [`Schema::name`].
+        name: String,
+        /// See [`Schema::version`].
+        version: u32,
+        /// See [`Schema::attestor_set`].
+        attestor_set: AttestorSetId,
+        /// See [`Schema::fee_routing_bps`].
+        fee_routing_bps: u16,
+        /// See [`Schema::fee_routing_addr`].
+        fee_routing_addr: Option<Address>,
+    },
+
+    /// Submit a new [`Attestation`] under an existing schema.
+    ///
+    /// Costs `ATTESTATION_FEE` $LGT (governance, default 0.001 $LGT),
+    /// split per [`Schema::fee_routing_bps`]. Signatures are validated
+    /// against the schema's [`AttestorSet`] at submission time.
+    SubmitAttestation {
+        /// See [`Attestation::schema_id`].
+        schema_id: SchemaId,
+        /// See [`Attestation::payload_hash`].
+        payload_hash: Hash32,
+        /// See [`Attestation::signatures`].
+        signatures: Vec<AttestorSignature>,
+    },
+}
+
+// ----- State layout (placeholder) --------------------------------------------
+
+/// Schema store, keyed by [`SchemaId`]. Placeholder for the eventual
+/// `sov_modules_api::StateMap<SchemaId, Schema>` — see crate-level docs.
+pub type SchemaStore = BTreeMap<SchemaId, Schema>;
+
+/// Attestor-set store, keyed by [`AttestorSetId`]. Placeholder for the
+/// eventual `sov_modules_api::StateMap<AttestorSetId, AttestorSet>`.
+pub type AttestorSetStore = BTreeMap<AttestorSetId, AttestorSet>;
+
+/// Attestation store, keyed by [`AttestationKey`]. Placeholder for the
+/// eventual `sov_modules_api::StateMap<AttestationKey, Attestation>`.
+pub type AttestationStore = BTreeMap<AttestationKey, Attestation>;
+
+// ----- Protocol constants -----------------------------------------------------
+
+/// Maximum `fee_routing_bps` accepted at schema registration (5000 = 50%).
+/// Governance-adjustable in v1+; hardcoded for v0.
+pub const MAX_BUILDER_BPS: u16 = 5000;
+
+/// Default attestation fee in $LGT, in the chain's smallest unit.
+/// Placeholder constant — real fee sizing is a governance parameter set
+/// at launch. Documented here for reference against the spec.
+pub const DEFAULT_ATTESTATION_FEE_LGT_MICROS: u64 = 1_000; // 0.001 $LGT at 6 decimals

--- a/crates/modules/src/lib.rs
+++ b/crates/modules/src/lib.rs
@@ -1,2 +1,0 @@
-// Ligate rollup modules — scaffold.
-// Attestation module lands in issue #4.

--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -1,0 +1,255 @@
+# Ligate Attestation Protocol — Specification v0
+
+**Status:** design draft for v0 devnet implementation
+**Scope:** types, state layout, state transitions, fees, invariants
+**Applies to:** the `attestation` Sovereign SDK module in `crates/modules/attestation`
+
+---
+
+## Purpose
+
+Ligate Chain's core primitive is a **generic on-chain attestation protocol**.
+
+Anyone can:
+
+1. **Register an AttestorSet** — a quorum of signers (pubkeys + threshold)
+2. **Register a Schema** — the shape of an attestation: who owns it, what it's called, which AttestorSet must sign under it, optional fee routing
+3. **Submit an Attestation** — a signed payload hash bound to a schema
+
+Chain stores only hashes and signatures — never plaintext prompts, outputs, or sensitive payload data. Apps hash their domain-specific payloads client-side.
+
+The protocol is intentionally narrow. It does **not** do identity, reputation, slashing, cryptographic inference verification, or payments. Those are separate modules or external primitives composed on top.
+
+**Flagship consumers** (using the protocol; not part of it):
+- **Themisra** — Proof of Prompt (schema: `themisra.proof-of-prompt/v1`)
+- **Kleidon** — SaaS / gaming products (multiple schemas in v1+)
+- **Ligate MCP Server + Relayer** — attestation for AI agents (multiple schemas, v0.5 product)
+
+---
+
+## Entities
+
+### Schema
+
+Identifies an app's attestation shape and rules.
+
+```
+Schema {
+    id:               [u8; 32]          // SHA-256(owner ‖ name ‖ version)
+    owner:            Address           // who registered it; can upgrade (new version = new id)
+    name:             String            // human-readable, e.g. "themisra.proof-of-prompt"
+    version:          u32               // monotonic; immutable per id
+    attestor_set:     AttestorSetId     // which quorum must sign under this schema
+    fee_routing_bps:  u16               // 0–5000 basis points (cap 50%)
+    fee_routing_addr: Option<Address>   // where the builder's share goes; None = 100% treasury
+}
+```
+
+Registration is **permissionless** (anyone can register) — spam mitigated by the registration fee in $LGT.
+
+**Namespace ownership:** `schema_id` is derived from `owner` too, so two different owners registering the same `name` produce different `schema_id`s. No protocol-level name squatting. Social identity (who is the "real" Themisra) is handled off-chain via owner address + verified-tag metadata in SDKs and explorers. Same model as ERC-20 token names.
+
+### AttestorSet
+
+A quorum of signers. **Immutable once registered.**
+
+```
+AttestorSet {
+    id:         [u8; 32]        // SHA-256(members ‖ threshold)
+    members:    Vec<PubKey>     // ed25519 for v0
+    threshold:  u8              // M-of-N signatures required
+}
+```
+
+To "rotate" an attestor set, register a new one and point an affected schema to it via a schema version bump. No in-place mutation.
+
+### Attestation
+
+The on-chain record.
+
+```
+Attestation {
+    schema_id:    SchemaId
+    payload_hash: [u8; 32]                // app-computed; chain never sees plaintext
+    submitter:    Address
+    timestamp:    u64                      // unix seconds, from the tx's block header
+    signatures:   Vec<AttestorSignature>  // validated against schema.attestor_set at submit time
+}
+
+AttestorSignature {
+    pubkey: [u8; 32]      // must be ∈ AttestorSet.members
+    sig:    Vec<u8>       // scheme-dependent length (ed25519 = 64, BLS = 48)
+}
+```
+
+---
+
+## State
+
+Three `StateMap`s in the `attestation` module:
+
+| Map | Key | Value | Notes |
+|---|---|---|---|
+| `schemas` | `SchemaId` | `Schema` | set once, immutable after |
+| `attestor_sets` | `AttestorSetId` | `AttestorSet` | set once, immutable after |
+| `attestations` | `(SchemaId, PayloadHash)` | `Attestation` | write-once per pair |
+
+---
+
+## Call messages
+
+```
+enum CallMessage {
+    RegisterAttestorSet {
+        members:   Vec<PubKey>,
+        threshold: u8,
+    },
+    RegisterSchema {
+        name:             String,
+        version:          u32,
+        attestor_set:     AttestorSetId,
+        fee_routing_bps:  u16,
+        fee_routing_addr: Option<Address>,
+    },
+    SubmitAttestation {
+        schema_id:    SchemaId,
+        payload_hash: [u8; 32],
+        signatures:   Vec<AttestorSignature>,
+    },
+}
+```
+
+**Deliberately omitted:** `VerifyReceipt` / `VerifyAttestation`. Verification is a read — exposed as RPC query, not a state-mutating transaction.
+
+---
+
+## Query RPC (read path)
+
+```
+get_schema(schema_id)                       -> Option<Schema>
+get_attestor_set(set_id)                    -> Option<AttestorSet>
+get_attestation(schema_id, payload_hash)    -> Option<Attestation>
+list_attestations_by_schema(schema_id, pagination)  -> Vec<AttestationKey>
+list_schemas_by_owner(owner, pagination)    -> Vec<SchemaId>
+```
+
+No transactions. No state changes. Cheap to serve from indexed node.
+
+---
+
+## Invariants
+
+The state transitions MUST enforce:
+
+1. `RegisterSchema.attestor_set` references a registered `AttestorSet` — else reject.
+2. `RegisterSchema.fee_routing_bps` ≤ `MAX_BUILDER_BPS` (default 5000 = 50%, governance-adjustable in v1+) — else reject.
+3. `RegisterSchema.fee_routing_addr.is_some() == (fee_routing_bps > 0)` — no dangling routing, no orphan addr.
+4. `SubmitAttestation` signatures must:
+   - All `pubkey`s be ∈ schema's `AttestorSet.members`
+   - All signatures verify over canonical Borsh encoding of the signed payload (spec'd below)
+   - Count of valid signatures ≥ schema's `AttestorSet.threshold`
+5. `(schema_id, payload_hash)` is write-once — `SubmitAttestation` for an existing pair is rejected.
+6. `SchemaId` derivation must match `SHA-256(owner ‖ name ‖ version)` exactly; redundant — but recomputed by the runtime at registration and stored on-chain so consumers don't have to trust the submitter's claimed ID.
+
+---
+
+## Signed payload for attestations
+
+Attestors sign the canonical Borsh encoding of:
+
+```
+SignedPayload {
+    schema_id:    [u8; 32],
+    payload_hash: [u8; 32],
+    submitter:    [u8; 32],
+    timestamp:    u64,
+}
+```
+
+Signatures do NOT cover the `signatures` field itself (that would be circular). Replay is prevented by the `(schema_id, payload_hash)` write-once invariant — the same pair can't be submitted twice, so the same signature can't be replayed.
+
+---
+
+## Fees
+
+All amounts in $LGT.
+
+| Event | Fee | Split |
+|---|---|---|
+| `RegisterAttestorSet` | `ATTESTOR_SET_FEE` (governance, default 10 $LGT) | 100% treasury |
+| `RegisterSchema` | `SCHEMA_REGISTRATION_FEE` (governance, default 100 $LGT) | 100% treasury |
+| `SubmitAttestation` | `ATTESTATION_FEE` (governance, default 0.001 $LGT) | See below |
+
+### Attestation fee split
+
+```
+total = ATTESTATION_FEE
+builder = total × schema.fee_routing_bps / 10000   (if fee_routing_addr set, else 0)
+treasury = total - builder
+```
+
+Builder's share is sent to `schema.fee_routing_addr`. Treasury receives the rest.
+
+Schema owners choose `fee_routing_bps` at registration (0–5000). Changing requires a schema version bump. Users of the schema implicitly opt in by migrating to new versions — no bait-and-switch possible on existing users.
+
+---
+
+## Permissionless-by-design
+
+- Anyone can `RegisterAttestorSet` with any set of pubkeys — quality is a social concern, not a protocol gate.
+- Anyone can `RegisterSchema` with any name — different owners can register the same `name` (different `schema_id`s). Social layer handles identity / "verified" tags.
+- Anyone can `SubmitAttestation` under any schema, provided they supply valid signatures from that schema's `AttestorSet`. The `AttestorSet` is the permission layer.
+
+---
+
+## Non-goals for v0
+
+The protocol intentionally does not handle:
+
+- **Identity** — v1 module `identity` adds DID-like lookups (address → handle, pubkey, metadata URI).
+- **Reputation / slashing** — v1 module `disputes` adds on-chain flagging + attestor slashing tied to AttestorSet stake.
+- **Cryptographic inference verification** — v2+ schemas like `themisra.verified-inference/v1` carry external zkML / TEE proof hashes in their `payload_hash`; clients verify the external proof off-chain with the proving system that generated it. **Ligate does not build its own zkML.**
+- **Payments / streaming / metered billing** — v2 module `payments` extends `bank`.
+- **Agent registry** — v2 module `agents` (distinct from the v0.5 Ligate MCP Server, which is a developer-facing tool on top of this protocol, not a new module).
+
+---
+
+## Trust model
+
+**v0 is federated.** Attestor sets are operated by the schema owner (for Themisra, by Ligate Labs; for third-party schemas, by whoever registers them). Correctness depends on the quorum being trustworthy.
+
+**v1 adds economic skin** via slashing in the `disputes` module.
+
+**v2 optionally adds cryptographic proof** by letting schemas carry zkML/TEE proof hashes in their payloads. Ligate stays neutral on proving tech — customers bring their own.
+
+---
+
+## How Themisra consumes this
+
+Themisra registers exactly one schema for v0:
+
+```
+name:             "themisra.proof-of-prompt"
+version:          1
+attestor_set:     <ligate-operated attestor set id>
+fee_routing_bps:  0                   // all fees to treasury at launch
+fee_routing_addr: None
+```
+
+Themisra's client SDK (Rust + TypeScript, shipping in `crates/schemas/themisra-pop` and npm package `@ligate/themisra`):
+
+```
+themisra.attest(model, prompt, output):
+    payload      = borsh((model, sha256(prompt), sha256(output), timestamp, client))
+    payload_hash = sha256(payload)
+    signatures   = fetch from Themisra attestor quorum (off-chain; quorum HTTP API)
+    chain.SubmitAttestation { THEMISRA_SCHEMA_ID, payload_hash, signatures }
+    return receipt_id = (THEMISRA_SCHEMA_ID, payload_hash)
+
+themisra.verify(receipt_id):
+    attestation = chain.get_attestation(receipt_id)
+    // caller validates whatever domain-specific checks they care about
+    return attestation
+```
+
+The attestor quorum HTTP API, the Themisra payload canonicalisation, and the TypeScript/Rust SDK surfaces are out of scope for this chain-level spec — they're Themisra product concerns, documented in the `themisra-pop` crate and the `@ligate/themisra` package.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87.0"
-components = ["rustfmt", "clippy"]
+channel = "1.93.0"
+components = ["rustfmt", "rust-src", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Pivots the attestation module from Themisra-specific shapes to the **generic protocol primitive**. Themisra's Proof-of-Prompt will live in a dedicated `themisra-pop` schema crate in a follow-up issue.

- `crates/modules/attestation/src/lib.rs` — `Schema`, `AttestorSet`, `Attestation`, `AttestorSignature`, `SignedAttestationPayload`, and `CallMessage` (`RegisterAttestorSet` / `RegisterSchema` / `SubmitAttestation`). Verification is intentionally a query RPC, not a `CallMessage`.
- `docs/protocol/attestation-v0.md` — canonical v0 spec: entities, state layout, invariants, signed-payload format, fees (0.001 \$LGT, fee-routing cap 50%), permissionless-by-owner naming, explicit non-goals (no identity, no slashing, no native zkML).
- Workspace restructured: `crates/modules/attestation/` replaces the old `crates/modules/` placeholder.
- Rust toolchain + CI + Cargo.toml bumped 1.87 → 1.93 to match Sovereign SDK's own `rust-toolchain.toml`.

## Intentionally not in this PR

- **State transitions** (`call` impl) — blocked on Sovereign SDK integration (nightly rev `f89964c` throws 45 `impl_gas_unit!` macro errors; needs its own dedicated issue).
- **Real `StateMap` wiring** — stored as `BTreeMap` placeholder types today (`SchemaStore`, `AttestorSetStore`, `AttestationStore`); swap for `sov_modules_api::StateMap` when SDK lands.
- **Fee-split enforcement, signature validation, genesis, query RPC** — all downstream of state transitions.
- **Issue housekeeping** — existing issues #6, #7, #10, #12 need rescoping from Themisra-specific to protocol-generic. Also new issues to open for SDK integration, themisra-pop crate, query RPC, fee routing. Tracking as a separate follow-up.

## Test plan

- [x] \`cargo check --workspace\` passes locally
- [x] \`cargo fmt --all -- --check\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` passes
- [ ] CI green on this PR (verifies the 1.93 toolchain bump works in the Actions runner)