### PR TITLE
Soften no-EVM language to v4 deferral

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ligate Chain is a **specialized app-chain**, not a general-purpose smart-contrac
 
 **It isn't:**
 
-- An EVM chain. There is no Solidity, no contract deployment, no ERC-20 deploy via tx. Tokens and NFTs come through the curated `tokens` and `nft` modules. We will not bolt on `sov-evm`.
+- An EVM chain in v0 / v1 / v2 / v3. There is no Solidity, no contract deployment, no ERC-20 deploy via tx in any of those phases. Tokens and NFTs come through the curated `tokens` and `nft` modules. EVM compatibility is tracked as a long-horizon v4 option ([#52](https://github.com/ligate-io/ligate-chain/issues/52)) we will revisit only after the attestation focus has paid off in shipped, in-production users; until then we don't dilute the chain identity for it.
 - An L1 in the Bitcoin / Ethereum sense. We use Celestia for data availability rather than building our own DA layer. We are sovereign in the rollup sense (no settlement to Ethereum, our own validator set), but DA is outsourced.
 - An L2 in the Optimism / Arbitrum sense. We do not settle to Ethereum.
 - A general DeFi platform. The chain is shaped for attestation primitives plus a few sister modules. Lending, AMMs, perps, and similar live on chains designed for them.

--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -31,7 +31,9 @@ The protocol is intentionally narrow. It does **not** do identity, reputation, s
 
 Ligate Chain is a **specialized app-chain**, not a general-purpose smart-contract platform. The protocol described here is the chain's core primitive, not the only thing the chain does, but it is the only thing **users program**.
 
-There is no Solidity, no Vyper, no CosmWasm, no contract deployment via tx. New chain capabilities arrive as new modules through coordinated upgrades, not as user-deployed code. Fungible tokens and NFTs, when they ship, come from curated modules (`tokens`, `nft`), not from arbitrary contract execution.
+There is no Solidity, no Vyper, no CosmWasm, no contract deployment via tx in v0 through v3. New chain capabilities arrive as new modules through coordinated upgrades, not as user-deployed code. Fungible tokens and NFTs, when they ship in v1, come from curated modules (`tokens`, `nft`), not from arbitrary contract execution.
+
+EVM compatibility is tracked as a long-horizon v4 option (chain issue #52). It is deliberately deferred until the attestation thesis has shipped and proven out. Pre-mainnet readers should treat this chain as non-EVM; treat any earlier opening of EVM compatibility as a strategic shift that requires its own announcement, not a feature add.
 
 Permissionless extension exists at exactly one layer: anyone can register a `Schema` plus an `AttestorSet` on the `attestation` module and submit attestations under their own rules. That is the entire user-facing surface for application logic.
 


### PR DESCRIPTION
## Summary

Stacks on top of [PR #49 (positioning)](https://github.com/ligate-io/ligate-chain/pull/49). Replaces the flat `We will not bolt on sov-evm` language in README and spec with a v4-deferral framing, matching the new [#52](https://github.com/ligate-io/ligate-chain/issues/52).

The chain stays non-EVM through v0 / v1 / v2 / v3 (spec-locked). EVM compatibility is tracked as a long-horizon v4 option: revisited only after the attestation thesis has shipped real users. Pre-mainnet readers should treat the chain as non-EVM, full stop; any earlier opening of EVM is a strategic shift that gets its own announcement.

## Why

Earlier PR positioning said EVM is off the table forever. We agreed (in conversation) that v4 is the right place to track it: not now, not v1, not v2, not v3, but on the long-term roadmap so community / investors / contributors who ask aren't told a flat no.

## Merge ordering

This PR is stacked on `chain/positioning` (PR #49). Merge order:
1. PR #49 first (positioning section).
2. This PR rebases automatically and shows only the soft-no diff.

## Local verification

Markdown only. No CI implications.