### PR TITLE
Implement Module trait and state transitions (closes #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,25 @@ jobs:
           toolchain: 1.93.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-targets
+
+  doc:
+    name: cargo doc
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.93.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --workspace --no-deps --document-private-items
+
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-audit
-      - run: cargo audit
+      # Ignores below are documented in audit.toml. Revisit on every
+      # Sovereign SDK rev bump; all entries come from transitive deps
+      # pinned by the SDK that we can't directly upgrade.
+      - run: |
+          cargo audit \
+            --ignore RUSTSEC-2026-0104 \
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2025-0141 \
+            --ignore RUSTSEC-2025-0134

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@cargo-audit
+      - run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "sov-modules-api",
+ "sov-prover-storage-manager",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ rust-version = "1.93"
 [workspace.dependencies]
 # Sovereign SDK — pinned to the same rev that `sov-rollup-starter` uses.
 # v0.3-era (known-compiling baseline). Bump alongside SDK upgrades.
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
-sov-modules-api      = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
-sov-state            = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
+sov-rollup-interface       = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
+sov-modules-api            = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
+sov-state                  = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
+sov-prover-storage-manager = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
 
 # Shared workspace dependencies
 anyhow     = "1.0"
@@ -36,6 +37,7 @@ sha2       = "0.10"
 # module RPC method derives (see starter's sov-accounts/sov-bank pattern),
 # node RPC server, and client-rs transport. Pin matches starter.
 jsonrpsee  = { version = "0.20.1", features = ["jsonrpsee-types", "macros", "server", "http-client"] }
+tempfile   = "3.8"
 
 [profile.release]
 lto = "thin"

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit config.
+#
+# Ignored advisories are tracked with clear rationale. Revisit every time we
+# upgrade the Sovereign SDK rev (all current entries come from transitive
+# deps pinned by the SDK at `13e4077c`).
+
+[advisories]
+ignore = [
+    # rustls-webpki 0.101.7, reachable panic when parsing a CRL's
+    # `onlySomeReasons` element. Only exploitable by apps that parse CRLs.
+    # Ligate's TLS usage (Celestia DA client, JSON-RPC) does not parse CRLs,
+    # so the panic is unreachable. Clears when SDK upgrades rustls.
+    "RUSTSEC-2026-0104",
+
+    # rustls-webpki 0.101.7, name constraints for URI names were ignored.
+    # Only exploitable given CA misissuance, which is out of scope for our
+    # threat model. Clears when SDK upgrades rustls.
+    "RUSTSEC-2026-0098",
+
+    # rustls-webpki 0.101.7, name constraints incorrectly accepted for
+    # wildcard certs. Same misissuance precondition as 0098. Out of scope.
+    "RUSTSEC-2026-0099",
+]

--- a/audit.toml
+++ b/audit.toml
@@ -20,4 +20,14 @@ ignore = [
     # rustls-webpki 0.101.7, name constraints incorrectly accepted for
     # wildcard certs. Same misissuance precondition as 0098. Out of scope.
     "RUSTSEC-2026-0099",
+
+    # bincode 1.3.3 unmaintained (upstream ceased development). Pulled
+    # transitively by sov-db. Not a vulnerability; clears when the SDK
+    # migrates to an actively maintained serializer.
+    "RUSTSEC-2025-0141",
+
+    # rustls-pemfile 1.0.4 unmaintained (superseded by rustls-pki-types).
+    # Pulled transitively by jsonrpsee-http-client -> hyper-rustls.
+    # Not a vulnerability; clears on SDK + jsonrpsee upgrade.
+    "RUSTSEC-2025-0134",
 ]

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -15,9 +15,12 @@ anyhow.workspace = true
 borsh.workspace = true
 serde.workspace = true
 sha2.workspace = true
+thiserror.workspace = true
 
 sov-modules-api = { workspace = true, features = ["native"] }
 jsonrpsee       = { workspace = true }
 
 [dev-dependencies]
 serde_json.workspace = true
+sov-prover-storage-manager = { workspace = true, features = ["test-utils"] }
+tempfile.workspace = true

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -1,4 +1,4 @@
-//! Ligate attestation protocol — generic on-chain attestation primitive.
+//! Ligate attestation protocol, generic on-chain attestation primitive.
 //!
 //! This crate implements the protocol's data shapes and state layout.
 //! See [`docs/protocol/attestation-v0.md`][spec] for the full specification.
@@ -16,7 +16,7 @@
 //! | [`Attestation`]  | `(schema_id, payload_hash)` | [`CallMessage::SubmitAttestation`] |
 //!
 //! Reads (`get_schema`, `get_attestor_set`, `get_attestation`, listing variants)
-//! are exposed via query RPC and deliberately absent from [`CallMessage`] —
+//! are exposed via query RPC and deliberately absent from [`CallMessage`] ,
 //! verification is a read, not a state-mutating transaction.
 //!
 //! # Scope of this crate
@@ -24,14 +24,17 @@
 //! Protocol-shaped data types + the [`AttestationModule`] struct with its
 //! state layout wired to the real `sov_modules_api::StateMap`. State
 //! transition implementations (`call`), genesis config, RPC endpoints,
-//! and fee-split enforcement land in sibling issues (#7, #8, #20–#22).
+//! and fee-split enforcement land in sibling issues (#7, #8, #20-#22).
 
 #![deny(missing_docs)]
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use sov_modules_api::{Context, ModuleInfo, StateMap};
+use sov_modules_api::{
+    prelude::*, CallResponse, Context, Error, Module, ModuleInfo, StateMap, WorkingSet,
+};
+use thiserror::Error as ThisError;
 
 // ----- Primitive aliases ------------------------------------------------------
 
@@ -55,14 +58,14 @@ pub type AttestorSetId = Hash32;
 
 // ----- AttestorSet ------------------------------------------------------------
 
-/// A quorum of signers. **Immutable once registered** — to "rotate" an
+/// A quorum of signers. **Immutable once registered**, to "rotate" an
 /// attestor set, register a new one and bump any affected schema to a new
 /// version that points at the new [`AttestorSetId`].
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct AttestorSet {
     /// Ordered list of attestor public keys.
     ///
-    /// Order matters for the derivation of [`AttestorSetId`] — callers
+    /// Order matters for the derivation of [`AttestorSetId`], callers
     /// must supply a canonical (e.g. lexicographic) ordering, and the
     /// state transition re-hashes to verify before accepting.
     pub members: Vec<PubKey>,
@@ -91,7 +94,7 @@ pub struct AttestorSignature {
 
 /// An app's attestation shape and rules.
 ///
-/// Registration is permissionless — anyone with enough $LGT to pay the
+/// Registration is permissionless, anyone with enough $LGT to pay the
 /// registration fee can register a schema. Name collisions across owners
 /// are allowed (different `owner` bytes → different [`SchemaId`]); social
 /// identity of the "real" schema owner lives off-chain.
@@ -114,7 +117,7 @@ pub struct Schema {
     /// v0; governance-adjustable in v1+.
     pub fee_routing_bps: u16,
     /// Destination of the builder's fee share. `None` iff
-    /// `fee_routing_bps == 0` — the state transition rejects dangling
+    /// `fee_routing_bps == 0`, the state transition rejects dangling
     /// routing and orphan addresses at registration time.
     pub fee_routing_addr: Option<Address>,
 }
@@ -159,7 +162,7 @@ impl AttestorSet {
 
 /// Key used for the attestation store: `(schema_id, payload_hash)`.
 ///
-/// Each pair is write-once — resubmitting the same pair is rejected by
+/// Each pair is write-once, resubmitting the same pair is rejected by
 /// the state transition. This is also what provides replay protection for
 /// the attestor signatures.
 pub type AttestationKey = (SchemaId, Hash32);
@@ -275,9 +278,9 @@ pub enum CallMessage {
 ///
 /// Three state fields map 1-to-1 to the three protocol entities:
 ///
-/// - [`AttestationModule::schemas`] — `SchemaId → Schema`
-/// - [`AttestationModule::attestor_sets`] — `AttestorSetId → AttestorSet`
-/// - [`AttestationModule::attestations`] — `(SchemaId, PayloadHash) → Attestation`
+/// - [`AttestationModule::schemas`], `SchemaId → Schema`
+/// - [`AttestationModule::attestor_sets`], `AttestorSetId → AttestorSet`
+/// - [`AttestationModule::attestations`], `(SchemaId, PayloadHash) → Attestation`
 ///
 /// Call handlers and genesis config live in sibling issues; this struct
 /// exists to lock down the state layout that every other piece of the
@@ -308,9 +311,281 @@ pub struct AttestationModule<C: Context> {
 pub const MAX_BUILDER_BPS: u16 = 5000;
 
 /// Default attestation fee in $LGT, in the chain's smallest unit.
-/// Placeholder constant — real fee sizing is a governance parameter set
+/// Placeholder constant. Real fee sizing is a governance parameter set
 /// at launch. Documented here for reference against the spec.
 pub const DEFAULT_ATTESTATION_FEE_LGT_MICROS: u64 = 1_000; // 0.001 $LGT at 6 decimals
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/// Typed errors produced by the attestation module's call handlers.
+///
+/// These convert into [`sov_modules_api::Error`] (via [`anyhow::Error`]) when
+/// returned from a Module handler, so callers of the RPC can pattern-match
+/// on the wire shape while the chain runtime stays generic.
+#[derive(Debug, ThisError)]
+pub enum AttestationError {
+    /// `threshold` was greater than the number of supplied members.
+    #[error("attestor set threshold ({threshold}) exceeds member count ({count})")]
+    ThresholdExceedsMembers {
+        /// Supplied threshold.
+        threshold: u8,
+        /// Number of members supplied.
+        count: usize,
+    },
+
+    /// A threshold of 0 was supplied, which would accept attestations with no
+    /// signatures.
+    #[error("attestor set threshold must be at least 1")]
+    ZeroThreshold,
+
+    /// Members list was empty.
+    #[error("attestor set must have at least one member")]
+    EmptyAttestorSet,
+
+    /// An attestor set with this derived id already exists.
+    #[error("attestor set already registered")]
+    DuplicateAttestorSet,
+
+    /// A schema with this derived id already exists (same owner, name, version).
+    #[error("schema already registered")]
+    DuplicateSchema,
+
+    /// Schema registration referenced an [`AttestorSetId`] that isn't stored.
+    #[error("schema references an unregistered attestor set")]
+    UnknownAttestorSet,
+
+    /// `fee_routing_bps` exceeded the protocol cap [`MAX_BUILDER_BPS`].
+    #[error("fee routing bps ({bps}) exceeds protocol cap ({cap})")]
+    FeeRoutingExceedsCap {
+        /// Supplied basis points.
+        bps: u16,
+        /// Protocol cap (v0: 5000 = 50%).
+        cap: u16,
+    },
+
+    /// Fee routing was misconfigured: address set without basis points, or
+    /// basis points > 0 without an address.
+    #[error(
+        "fee routing misconfigured: address and basis points must be set together or both absent"
+    )]
+    OrphanFeeRouting,
+
+    /// Submission referenced a [`SchemaId`] that isn't stored.
+    #[error("schema not found")]
+    UnknownSchema,
+
+    /// An attestation with this `(schema_id, payload_hash)` already exists.
+    #[error("attestation already exists for this (schema_id, payload_hash)")]
+    DuplicateAttestation,
+
+    /// `context.sender()` did not produce a 32-byte representation.
+    #[error("sender address is not 32 bytes")]
+    BadSenderLength,
+}
+
+// ============================================================================
+// Module implementation
+// ============================================================================
+
+impl<C: Context> Module for AttestationModule<C> {
+    type Context = C;
+    type Config = ();
+    type CallMessage = CallMessage;
+    type Event = ();
+
+    fn genesis(
+        &self,
+        _config: &Self::Config,
+        _working_set: &mut WorkingSet<C>,
+    ) -> Result<(), Error> {
+        // v0: no pre-seeded state. Schemas and attestor sets are registered
+        // via tx after launch. Genesis-seeding (e.g. for the Themisra attestor
+        // set) lands with #8.
+        Ok(())
+    }
+
+    fn call(
+        &self,
+        msg: Self::CallMessage,
+        context: &Self::Context,
+        working_set: &mut WorkingSet<C>,
+    ) -> Result<CallResponse, Error> {
+        match msg {
+            CallMessage::RegisterAttestorSet { members, threshold } => {
+                Ok(self.handle_register_attestor_set(members, threshold, working_set)?)
+            }
+            CallMessage::RegisterSchema {
+                name,
+                version,
+                attestor_set,
+                fee_routing_bps,
+                fee_routing_addr,
+            } => Ok(self.handle_register_schema(
+                name,
+                version,
+                attestor_set,
+                fee_routing_bps,
+                fee_routing_addr,
+                context,
+                working_set,
+            )?),
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures } => Ok(self
+                .handle_submit_attestation(
+                    schema_id,
+                    payload_hash,
+                    signatures,
+                    context,
+                    working_set,
+                )?),
+        }
+    }
+}
+
+impl<C: Context> AttestationModule<C> {
+    /// Handle [`CallMessage::RegisterAttestorSet`].
+    fn handle_register_attestor_set(
+        &self,
+        members: Vec<PubKey>,
+        threshold: u8,
+        working_set: &mut WorkingSet<C>,
+    ) -> anyhow::Result<CallResponse> {
+        if members.is_empty() {
+            return Err(AttestationError::EmptyAttestorSet.into());
+        }
+        if threshold == 0 {
+            return Err(AttestationError::ZeroThreshold.into());
+        }
+        if usize::from(threshold) > members.len() {
+            return Err(AttestationError::ThresholdExceedsMembers {
+                threshold,
+                count: members.len(),
+            }
+            .into());
+        }
+
+        // Store members in sorted order so later reads match the id derivation.
+        let mut sorted_members = members;
+        sorted_members.sort_unstable();
+
+        let id = AttestorSet::derive_id(&sorted_members, threshold);
+        if self.attestor_sets.get(&id, working_set).is_some() {
+            return Err(AttestationError::DuplicateAttestorSet.into());
+        }
+
+        self.attestor_sets.set(
+            &id,
+            &AttestorSet { members: sorted_members, threshold },
+            working_set,
+        );
+
+        Ok(CallResponse::default())
+    }
+
+    /// Handle [`CallMessage::RegisterSchema`].
+    #[allow(clippy::too_many_arguments)]
+    fn handle_register_schema(
+        &self,
+        name: String,
+        version: u32,
+        attestor_set: AttestorSetId,
+        fee_routing_bps: u16,
+        fee_routing_addr: Option<Address>,
+        context: &C,
+        working_set: &mut WorkingSet<C>,
+    ) -> anyhow::Result<CallResponse> {
+        if fee_routing_bps > MAX_BUILDER_BPS {
+            return Err(AttestationError::FeeRoutingExceedsCap {
+                bps: fee_routing_bps,
+                cap: MAX_BUILDER_BPS,
+            }
+            .into());
+        }
+        if (fee_routing_bps > 0) != fee_routing_addr.is_some() {
+            return Err(AttestationError::OrphanFeeRouting.into());
+        }
+        if self.attestor_sets.get(&attestor_set, working_set).is_none() {
+            return Err(AttestationError::UnknownAttestorSet.into());
+        }
+
+        let owner = sender_to_address::<C>(context.sender())?;
+        let id = Schema::derive_id(&owner, &name, version);
+
+        if self.schemas.get(&id, working_set).is_some() {
+            return Err(AttestationError::DuplicateSchema.into());
+        }
+
+        self.schemas.set(
+            &id,
+            &Schema { owner, name, version, attestor_set, fee_routing_bps, fee_routing_addr },
+            working_set,
+        );
+
+        Ok(CallResponse::default())
+    }
+
+    /// Handle [`CallMessage::SubmitAttestation`].
+    ///
+    /// Signature validation is **stubbed** in this revision (issue #20 owns
+    /// the real ed25519 verification + quorum enforcement). For now we just
+    /// require the schema and the signatures vector to be structurally
+    /// well-formed.
+    fn handle_submit_attestation(
+        &self,
+        schema_id: SchemaId,
+        payload_hash: Hash32,
+        signatures: Vec<AttestorSignature>,
+        context: &C,
+        working_set: &mut WorkingSet<C>,
+    ) -> anyhow::Result<CallResponse> {
+        if self.schemas.get(&schema_id, working_set).is_none() {
+            return Err(AttestationError::UnknownSchema.into());
+        }
+
+        let key = (schema_id, payload_hash);
+        if self.attestations.get(&key, working_set).is_some() {
+            return Err(AttestationError::DuplicateAttestation.into());
+        }
+
+        // TODO(#20): verify each `AttestorSignature` against the schema's
+        // `AttestorSet`, check quorum threshold, enforce no-duplicate-pubkeys.
+        // TODO(#22): charge `ATTESTATION_FEE` via bank and split per
+        // schema.fee_routing_bps / schema.fee_routing_addr.
+
+        let submitter = sender_to_address::<C>(context.sender())?;
+        // TODO: pull the real block timestamp once WorkingSet exposes it
+        // (slot/header access lives behind the rollup-blueprint layer and is
+        // wired in #13). For now, attestations carry `timestamp = 0`; the
+        // write-once key prevents replay either way.
+        let timestamp = 0u64;
+
+        self.attestations.set(
+            &key,
+            &Attestation { schema_id, payload_hash, submitter, timestamp, signatures },
+            working_set,
+        );
+
+        Ok(CallResponse::default())
+    }
+}
+
+/// Convert the runtime's `C::Address` to the protocol's fixed 32-byte
+/// [`Address`] shape.
+///
+/// Relies on `C::Address` implementing `AsRef<[u8]>` (standard for Sovereign
+/// SDK default contexts). Rejects anything that doesn't hand back exactly 32
+/// bytes, so the protocol's on-chain representation stays unambiguous even
+/// if a Context with a non-32-byte address is introduced later.
+fn sender_to_address<C: Context>(sender: &C::Address) -> anyhow::Result<Address> {
+    let bytes: &[u8] = sender.as_ref();
+    if bytes.len() != 32 {
+        return Err(AttestationError::BadSenderLength.into());
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(bytes);
+    Ok(out)
+}
 
 // ============================================================================
 // Tests
@@ -537,5 +812,241 @@ mod tests {
         // Documenting the invariant explicitly so a future refactor
         // doesn't silently raise the cap without thought.
         assert_eq!(MAX_BUILDER_BPS, 5000);
+    }
+}
+
+// ============================================================================
+// State-transition tests (end-to-end via module.call)
+// ============================================================================
+
+#[cfg(test)]
+mod state_transition_tests {
+    use sov_modules_api::default_context::DefaultContext;
+    use sov_modules_api::{Address as SovAddress, Module as _, WorkingSet};
+    use sov_prover_storage_manager::new_orphan_storage;
+
+    use super::*;
+
+    type TestModule = AttestationModule<DefaultContext>;
+
+    fn fresh() -> (TestModule, DefaultContext, WorkingSet<DefaultContext>, tempfile::TempDir) {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let working_set = WorkingSet::new(new_orphan_storage(tmpdir.path()).unwrap());
+        let sender = SovAddress::from([1u8; 32]);
+        let sequencer = SovAddress::from([9u8; 32]);
+        let context = DefaultContext::new(sender, sequencer, 1);
+        let module = TestModule::default();
+        (module, context, working_set, tmpdir)
+    }
+
+    fn sample_members() -> Vec<PubKey> {
+        vec![[1u8; 32], [2u8; 32], [3u8; 32]]
+    }
+
+    #[test]
+    fn register_attestor_set_happy_path() {
+        let (module, context, mut ws, _td) = fresh();
+
+        let res = module.call(
+            CallMessage::RegisterAttestorSet { members: sample_members(), threshold: 2 },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_ok(), "register should succeed: {res:?}");
+
+        // Verify it's in state
+        let id = AttestorSet::derive_id(&sample_members(), 2);
+        let stored = module.attestor_sets.get(&id, &mut ws);
+        assert!(stored.is_some(), "attestor set should be stored");
+        let stored = stored.unwrap();
+        assert_eq!(stored.threshold, 2);
+        assert_eq!(stored.members.len(), 3);
+    }
+
+    #[test]
+    fn register_attestor_set_rejects_threshold_over_members() {
+        let (module, context, mut ws, _td) = fresh();
+        let res = module.call(
+            CallMessage::RegisterAttestorSet { members: vec![[1u8; 32]], threshold: 2 },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn register_attestor_set_rejects_zero_threshold() {
+        let (module, context, mut ws, _td) = fresh();
+        let res = module.call(
+            CallMessage::RegisterAttestorSet { members: sample_members(), threshold: 0 },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn register_schema_requires_existing_attestor_set() {
+        let (module, context, mut ws, _td) = fresh();
+        let res = module.call(
+            CallMessage::RegisterSchema {
+                name: "foo".into(),
+                version: 1,
+                attestor_set: [0xAAu8; 32],
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err(), "expected UnknownAttestorSet");
+    }
+
+    #[test]
+    fn register_schema_rejects_over_cap_fee_routing() {
+        let (module, context, mut ws, _td) = fresh();
+        // Seed the attestor set first so we isolate the fee-routing check
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: sample_members(), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let attestor_set_id = AttestorSet::derive_id(&sample_members(), 2);
+
+        let res = module.call(
+            CallMessage::RegisterSchema {
+                name: "foo".into(),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 6000, // > MAX_BUILDER_BPS (5000)
+                fee_routing_addr: Some([2u8; 32]),
+            },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err(), "expected FeeRoutingExceedsCap");
+    }
+
+    #[test]
+    fn register_schema_rejects_orphan_routing() {
+        let (module, context, mut ws, _td) = fresh();
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: sample_members(), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let attestor_set_id = AttestorSet::derive_id(&sample_members(), 2);
+
+        // bps > 0 but no addr
+        let res = module.call(
+            CallMessage::RegisterSchema {
+                name: "foo".into(),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 1000,
+                fee_routing_addr: None,
+            },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err());
+
+        // addr set but bps == 0
+        let res = module.call(
+            CallMessage::RegisterSchema {
+                name: "foo".into(),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: Some([2u8; 32]),
+            },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn submit_attestation_requires_existing_schema() {
+        let (module, context, mut ws, _td) = fresh();
+        let res = module.call(
+            CallMessage::SubmitAttestation {
+                schema_id: [0xDEu8; 32],
+                payload_hash: [0xADu8; 32],
+                signatures: vec![],
+            },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err(), "expected UnknownSchema");
+    }
+
+    #[test]
+    fn full_register_register_submit_flow() {
+        let (module, context, mut ws, _td) = fresh();
+
+        // 1. Register attestor set
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: sample_members(), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .expect("register attestor set");
+        let attestor_set_id = AttestorSet::derive_id(&sample_members(), 2);
+
+        // 2. Register schema
+        module
+            .call(
+                CallMessage::RegisterSchema {
+                    name: "themisra.proof-of-prompt".into(),
+                    version: 1,
+                    attestor_set: attestor_set_id,
+                    fee_routing_bps: 0,
+                    fee_routing_addr: None,
+                },
+                &context,
+                &mut ws,
+            )
+            .expect("register schema");
+        let owner = [1u8; 32]; // matches the sender in fresh()
+        let schema_id = Schema::derive_id(&owner, "themisra.proof-of-prompt", 1);
+
+        // 3. Submit attestation
+        let payload_hash = [0x42u8; 32];
+        module
+            .call(
+                CallMessage::SubmitAttestation {
+                    schema_id,
+                    payload_hash,
+                    signatures: vec![AttestorSignature {
+                        pubkey: [1u8; 32],
+                        sig: vec![0xAAu8; 64],
+                    }],
+                },
+                &context,
+                &mut ws,
+            )
+            .expect("submit attestation");
+
+        // 4. Verify state
+        let stored = module.attestations.get(&(schema_id, payload_hash), &mut ws);
+        assert!(stored.is_some(), "attestation should be stored");
+        let stored = stored.unwrap();
+        assert_eq!(stored.schema_id, schema_id);
+        assert_eq!(stored.payload_hash, payload_hash);
+        assert_eq!(stored.submitter, owner);
+
+        // 5. Write-once: resubmitting same (schema_id, payload_hash) must fail
+        let res = module.call(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures: vec![] },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err(), "duplicate (schema_id, payload_hash) must be rejected");
     }
 }

--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -1,4 +1,4 @@
-# Ligate Attestation Protocol — Specification v0
+# Ligate Attestation Protocol, Specification v0
 
 **Status:** design draft for v0 devnet implementation
 **Scope:** types, state layout, state transitions, fees, invariants
@@ -12,18 +12,18 @@ Ligate Chain's core primitive is a **generic on-chain attestation protocol**.
 
 Anyone can:
 
-1. **Register an AttestorSet** — a quorum of signers (pubkeys + threshold)
-2. **Register a Schema** — the shape of an attestation: who owns it, what it's called, which AttestorSet must sign under it, optional fee routing
-3. **Submit an Attestation** — a signed payload hash bound to a schema
+1. **Register an AttestorSet**, a quorum of signers (pubkeys + threshold)
+2. **Register a Schema**, the shape of an attestation: who owns it, what it's called, which AttestorSet must sign under it, optional fee routing
+3. **Submit an Attestation**, a signed payload hash bound to a schema
 
-Chain stores only hashes and signatures — never plaintext prompts, outputs, or sensitive payload data. Apps hash their domain-specific payloads client-side.
+Chain stores only hashes and signatures, never plaintext prompts, outputs, or sensitive payload data. Apps hash their domain-specific payloads client-side.
 
 The protocol is intentionally narrow. It does **not** do identity, reputation, slashing, cryptographic inference verification, or payments. Those are separate modules or external primitives composed on top.
 
 **Flagship consumers** (using the protocol; not part of it):
-- **Themisra** — Proof of Prompt (schema: `themisra.proof-of-prompt/v1`)
-- **Kleidon** — SaaS / gaming products (multiple schemas in v1+)
-- **Ligate MCP Server + Relayer** — attestation for AI agents (multiple schemas, v0.5 product)
+- **Themisra**, Proof of Prompt (schema: `themisra.proof-of-prompt/v1`)
+- **Kleidon**, SaaS / gaming products (multiple schemas in v1+)
+- **Ligate MCP Server + Relayer**, attestation for AI agents (multiple schemas, v0.5 product)
 
 ---
 
@@ -40,12 +40,12 @@ Schema {
     name:             String            // human-readable, e.g. "themisra.proof-of-prompt"
     version:          u32               // monotonic; immutable per id
     attestor_set:     AttestorSetId     // which quorum must sign under this schema
-    fee_routing_bps:  u16               // 0–5000 basis points (cap 50%)
+    fee_routing_bps:  u16               // 0-5000 basis points (cap 50%)
     fee_routing_addr: Option<Address>   // where the builder's share goes; None = 100% treasury
 }
 ```
 
-Registration is **permissionless** (anyone can register) — spam mitigated by the registration fee in $LGT.
+Registration is **permissionless** (anyone can register), spam mitigated by the registration fee in $LGT.
 
 **Namespace ownership:** `schema_id` is derived from `owner` too, so two different owners registering the same `name` produce different `schema_id`s. No protocol-level name squatting. Social identity (who is the "real" Themisra) is handled off-chain via owner address + verified-tag metadata in SDKs and explorers. Same model as ERC-20 token names.
 
@@ -119,7 +119,7 @@ enum CallMessage {
 }
 ```
 
-**Deliberately omitted:** `VerifyReceipt` / `VerifyAttestation`. Verification is a read — exposed as RPC query, not a state-mutating transaction.
+**Deliberately omitted:** `VerifyReceipt` / `VerifyAttestation`. Verification is a read, exposed as RPC query, not a state-mutating transaction.
 
 ---
 
@@ -141,15 +141,15 @@ No transactions. No state changes. Cheap to serve from indexed node.
 
 The state transitions MUST enforce:
 
-1. `RegisterSchema.attestor_set` references a registered `AttestorSet` — else reject.
-2. `RegisterSchema.fee_routing_bps` ≤ `MAX_BUILDER_BPS` (default 5000 = 50%, governance-adjustable in v1+) — else reject.
-3. `RegisterSchema.fee_routing_addr.is_some() == (fee_routing_bps > 0)` — no dangling routing, no orphan addr.
+1. `RegisterSchema.attestor_set` references a registered `AttestorSet`, else reject.
+2. `RegisterSchema.fee_routing_bps` ≤ `MAX_BUILDER_BPS` (default 5000 = 50%, governance-adjustable in v1+), else reject.
+3. `RegisterSchema.fee_routing_addr.is_some() == (fee_routing_bps > 0)`, no dangling routing, no orphan addr.
 4. `SubmitAttestation` signatures must:
    - All `pubkey`s be ∈ schema's `AttestorSet.members`
    - All signatures verify over canonical Borsh encoding of the signed payload (spec'd below)
    - Count of valid signatures ≥ schema's `AttestorSet.threshold`
-5. `(schema_id, payload_hash)` is write-once — `SubmitAttestation` for an existing pair is rejected.
-6. `SchemaId` derivation must match `SHA-256(owner ‖ name ‖ version)` exactly; redundant — but recomputed by the runtime at registration and stored on-chain so consumers don't have to trust the submitter's claimed ID.
+5. `(schema_id, payload_hash)` is write-once, `SubmitAttestation` for an existing pair is rejected.
+6. `SchemaId` derivation must match `SHA-256(owner ‖ name ‖ version)` exactly; redundant, but recomputed by the runtime at registration and stored on-chain so consumers don't have to trust the submitter's claimed ID.
 
 ---
 
@@ -166,7 +166,7 @@ SignedPayload {
 }
 ```
 
-Signatures do NOT cover the `signatures` field itself (that would be circular). Replay is prevented by the `(schema_id, payload_hash)` write-once invariant — the same pair can't be submitted twice, so the same signature can't be replayed.
+Signatures do NOT cover the `signatures` field itself (that would be circular). Replay is prevented by the `(schema_id, payload_hash)` write-once invariant, the same pair can't be submitted twice, so the same signature can't be replayed.
 
 ---
 
@@ -190,14 +190,14 @@ treasury = total - builder
 
 Builder's share is sent to `schema.fee_routing_addr`. Treasury receives the rest.
 
-Schema owners choose `fee_routing_bps` at registration (0–5000). Changing requires a schema version bump. Users of the schema implicitly opt in by migrating to new versions — no bait-and-switch possible on existing users.
+Schema owners choose `fee_routing_bps` at registration (0-5000). Changing requires a schema version bump. Users of the schema implicitly opt in by migrating to new versions, no bait-and-switch possible on existing users.
 
 ---
 
 ## Permissionless-by-design
 
-- Anyone can `RegisterAttestorSet` with any set of pubkeys — quality is a social concern, not a protocol gate.
-- Anyone can `RegisterSchema` with any name — different owners can register the same `name` (different `schema_id`s). Social layer handles identity / "verified" tags.
+- Anyone can `RegisterAttestorSet` with any set of pubkeys, quality is a social concern, not a protocol gate.
+- Anyone can `RegisterSchema` with any name, different owners can register the same `name` (different `schema_id`s). Social layer handles identity / "verified" tags.
 - Anyone can `SubmitAttestation` under any schema, provided they supply valid signatures from that schema's `AttestorSet`. The `AttestorSet` is the permission layer.
 
 ---
@@ -206,11 +206,11 @@ Schema owners choose `fee_routing_bps` at registration (0–5000). Changing requ
 
 The protocol intentionally does not handle:
 
-- **Identity** — v1 module `identity` adds DID-like lookups (address → handle, pubkey, metadata URI).
-- **Reputation / slashing** — v1 module `disputes` adds on-chain flagging + attestor slashing tied to AttestorSet stake.
-- **Cryptographic inference verification** — v2+ schemas like `themisra.verified-inference/v1` carry external zkML / TEE proof hashes in their `payload_hash`; clients verify the external proof off-chain with the proving system that generated it. **Ligate does not build its own zkML.**
-- **Payments / streaming / metered billing** — v2 module `payments` extends `bank`.
-- **Agent registry** — v2 module `agents` (distinct from the v0.5 Ligate MCP Server, which is a developer-facing tool on top of this protocol, not a new module).
+- **Identity**, v1 module `identity` adds DID-like lookups (address → handle, pubkey, metadata URI).
+- **Reputation / slashing**, v1 module `disputes` adds on-chain flagging + attestor slashing tied to AttestorSet stake.
+- **Cryptographic inference verification**, v2+ schemas like `themisra.verified-inference/v1` carry external zkML / TEE proof hashes in their `payload_hash`; clients verify the external proof off-chain with the proving system that generated it. **Ligate does not build its own zkML.**
+- **Payments / streaming / metered billing**, v2 module `payments` extends `bank`.
+- **Agent registry**, v2 module `agents` (distinct from the v0.5 Ligate MCP Server, which is a developer-facing tool on top of this protocol, not a new module).
 
 ---
 
@@ -220,7 +220,7 @@ The protocol intentionally does not handle:
 
 **v1 adds economic skin** via slashing in the `disputes` module.
 
-**v2 optionally adds cryptographic proof** by letting schemas carry zkML/TEE proof hashes in their payloads. Ligate stays neutral on proving tech — customers bring their own.
+**v2 optionally adds cryptographic proof** by letting schemas carry zkML/TEE proof hashes in their payloads. Ligate stays neutral on proving tech, customers bring their own.
 
 ---
 
@@ -252,4 +252,4 @@ themisra.verify(receipt_id):
     return attestation
 ```
 
-The attestor quorum HTTP API, the Themisra payload canonicalisation, and the TypeScript/Rust SDK surfaces are out of scope for this chain-level spec — they're Themisra product concerns, documented in the `themisra-pop` crate and the `@ligate/themisra` package.
+The attestor quorum HTTP API, the Themisra payload canonicalisation, and the TypeScript/Rust SDK surfaces are out of scope for this chain-level spec, they're Themisra product concerns, documented in the `themisra-pop` crate and the `@ligate/themisra` package.


### PR DESCRIPTION
## Summary

Wires the attestation module's call path end to end.

- `Module<C: Context>` impl with `call()` dispatch on the three `CallMessage` variants.
- Three handler methods with full invariant enforcement (see list below).
- Typed `AttestationError` enum (10 variants) routed through `anyhow` to `sov_modules_api::Error`.
- `Context -> Address` conversion helper (`C::Address` to 32-byte `[u8; 32]` with length check).
- **8 state-transition tests** running against a real `DefaultContext` + `WorkingSet` + rocksdb orphan storage.
- 26 total tests passing (18 existing type / derive-id / digest + 8 new state-transition).

## Handler invariants enforced

**RegisterAttestorSet**
- Non-empty members
- 1 <= threshold <= members.len()
- Dedup on derived `AttestorSetId`
- Members stored sorted so reads match id derivation

**RegisterSchema**
- `fee_routing_bps <= MAX_BUILDER_BPS (5000)`
- `(fee_routing_bps > 0) iff (fee_routing_addr is Some)`
- Referenced `AttestorSetId` must exist
- Owner is always `context.sender()`, never submitter-provided
- Dedup on derived `SchemaId`

**SubmitAttestation**
- Schema must exist
- `(schema_id, payload_hash)` is write-once
- Submitter is `context.sender()`
- Signature validation **stubbed** here (real ed25519 verification + quorum check lives in #20)
- Fee charging stubbed here (real bank integration + split lives in #22)
- Timestamp is 0 until block-header access lands with the node binary (#13)

## Test coverage

| Test | What it covers |
|---|---|
| `register_attestor_set_happy_path` | Register + verify round trip |
| `register_attestor_set_rejects_threshold_over_members` | Reject path |
| `register_attestor_set_rejects_zero_threshold` | Reject path |
| `register_schema_requires_existing_attestor_set` | Reject path |
| `register_schema_rejects_over_cap_fee_routing` | Reject path |
| `register_schema_rejects_orphan_routing` | Both directions of the invariant |
| `submit_attestation_requires_existing_schema` | Reject path |
| `full_register_register_submit_flow` | Full 3-step happy path + write-once enforcement |

Each test uses real `WorkingSet<DefaultContext>` with rocksdb storage via `sov_prover_storage_manager::new_orphan_storage`, not a mock. If Module dispatch or StateMap semantics break, these fail.

## New deps

- `thiserror` added to the attestation crate's `[dependencies]` (was already in workspace deps).
- `sov-prover-storage-manager` added to workspace deps + attestation's `[dev-dependencies]` with `test-utils` feature for `new_orphan_storage`.
- `tempfile` added to workspace deps + attestation's `[dev-dependencies]`.

## Out of scope (tracked separately)

- Real ed25519 signature validation in SubmitAttestation (#20)
- Fee routing + cap enforcement at the bank-integration level (#22)
- Query RPC endpoints (#21)
- Genesis config with Themisra attestor set seeded at chain launch (#8)
- Block timestamp from header (part of #13 node wiring)

## Local verification

- [x] `cargo test -p attestation`: 26 passed, 0 failed
- [x] `cargo fmt --all -- --check`: clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean

## Stylistic

Stripped em and en dashes from the attestation crate's doc comments and from `docs/protocol/attestation-v0.md` to match project prose convention. Pure text changes, no code semantics affected.

Closes #7. Progress on #9.