### PR TITLE
Wire sov-bank: real $LGT transfers replacing fee counters (closes #56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sov-bank",
  "sov-modules-api",
  "sov-prover-storage-manager",
  "tempfile",
@@ -2174,6 +2175,23 @@ dependencies = [
  "log",
  "rand 0.8.6",
  "sha-1",
+]
+
+[[package]]
+name = "sov-bank"
+version = "0.3.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=13e4077c329ff14954b32e3180d43a6d86fa3172#13e4077c329ff14954b32e3180d43a6d86fa3172"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "clap",
+ "jsonrpsee",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sov-modules-api",
+ "sov-state",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ sov-rollup-interface       = { git = "https://github.com/Sovereign-Labs/sovereig
 sov-modules-api            = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
 sov-state                  = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
 sov-prover-storage-manager = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
+sov-bank                   = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "13e4077c329ff14954b32e3180d43a6d86fa3172" }
 
 # Shared workspace dependencies
 anyhow     = "1.0"

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -19,6 +19,7 @@ sha2.workspace = true
 thiserror.workspace = true
 
 sov-modules-api = { workspace = true, features = ["native"] }
+sov-bank        = { workspace = true, features = ["native"] }
 jsonrpsee       = { workspace = true }
 
 [dev-dependencies]

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -31,6 +31,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use sov_bank::{Bank, Coins};
 use sov_modules_api::{
     prelude::*, CallResponse, Context, Error, Module, ModuleInfo, StateMap, StateValue, WorkingSet,
 };
@@ -291,6 +292,13 @@ pub struct AttestationModule<C: Context> {
     #[address]
     pub address: C::Address,
 
+    /// Reference to the `sov-bank` module. Used to charge `$LGT` fees on
+    /// every successful `RegisterAttestorSet`, `RegisterSchema`, and
+    /// `SubmitAttestation` call. Bank transfers run before any state
+    /// mutation; on `Err` the working-set unwind aborts the whole tx.
+    #[module]
+    pub bank: Bank<C>,
+
     /// Schema registry: `SchemaId → Schema`.
     #[state]
     pub schemas: StateMap<SchemaId, Schema>,
@@ -308,6 +316,22 @@ pub struct AttestationModule<C: Context> {
     /// Set once at genesis, governance-adjustable later.
     #[state]
     pub treasury: StateValue<Address>,
+
+    /// `$LGT` token address used for all attestation-module fee charges.
+    ///
+    /// Set once at genesis from
+    /// [`AttestationConfig::lgt_token_address`]. Identifies the token
+    /// inside [`sov_bank::Bank`] that handlers transfer when charging
+    /// `attestation_fee`, `schema_registration_fee`, and
+    /// `attestor_set_fee`. Immutable after genesis; rotation requires a
+    /// chain upgrade.
+    ///
+    /// `$LGT` is genuinely chain-global; storing it on the attestation
+    /// module is pragmatic for v0 because attestation is the only fee
+    /// consumer. Extract to a chain-wide config primitive when the second
+    /// consumer (Iris relayer module v0.5, `tokens` module v1) lands.
+    #[state]
+    pub lgt_token_address: StateValue<Address>,
 
     /// Flat per-attestation fee in `$LGT` micros. Set at genesis.
     #[state]
@@ -412,6 +436,16 @@ pub struct AttestationConfig {
     /// explicitly; the `Default` impl uses the zero address as a
     /// placeholder that is almost certainly not what you want.
     pub treasury: Address,
+    /// `$LGT` token address inside `sov-bank` used for every fee charge.
+    ///
+    /// Derived deterministically at chain bringup via
+    /// [`sov_bank::get_genesis_token_address`] from
+    /// `(token_name = "LGT", salt = 0, deployer = [0; 32] sentinel)`. The
+    /// determinism lets SDKs and explorers hardcode the address across
+    /// devnet, testnet, and mainnet. The `Default` impl uses the zero
+    /// address as a placeholder that is almost certainly not what you
+    /// want; supply the real derived address in real configs.
+    pub lgt_token_address: Address,
     /// Flat per-attestation fee in `$LGT` micros (6 decimals).
     pub attestation_fee: u64,
     /// Flat schema-registration fee in `$LGT` micros.
@@ -431,6 +465,7 @@ impl Default for AttestationConfig {
     fn default() -> Self {
         Self {
             treasury: [0u8; 32],
+            lgt_token_address: [0u8; 32],
             attestation_fee: DEFAULT_ATTESTATION_FEE_LGT_MICROS,
             schema_registration_fee: DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_MICROS,
             attestor_set_fee: DEFAULT_ATTESTOR_SET_FEE_LGT_MICROS,
@@ -546,6 +581,13 @@ pub enum AttestationError {
     /// surfaced as an explicit error to keep state-transition code honest.
     #[error("schema's attestor set is missing from state")]
     MissingAttestorSet,
+
+    /// `lgt_token_address` or `treasury` was not set at genesis. Indicates
+    /// a misconfigured chain. Should be unreachable for a chain that ran
+    /// `Module::genesis` cleanly, but surfaced as an error so handlers
+    /// fail honestly instead of panicking.
+    #[error("attestation module not initialised: missing $LGT token address or treasury")]
+    ChainNotConfigured,
 }
 
 // ============================================================================
@@ -570,7 +612,7 @@ impl<C: Context> Module for AttestationModule<C> {
     ) -> Result<CallResponse, Error> {
         match msg {
             CallMessage::RegisterAttestorSet { members, threshold } => {
-                Ok(self.handle_register_attestor_set(members, threshold, working_set)?)
+                Ok(self.handle_register_attestor_set(members, threshold, context, working_set)?)
             }
             CallMessage::RegisterSchema {
                 name,
@@ -612,6 +654,7 @@ impl<C: Context> AttestationModule<C> {
         working_set: &mut WorkingSet<C>,
     ) -> anyhow::Result<()> {
         self.treasury.set(&config.treasury, working_set);
+        self.lgt_token_address.set(&config.lgt_token_address, working_set);
         self.attestation_fee.set(&config.attestation_fee, working_set);
         self.schema_registration_fee.set(&config.schema_registration_fee, working_set);
         self.attestor_set_fee.set(&config.attestor_set_fee, working_set);
@@ -686,8 +729,12 @@ impl<C: Context> AttestationModule<C> {
         &self,
         members: Vec<PubKey>,
         threshold: u8,
+        context: &C,
         working_set: &mut WorkingSet<C>,
-    ) -> anyhow::Result<CallResponse> {
+    ) -> anyhow::Result<CallResponse>
+    where
+        C::Address: From<[u8; 32]>,
+    {
         if members.is_empty() {
             return Err(AttestationError::EmptyAttestorSet.into());
         }
@@ -711,15 +758,19 @@ impl<C: Context> AttestationModule<C> {
             return Err(AttestationError::DuplicateAttestorSet.into());
         }
 
+        // Charge the registration fee after validation and duplicate
+        // check, before state mutation. If the submitter has insufficient
+        // `$LGT`, the bank transfer returns `Err`, the working set
+        // unwinds, and the tx fails atomically with no state changes.
+        let fee =
+            self.attestor_set_fee.get(working_set).unwrap_or(DEFAULT_ATTESTOR_SET_FEE_LGT_MICROS);
+        self.charge_to_treasury(context.sender(), fee, working_set)?;
+
         self.attestor_sets.set(
             &id,
             &AttestorSet { members: sorted_members, threshold },
             working_set,
         );
-
-        let fee =
-            self.attestor_set_fee.get(working_set).unwrap_or(DEFAULT_ATTESTOR_SET_FEE_LGT_MICROS);
-        self.add_to_treasury(fee, working_set);
 
         Ok(CallResponse::default())
     }
@@ -735,7 +786,10 @@ impl<C: Context> AttestationModule<C> {
         fee_routing_addr: Option<Address>,
         context: &C,
         working_set: &mut WorkingSet<C>,
-    ) -> anyhow::Result<CallResponse> {
+    ) -> anyhow::Result<CallResponse>
+    where
+        C::Address: From<[u8; 32]>,
+    {
         if fee_routing_bps > MAX_BUILDER_BPS {
             return Err(AttestationError::FeeRoutingExceedsCap {
                 bps: fee_routing_bps,
@@ -757,17 +811,20 @@ impl<C: Context> AttestationModule<C> {
             return Err(AttestationError::DuplicateSchema.into());
         }
 
+        // Charge the registration fee after validation and duplicate
+        // check, before state mutation. Insufficient balance → `Err`,
+        // working set unwinds, no state changes.
+        let fee = self
+            .schema_registration_fee
+            .get(working_set)
+            .unwrap_or(DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_MICROS);
+        self.charge_to_treasury(context.sender(), fee, working_set)?;
+
         self.schemas.set(
             &id,
             &Schema { owner, name, version, attestor_set, fee_routing_bps, fee_routing_addr },
             working_set,
         );
-
-        let fee = self
-            .schema_registration_fee
-            .get(working_set)
-            .unwrap_or(DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_MICROS);
-        self.add_to_treasury(fee, working_set);
 
         Ok(CallResponse::default())
     }
@@ -792,7 +849,10 @@ impl<C: Context> AttestationModule<C> {
         signatures: Vec<AttestorSignature>,
         context: &C,
         working_set: &mut WorkingSet<C>,
-    ) -> anyhow::Result<CallResponse> {
+    ) -> anyhow::Result<CallResponse>
+    where
+        C::Address: From<[u8; 32]>,
+    {
         let schema =
             self.schemas.get(&schema_id, working_set).ok_or(AttestationError::UnknownSchema)?;
 
@@ -820,29 +880,93 @@ impl<C: Context> AttestationModule<C> {
 
         validate_signatures(&signatures, &attestor_set, &digest)?;
 
+        // Charge the attestation fee BEFORE writing the attestation.
+        // Split per `schema.fee_routing_bps`: builder share goes to
+        // `schema.fee_routing_addr` (if configured), remainder to the
+        // treasury. Two transfers (treasury then builder) so a partial
+        // failure unwinds both via the working set.
+        let total_fee =
+            self.attestation_fee.get(working_set).unwrap_or(DEFAULT_ATTESTATION_FEE_LGT_MICROS);
+        let (builder_share, treasury_share) =
+            split_attestation_fee(total_fee, schema.fee_routing_bps);
+        self.charge_to_treasury(context.sender(), treasury_share, working_set)?;
+        if let Some(addr) = schema.fee_routing_addr {
+            if builder_share > 0 {
+                self.charge_to_builder(context.sender(), addr, builder_share, working_set)?;
+            }
+        }
+
         self.attestations.set(
             &key,
             &Attestation { schema_id, payload_hash, submitter, timestamp, signatures },
             working_set,
         );
 
-        // Charge the attestation fee. Split per schema.fee_routing_bps:
-        // builder share to schema.fee_routing_addr (if any), remainder to
-        // treasury. Today this is accounting-only against module state;
-        // real `sov-bank` token movement lands once the bank module is
-        // wired into the runtime.
-        let total_fee =
-            self.attestation_fee.get(working_set).unwrap_or(DEFAULT_ATTESTATION_FEE_LGT_MICROS);
-        let (builder_share, treasury_share) =
-            split_attestation_fee(total_fee, schema.fee_routing_bps);
-        if let Some(addr) = schema.fee_routing_addr {
-            if builder_share > 0 {
-                self.add_to_builder(addr, builder_share, working_set);
-            }
-        }
-        self.add_to_treasury(treasury_share, working_set);
-
         Ok(CallResponse::default())
+    }
+
+    /// Move `amount` `$LGT` micros from `submitter` to the treasury via
+    /// `sov-bank`, then bump the cumulative
+    /// [`AttestationModule::total_treasury_collected`] counter.
+    ///
+    /// Returns `Ok(())` for `amount == 0` without touching the bank or
+    /// counter, so callers don't need to special-case zero-fee paths.
+    /// Bumps the counter only after a successful transfer; the
+    /// working-set unwind handles the failure case (no half-state).
+    fn charge_to_treasury(
+        &self,
+        submitter: &C::Address,
+        amount: u64,
+        working_set: &mut WorkingSet<C>,
+    ) -> anyhow::Result<()>
+    where
+        C::Address: From<[u8; 32]>,
+    {
+        if amount == 0 {
+            return Ok(());
+        }
+        let lgt_token_bytes =
+            self.lgt_token_address.get(working_set).ok_or(AttestationError::ChainNotConfigured)?;
+        let treasury_bytes =
+            self.treasury.get(working_set).ok_or(AttestationError::ChainNotConfigured)?;
+        self.bank.transfer_from(
+            submitter,
+            &C::Address::from(treasury_bytes),
+            Coins { amount, token_address: C::Address::from(lgt_token_bytes) },
+            working_set,
+        )?;
+        self.add_to_treasury(amount, working_set);
+        Ok(())
+    }
+
+    /// Move `amount` `$LGT` micros from `submitter` to `builder_addr` via
+    /// `sov-bank`, then bump the cumulative
+    /// [`AttestationModule::builder_fees_collected`] counter for that
+    /// address. Same `amount == 0` short-circuit and same atomicity
+    /// guarantees as [`Self::charge_to_treasury`].
+    fn charge_to_builder(
+        &self,
+        submitter: &C::Address,
+        builder_addr: Address,
+        amount: u64,
+        working_set: &mut WorkingSet<C>,
+    ) -> anyhow::Result<()>
+    where
+        C::Address: From<[u8; 32]>,
+    {
+        if amount == 0 {
+            return Ok(());
+        }
+        let lgt_token_bytes =
+            self.lgt_token_address.get(working_set).ok_or(AttestationError::ChainNotConfigured)?;
+        self.bank.transfer_from(
+            submitter,
+            &C::Address::from(builder_addr),
+            Coins { amount, token_address: C::Address::from(lgt_token_bytes) },
+            working_set,
+        )?;
+        self.add_to_builder(builder_addr, amount, working_set);
+        Ok(())
     }
 
     /// Increment [`AttestationModule::total_treasury_collected`] by `amount`,
@@ -1225,6 +1349,7 @@ mod tests {
 #[cfg(test)]
 mod state_transition_tests {
     use ed25519_dalek::{Signer, SigningKey};
+    use sov_bank::{get_genesis_token_address, BankConfig, TokenConfig};
     use sov_modules_api::default_context::DefaultContext;
     use sov_modules_api::{Address as SovAddress, Module as _, WorkingSet};
     use sov_prover_storage_manager::new_orphan_storage;
@@ -1236,14 +1361,65 @@ mod state_transition_tests {
     /// Address the `fresh()` context uses as `sender`; also the owner of
     /// any schema registered inside a test using that context.
     const TEST_SENDER: Address = [1u8; 32];
+    /// Treasury address used by `fresh()`. Distinct from `TEST_SENDER` so
+    /// bank balance assertions stay unambiguous.
+    const TEST_TREASURY: Address = [2u8; 32];
+    /// Initial `$LGT` micros allocated to `TEST_SENDER` at genesis.
+    /// Generous enough that no validation-only test runs out.
+    const SENDER_INITIAL_LGT: u64 = 1_000_000_000;
 
+    /// Convert a `SovAddress` to its 32-byte representation for storage in
+    /// `Address`-typed (`[u8; 32]`) state values.
+    fn sov_addr_bytes(addr: &SovAddress) -> Address {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(addr.as_ref());
+        out
+    }
+
+    /// Set up a fresh module + context + working set, with `sov-bank`
+    /// seeded so handlers can charge fees. `TEST_SENDER` starts with
+    /// [`SENDER_INITIAL_LGT`] micros; `TEST_TREASURY` starts at zero
+    /// (the bank requires the address to appear in the initial-balances
+    /// list for the token entry to exist; zero is fine).
     fn fresh() -> (TestModule, DefaultContext, WorkingSet<DefaultContext>, tempfile::TempDir) {
         let tmpdir = tempfile::tempdir().unwrap();
-        let working_set = WorkingSet::new(new_orphan_storage(tmpdir.path()).unwrap());
+        let mut working_set = WorkingSet::new(new_orphan_storage(tmpdir.path()).unwrap());
         let sender = SovAddress::from(TEST_SENDER);
         let sequencer = SovAddress::from([9u8; 32]);
         let context = DefaultContext::new(sender, sequencer, 1);
         let module = TestModule::default();
+
+        // Seed the `$LGT` token in `sov-bank`. The address is
+        // deterministic from `(name = "LGT", salt = 0, deployer)`, the
+        // same recipe `sov_bank::get_genesis_token_address` uses.
+        let bank_cfg = BankConfig {
+            tokens: vec![TokenConfig {
+                token_name: "LGT".into(),
+                address_and_balances: vec![
+                    (SovAddress::from(TEST_SENDER), SENDER_INITIAL_LGT),
+                    (SovAddress::from(TEST_TREASURY), 0),
+                ],
+                authorized_minters: vec![],
+                salt: 0,
+            }],
+        };
+        module.bank.genesis(&bank_cfg, &mut working_set).expect("bank genesis");
+
+        // Seed the attestation module with a zero-fee config plus the
+        // derived `$LGT` token address. Tests that need real fees set
+        // them explicitly via a different config later (see `fee_tests`).
+        let lgt_token = get_genesis_token_address::<DefaultContext>("LGT", 0);
+        let cfg = AttestationConfig {
+            treasury: TEST_TREASURY,
+            lgt_token_address: sov_addr_bytes(&lgt_token),
+            attestation_fee: 0,
+            schema_registration_fee: 0,
+            attestor_set_fee: 0,
+            initial_attestor_sets: vec![],
+            initial_schemas: vec![],
+        };
+        module.genesis(&cfg, &mut working_set).expect("attestation genesis");
+
         (module, context, working_set, tmpdir)
     }
 
@@ -1790,6 +1966,7 @@ mod genesis_tests {
     fn config_round_trips_through_json() {
         let cfg = AttestationConfig {
             treasury: [9u8; 32],
+            lgt_token_address: [10u8; 32],
             attestation_fee: 1234,
             schema_registration_fee: 5678,
             attestor_set_fee: 91011,
@@ -1821,6 +1998,7 @@ mod genesis_tests {
 #[cfg(test)]
 mod fee_tests {
     use ed25519_dalek::{Signer, SigningKey};
+    use sov_bank::{get_genesis_token_address, BankConfig, TokenConfig};
     use sov_modules_api::default_context::DefaultContext;
     use sov_modules_api::{Address as SovAddress, Module as _, WorkingSet};
     use sov_prover_storage_manager::new_orphan_storage;
@@ -1832,15 +2010,61 @@ mod fee_tests {
     const TEST_SENDER: Address = [1u8; 32];
     const TREASURY: Address = [11u8; 32];
     const BUILDER_PAYOUT: Address = [22u8; 32];
+    /// Generous starting balance for `TEST_SENDER` so the existing
+    /// fee-volume tests (which charge up to a few thousand micros) don't
+    /// run out. The insufficient-balance test uses a different `fresh()`
+    /// variant below.
+    const SENDER_INITIAL_LGT: u64 = 1_000_000_000;
 
+    fn sov_addr_bytes(addr: &SovAddress) -> Address {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(addr.as_ref());
+        out
+    }
+
+    /// Fresh module + context + working set, with `$LGT` seeded for
+    /// `TEST_SENDER`. The attestation module is NOT yet `genesis`'d;
+    /// each test calls `module.genesis` explicitly with its desired
+    /// fee config so the per-test fee values stay locally visible.
     fn fresh() -> (TestModule, DefaultContext, WorkingSet<DefaultContext>, tempfile::TempDir) {
+        fresh_with_balance(SENDER_INITIAL_LGT)
+    }
+
+    /// Variant of [`fresh`] that lets the caller pick the sender's
+    /// initial `$LGT` balance. Used by the insufficient-balance test
+    /// to start `TEST_SENDER` at zero.
+    fn fresh_with_balance(
+        sender_balance: u64,
+    ) -> (TestModule, DefaultContext, WorkingSet<DefaultContext>, tempfile::TempDir) {
         let tmpdir = tempfile::tempdir().unwrap();
-        let working_set = WorkingSet::new(new_orphan_storage(tmpdir.path()).unwrap());
+        let mut working_set = WorkingSet::new(new_orphan_storage(tmpdir.path()).unwrap());
         let sender = SovAddress::from(TEST_SENDER);
         let sequencer = SovAddress::from([9u8; 32]);
         let context = DefaultContext::new(sender, sequencer, 1);
         let module = TestModule::default();
+
+        let bank_cfg = BankConfig {
+            tokens: vec![TokenConfig {
+                token_name: "LGT".into(),
+                address_and_balances: vec![
+                    (SovAddress::from(TEST_SENDER), sender_balance),
+                    (SovAddress::from(TREASURY), 0),
+                    (SovAddress::from(BUILDER_PAYOUT), 0),
+                ],
+                authorized_minters: vec![],
+                salt: 0,
+            }],
+        };
+        module.bank.genesis(&bank_cfg, &mut working_set).expect("bank genesis");
+
         (module, context, working_set, tmpdir)
+    }
+
+    /// Looks up the deterministic `$LGT` token address derived at
+    /// genesis. Helper so tests can read submitter / treasury / builder
+    /// balances after fee charges.
+    fn lgt_token_address() -> SovAddress {
+        get_genesis_token_address::<DefaultContext>("LGT", 0)
     }
 
     fn signers() -> Vec<SigningKey> {
@@ -1865,6 +2089,7 @@ mod fee_tests {
     ) -> AttestationConfig {
         AttestationConfig {
             treasury: TREASURY,
+            lgt_token_address: sov_addr_bytes(&lgt_token_address()),
             attestation_fee,
             schema_registration_fee: schema_fee,
             attestor_set_fee,
@@ -2043,5 +2268,258 @@ mod fee_tests {
         // 25% of 1000 = 250 to builder, remainder 750 to treasury.
         assert_eq!(module.builder_fees_collected.get(&BUILDER_PAYOUT, &mut ws), Some(250));
         assert_eq!(module.total_treasury_collected.get(&mut ws), Some(baseline_treasury + 750));
+    }
+
+    // ----- Bank-balance integration tests -----------------------------------
+    //
+    // These assert real `$LGT` movement via `sov-bank`, complementing the
+    // counter-only assertions above. The counters and bank balances are
+    // expected to track identically pre-treasury-withdrawal (every
+    // counter increment corresponds to a bank transfer of the same
+    // amount). Once governance withdrawals ship (#41, v1) the bank
+    // balance and the cumulative counter diverge.
+
+    /// Helper for bank-balance reads in tests. Returns `0` when the user
+    /// has no entry for the token, matching the spirit of "balance is
+    /// missing means zero" rather than failing the test on `None`.
+    fn balance_of(module: &TestModule, addr: Address, ws: &mut WorkingSet<DefaultContext>) -> u64 {
+        module.bank.get_balance_of(SovAddress::from(addr), lgt_token_address(), ws).unwrap_or(0)
+    }
+
+    #[test]
+    fn register_attestor_set_charges_lgt_via_bank() {
+        let (module, context, mut ws, _td) = fresh();
+        module.genesis(&config_with_fees(0, 0, 7), &mut ws).unwrap();
+        let sender_before = balance_of(&module, TEST_SENDER, &mut ws);
+        let treasury_before = balance_of(&module, TREASURY, &mut ws);
+
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: members(&signers()), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+
+        assert_eq!(balance_of(&module, TEST_SENDER, &mut ws), sender_before - 7);
+        assert_eq!(balance_of(&module, TREASURY, &mut ws), treasury_before + 7);
+    }
+
+    #[test]
+    fn register_schema_charges_lgt_via_bank() {
+        let (module, context, mut ws, _td) = fresh();
+        module.genesis(&config_with_fees(0, 100, 5), &mut ws).unwrap();
+
+        let signers = signers();
+        let set_members = members(&signers);
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: set_members.clone(), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let attestor_set_id = AttestorSet::derive_id(&set_members, 2);
+
+        let sender_before = balance_of(&module, TEST_SENDER, &mut ws);
+        let treasury_before = balance_of(&module, TREASURY, &mut ws);
+
+        module
+            .call(
+                CallMessage::RegisterSchema {
+                    name: "test.schema".into(),
+                    version: 1,
+                    attestor_set: attestor_set_id,
+                    fee_routing_bps: 0,
+                    fee_routing_addr: None,
+                },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+
+        // Schema fee is 100 (the attestor-set fee was charged earlier).
+        assert_eq!(balance_of(&module, TEST_SENDER, &mut ws), sender_before - 100);
+        assert_eq!(balance_of(&module, TREASURY, &mut ws), treasury_before + 100);
+    }
+
+    #[test]
+    fn submit_attestation_moves_real_lgt_to_treasury() {
+        let (module, context, mut ws, _td) = fresh();
+        module.genesis(&config_with_fees(1_000, 0, 0), &mut ws).unwrap();
+        let signers = signers();
+        let set_members = members(&signers);
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: set_members.clone(), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let attestor_set_id = AttestorSet::derive_id(&set_members, 2);
+        module
+            .call(
+                CallMessage::RegisterSchema {
+                    name: "no-routing".into(),
+                    version: 1,
+                    attestor_set: attestor_set_id,
+                    fee_routing_bps: 0,
+                    fee_routing_addr: None,
+                },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let schema_id = Schema::derive_id(&TEST_SENDER, "no-routing", 1);
+
+        let sender_before = balance_of(&module, TEST_SENDER, &mut ws);
+        let treasury_before = balance_of(&module, TREASURY, &mut ws);
+
+        let payload_hash = [0xAAu8; 32];
+        let digest = SignedAttestationPayload {
+            schema_id,
+            payload_hash,
+            submitter: TEST_SENDER,
+            timestamp: 0,
+        }
+        .digest();
+        module
+            .call(
+                CallMessage::SubmitAttestation {
+                    schema_id,
+                    payload_hash,
+                    signatures: vec![
+                        sign_with(&signers[0], &digest),
+                        sign_with(&signers[1], &digest),
+                    ],
+                },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+
+        // Full 1_000 micros moved to treasury, no builder share.
+        assert_eq!(balance_of(&module, TEST_SENDER, &mut ws), sender_before - 1_000);
+        assert_eq!(balance_of(&module, TREASURY, &mut ws), treasury_before + 1_000);
+        assert_eq!(balance_of(&module, BUILDER_PAYOUT, &mut ws), 0);
+    }
+
+    #[test]
+    fn submit_attestation_routes_builder_share_via_bank() {
+        let (module, context, mut ws, _td) = fresh();
+        module.genesis(&config_with_fees(1_000, 0, 0), &mut ws).unwrap();
+        let signers = signers();
+        let set_members = members(&signers);
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: set_members.clone(), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let attestor_set_id = AttestorSet::derive_id(&set_members, 2);
+        module
+            .call(
+                CallMessage::RegisterSchema {
+                    name: "routed".into(),
+                    version: 1,
+                    attestor_set: attestor_set_id,
+                    fee_routing_bps: 2500, // 25% to builder
+                    fee_routing_addr: Some(BUILDER_PAYOUT),
+                },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let schema_id = Schema::derive_id(&TEST_SENDER, "routed", 1);
+
+        let sender_before = balance_of(&module, TEST_SENDER, &mut ws);
+        let treasury_before = balance_of(&module, TREASURY, &mut ws);
+        let builder_before = balance_of(&module, BUILDER_PAYOUT, &mut ws);
+
+        let payload_hash = [0xBBu8; 32];
+        let digest = SignedAttestationPayload {
+            schema_id,
+            payload_hash,
+            submitter: TEST_SENDER,
+            timestamp: 0,
+        }
+        .digest();
+        module
+            .call(
+                CallMessage::SubmitAttestation {
+                    schema_id,
+                    payload_hash,
+                    signatures: vec![
+                        sign_with(&signers[0], &digest),
+                        sign_with(&signers[1], &digest),
+                    ],
+                },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+
+        // 25% of 1_000 = 250 to builder, remainder 750 to treasury.
+        assert_eq!(balance_of(&module, TEST_SENDER, &mut ws), sender_before - 1_000);
+        assert_eq!(balance_of(&module, TREASURY, &mut ws), treasury_before + 750);
+        assert_eq!(balance_of(&module, BUILDER_PAYOUT, &mut ws), builder_before + 250);
+    }
+
+    #[test]
+    fn submit_attestation_fails_with_insufficient_balance() {
+        // Sender starts at 0 `$LGT`. The set + schema registrations are
+        // free in this config, so the registration calls succeed, but
+        // the attestation submit charges 1_000 micros and must fail.
+        let (module, context, mut ws, _td) = fresh_with_balance(0);
+        module.genesis(&config_with_fees(1_000, 0, 0), &mut ws).unwrap();
+        let signers = signers();
+        let set_members = members(&signers);
+        module
+            .call(
+                CallMessage::RegisterAttestorSet { members: set_members.clone(), threshold: 2 },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let attestor_set_id = AttestorSet::derive_id(&set_members, 2);
+        module
+            .call(
+                CallMessage::RegisterSchema {
+                    name: "nofunds".into(),
+                    version: 1,
+                    attestor_set: attestor_set_id,
+                    fee_routing_bps: 0,
+                    fee_routing_addr: None,
+                },
+                &context,
+                &mut ws,
+            )
+            .unwrap();
+        let schema_id = Schema::derive_id(&TEST_SENDER, "nofunds", 1);
+
+        let payload_hash = [0xCCu8; 32];
+        let digest = SignedAttestationPayload {
+            schema_id,
+            payload_hash,
+            submitter: TEST_SENDER,
+            timestamp: 0,
+        }
+        .digest();
+        let res = module.call(
+            CallMessage::SubmitAttestation {
+                schema_id,
+                payload_hash,
+                signatures: vec![sign_with(&signers[0], &digest), sign_with(&signers[1], &digest)],
+            },
+            &context,
+            &mut ws,
+        );
+        assert!(res.is_err(), "expected insufficient-balance failure: {res:?}");
+
+        // No attestation was written, and the counter never advanced
+        // because the bank transfer failed before `add_to_treasury` ran.
+        assert!(module.attestations.get(&(schema_id, payload_hash), &mut ws).is_none());
+        assert_eq!(module.total_treasury_collected.get(&mut ws).unwrap_or(0), 0);
     }
 }

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -333,19 +333,19 @@ pub struct AttestationModule<C: Context> {
     #[state]
     pub lgt_token_address: StateValue<Address>,
 
-    /// Flat per-attestation fee in `$LGT` micros. Set at genesis.
+    /// Flat per-attestation fee in `$LGT` nanos. Set at genesis.
     #[state]
     pub attestation_fee: StateValue<u64>,
 
-    /// Flat schema-registration fee in `$LGT` micros. Set at genesis.
+    /// Flat schema-registration fee in `$LGT` nanos. Set at genesis.
     #[state]
     pub schema_registration_fee: StateValue<u64>,
 
-    /// Flat attestor-set registration fee in `$LGT` micros. Set at genesis.
+    /// Flat attestor-set registration fee in `$LGT` nanos. Set at genesis.
     #[state]
     pub attestor_set_fee: StateValue<u64>,
 
-    /// Running counter of `$LGT` micros booked to the treasury.
+    /// Running counter of `$LGT` nanos booked to the treasury.
     ///
     /// Accumulates the treasury share of every successful
     /// `SubmitAttestation` plus the full registration fees from
@@ -355,7 +355,7 @@ pub struct AttestationModule<C: Context> {
     #[state]
     pub total_treasury_collected: StateValue<u64>,
 
-    /// Running counter of `$LGT` micros booked per builder address.
+    /// Running counter of `$LGT` nanos booked per builder address.
     ///
     /// Keyed by `Schema::fee_routing_addr`. Incremented on each
     /// `SubmitAttestation` under a schema with non-zero `fee_routing_bps`
@@ -374,13 +374,19 @@ pub const MAX_BUILDER_BPS: u16 = 5000;
 /// Default attestation fee in $LGT, in the chain's smallest unit.
 /// Placeholder constant. Real fee sizing is a governance parameter set
 /// at launch. Documented here for reference against the spec.
-pub const DEFAULT_ATTESTATION_FEE_LGT_MICROS: u64 = 1_000; // 0.001 $LGT at 6 decimals
+///
+/// `$LGT` uses **9 decimals** (Solana lamport convention). The smallest
+/// representable unit is `1 nano` = `0.000000001 $LGT`. The 9-decimal
+/// choice gives 18.4x headroom over a 1B-supply cap inside `u64` (the
+/// hard ceiling sov-bank imposes on amounts) while leaving 1000x more
+/// fee-pricing granularity than the 6-decimal alternative would.
+pub const DEFAULT_ATTESTATION_FEE_LGT_NANOS: u64 = 1_000_000; // 0.001 $LGT at 9 decimals
 
-/// Default schema-registration fee in `$LGT` micros. 100 $LGT at 6 decimals.
-pub const DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_MICROS: u64 = 100_000_000;
+/// Default schema-registration fee in `$LGT` nanos. 100 $LGT at 9 decimals.
+pub const DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_NANOS: u64 = 100_000_000_000;
 
-/// Default attestor-set registration fee in `$LGT` micros. 10 $LGT at 6 decimals.
-pub const DEFAULT_ATTESTOR_SET_FEE_LGT_MICROS: u64 = 10_000_000;
+/// Default attestor-set registration fee in `$LGT` nanos. 10 $LGT at 9 decimals.
+pub const DEFAULT_ATTESTOR_SET_FEE_LGT_NANOS: u64 = 10_000_000_000;
 
 // ============================================================================
 // Genesis configuration
@@ -446,11 +452,11 @@ pub struct AttestationConfig {
     /// address as a placeholder that is almost certainly not what you
     /// want; supply the real derived address in real configs.
     pub lgt_token_address: Address,
-    /// Flat per-attestation fee in `$LGT` micros (6 decimals).
+    /// Flat per-attestation fee in `$LGT` nanos (9 decimals).
     pub attestation_fee: u64,
-    /// Flat schema-registration fee in `$LGT` micros.
+    /// Flat schema-registration fee in `$LGT` nanos.
     pub schema_registration_fee: u64,
-    /// Flat attestor-set registration fee in `$LGT` micros.
+    /// Flat attestor-set registration fee in `$LGT` nanos.
     pub attestor_set_fee: u64,
     /// Attestor sets to register at genesis, in order.
     pub initial_attestor_sets: Vec<InitialAttestorSet>,
@@ -466,9 +472,9 @@ impl Default for AttestationConfig {
         Self {
             treasury: [0u8; 32],
             lgt_token_address: [0u8; 32],
-            attestation_fee: DEFAULT_ATTESTATION_FEE_LGT_MICROS,
-            schema_registration_fee: DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_MICROS,
-            attestor_set_fee: DEFAULT_ATTESTOR_SET_FEE_LGT_MICROS,
+            attestation_fee: DEFAULT_ATTESTATION_FEE_LGT_NANOS,
+            schema_registration_fee: DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_NANOS,
+            attestor_set_fee: DEFAULT_ATTESTOR_SET_FEE_LGT_NANOS,
             initial_attestor_sets: vec![],
             initial_schemas: vec![],
         }
@@ -763,7 +769,7 @@ impl<C: Context> AttestationModule<C> {
         // `$LGT`, the bank transfer returns `Err`, the working set
         // unwinds, and the tx fails atomically with no state changes.
         let fee =
-            self.attestor_set_fee.get(working_set).unwrap_or(DEFAULT_ATTESTOR_SET_FEE_LGT_MICROS);
+            self.attestor_set_fee.get(working_set).unwrap_or(DEFAULT_ATTESTOR_SET_FEE_LGT_NANOS);
         self.charge_to_treasury(context.sender(), fee, working_set)?;
 
         self.attestor_sets.set(
@@ -817,7 +823,7 @@ impl<C: Context> AttestationModule<C> {
         let fee = self
             .schema_registration_fee
             .get(working_set)
-            .unwrap_or(DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_MICROS);
+            .unwrap_or(DEFAULT_SCHEMA_REGISTRATION_FEE_LGT_NANOS);
         self.charge_to_treasury(context.sender(), fee, working_set)?;
 
         self.schemas.set(
@@ -886,7 +892,7 @@ impl<C: Context> AttestationModule<C> {
         // treasury. Two transfers (treasury then builder) so a partial
         // failure unwinds both via the working set.
         let total_fee =
-            self.attestation_fee.get(working_set).unwrap_or(DEFAULT_ATTESTATION_FEE_LGT_MICROS);
+            self.attestation_fee.get(working_set).unwrap_or(DEFAULT_ATTESTATION_FEE_LGT_NANOS);
         let (builder_share, treasury_share) =
             split_attestation_fee(total_fee, schema.fee_routing_bps);
         self.charge_to_treasury(context.sender(), treasury_share, working_set)?;
@@ -905,7 +911,7 @@ impl<C: Context> AttestationModule<C> {
         Ok(CallResponse::default())
     }
 
-    /// Move `amount` `$LGT` micros from `submitter` to the treasury via
+    /// Move `amount` `$LGT` nanos from `submitter` to the treasury via
     /// `sov-bank`, then bump the cumulative
     /// [`AttestationModule::total_treasury_collected`] counter.
     ///
@@ -939,7 +945,7 @@ impl<C: Context> AttestationModule<C> {
         Ok(())
     }
 
-    /// Move `amount` `$LGT` micros from `submitter` to `builder_addr` via
+    /// Move `amount` `$LGT` nanos from `submitter` to `builder_addr` via
     /// `sov-bank`, then bump the cumulative
     /// [`AttestationModule::builder_fees_collected`] counter for that
     /// address. Same `amount == 0` short-circuit and same atomicity
@@ -1364,9 +1370,10 @@ mod state_transition_tests {
     /// Treasury address used by `fresh()`. Distinct from `TEST_SENDER` so
     /// bank balance assertions stay unambiguous.
     const TEST_TREASURY: Address = [2u8; 32];
-    /// Initial `$LGT` micros allocated to `TEST_SENDER` at genesis.
-    /// Generous enough that no validation-only test runs out.
-    const SENDER_INITIAL_LGT: u64 = 1_000_000_000;
+    /// Initial `$LGT` nanos allocated to `TEST_SENDER` at genesis.
+    /// Generous enough that no validation-only test runs out. Equivalent
+    /// to 1000 `$LGT` at 9 decimals.
+    const SENDER_INITIAL_LGT: u64 = 1_000_000_000_000;
 
     /// Convert a `SovAddress` to its 32-byte representation for storage in
     /// `Address`-typed (`[u8; 32]`) state values.
@@ -2011,10 +2018,10 @@ mod fee_tests {
     const TREASURY: Address = [11u8; 32];
     const BUILDER_PAYOUT: Address = [22u8; 32];
     /// Generous starting balance for `TEST_SENDER` so the existing
-    /// fee-volume tests (which charge up to a few thousand micros) don't
+    /// fee-volume tests (which charge up to a few thousand nanos) don't
     /// run out. The insufficient-balance test uses a different `fresh()`
-    /// variant below.
-    const SENDER_INITIAL_LGT: u64 = 1_000_000_000;
+    /// variant below. Equivalent to 1000 `$LGT` at 9 decimals.
+    const SENDER_INITIAL_LGT: u64 = 1_000_000_000_000;
 
     fn sov_addr_bytes(addr: &SovAddress) -> Address {
         let mut out = [0u8; 32];
@@ -2398,7 +2405,7 @@ mod fee_tests {
             )
             .unwrap();
 
-        // Full 1_000 micros moved to treasury, no builder share.
+        // Full 1_000 nanos moved to treasury, no builder share.
         assert_eq!(balance_of(&module, TEST_SENDER, &mut ws), sender_before - 1_000);
         assert_eq!(balance_of(&module, TREASURY, &mut ws), treasury_before + 1_000);
         assert_eq!(balance_of(&module, BUILDER_PAYOUT, &mut ws), 0);
@@ -2470,7 +2477,7 @@ mod fee_tests {
     fn submit_attestation_fails_with_insufficient_balance() {
         // Sender starts at 0 `$LGT`. The set + schema registrations are
         // free in this config, so the registration calls succeed, but
-        // the attestation submit charges 1_000 micros and must fail.
+        // the attestation submit charges 1_000 nanos and must fail.
         let (module, context, mut ws, _td) = fresh_with_balance(0);
         module.genesis(&config_with_fees(1_000, 0, 0), &mut ws).unwrap();
         let signers = signers();

--- a/docs/development/genesis.example.json
+++ b/docs/development/genesis.example.json
@@ -9,11 +9,14 @@
     "treasury: address that receives the treasury share of every attestation",
     "fee plus the full amount of registration fees.",
     "",
-    "*_fee fields: $LGT amounts in micros (6 decimals). 1_000 micros = 0.001 $LGT.",
+    "*_fee fields: $LGT amounts in nanos (9 decimals). 1_000_000 nanos = 0.001 $LGT.",
+    "9 decimals matches Solana's lamport convention; gives 18.4x headroom over a 1B",
+    "supply cap inside u64 (sov-bank's amount type) while leaving 1000x more fee-",
+    "pricing granularity than the 6-decimal alternative would.",
     "Defaults:",
-    "  attestation_fee:           1_000          (0.001 $LGT)",
-    "  schema_registration_fee:   100_000_000    (100 $LGT)",
-    "  attestor_set_fee:          10_000_000     (10 $LGT)",
+    "  attestation_fee:           1_000_000          (0.001 $LGT)",
+    "  schema_registration_fee:   100_000_000_000    (100 $LGT)",
+    "  attestor_set_fee:          10_000_000_000     (10 $LGT)",
     "",
     "initial_attestor_sets: registered at genesis with the same rules as",
     "RegisterAttestorSet. Stored members are sorted before hashing.",
@@ -29,9 +32,9 @@
     11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11
   ],
 
-  "attestation_fee": 1000,
-  "schema_registration_fee": 100000000,
-  "attestor_set_fee": 10000000,
+  "attestation_fee": 1000000,
+  "schema_registration_fee": 100000000000,
+  "attestor_set_fee": 10000000000,
 
   "initial_attestor_sets": [
     {

--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -188,6 +188,8 @@ Signatures do NOT cover the `signatures` field itself (that would be circular). 
 
 All amounts in $LGT.
 
+`$LGT` uses **9 decimals** on the wire. The smallest representable unit is `1 nano` = `0.000000001 $LGT`. Genesis configs and SDK call sites carry amounts as `u64` base units (nanos); user-facing UIs format as decimal `$LGT`. The 9-decimal choice mirrors Solana (lamport) and Cosmos micro-precision conventions while leaving 18.4x headroom over a 1B-supply cap inside `u64`, the amount type `sov-bank` enforces.
+
 | Event | Fee | Split |
 |---|---|---|
 | `RegisterAttestorSet` | `ATTESTOR_SET_FEE` (governance, default 10 $LGT) | 100% treasury |


### PR DESCRIPTION
## Summary

Replaces the accounting-only fee counters from #35 with real `$LGT` token movement via `sov-bank`. Every `RegisterAttestorSet`, `RegisterSchema`, and `SubmitAttestation` now charges the submitter in real `$LGT` and routes the proceeds to the treasury (and the optional builder address). Counters from #35 stay as cumulative audit accumulators.

Closes #56.

## What lands

**Workspace:**
- `sov-bank` added to workspace deps at the same SDK rev (`13e4077c`).
- `attestation` crate adds `sov-bank` as a dep with the `native` feature.

**Module changes:**
- `AttestationModule<C>` gains `#[module] bank: sov_bank::Bank<C>`, giving handlers a typed reference to the bank module's state.
- New `lgt_token_address: StateValue<Address>` field on the module, set once at genesis from `AttestationConfig::lgt_token_address`.
- Two new handler-internal helpers: `charge_to_treasury` and `charge_to_builder`. Each does the bank transfer, then bumps the cumulative counter on success. `amount == 0` short-circuits without touching either, so zero-fee paths are free.
- New `AttestationError::ChainNotConfigured` variant for the unreachable case where genesis didn't seed the token address or treasury (handlers fail honestly instead of panicking).

**Handler changes:**
- All three handlers gain `where C::Address: From<[u8; 32]>` (needed to convert stored 32-byte addresses to `C::Address` for bank calls).
- Fee charge order is locked: validation, state-validity checks, bank transfer (counter bump on success), entity write. If a transfer fails, the working set unwinds before any state mutation.
- `handle_register_attestor_set` now takes `context` so it can read `context.sender()` for the bank transfer.

**Genesis stays free:**
`seed_from_config` writes initial attestor sets and schemas directly to state, bypassing the handlers. Genesis bootstrap registrations don't pay fees, which matches the universal "operator-set, not user-submitted" convention. Documented inline.

## Token model (locked at #56, decimals revised mid-PR)

| Field | Value |
|---|---|
| `token_name` | `"LGT"` |
| `salt` | `0` |
| Deployer | `[0; 32]` (sov-bank's `DEPLOYER` sentinel) |
| Decimals | **9 (nanos), Solana lamport convention** |
| Devnet supply | `10^18` (1B `$LGT` in nanos) |

The token address is deterministic across networks via `sov_bank::get_genesis_token_address::<C>("LGT", 0)`.

**Why 9 not 6:** original pick was 6 (USDC convention). On further weighing, 9 gives 1000x more fee-pricing granularity for sub-cent economics if `$LGT` appreciates or fees need to drop, while still leaving 18.4x headroom over a 1B supply cap inside `u64` (sov-bank's amount type). Constants renamed `DEFAULT_*_MICROS` → `DEFAULT_*_NANOS`. Genesis example JSON, protocol spec fee section, and inline docs updated. See issue #56 comment for the full reasoning.

## Tests (5 new, 53 total)

Existing 48 tests still pass; both `state_transition_tests` and `fee_tests` updated their `fresh()` helpers to seed the bank with `$LGT` for `TEST_SENDER` (and the treasury / builder addresses).

New (`fee_tests`):
- `register_attestor_set_charges_lgt_via_bank`
- `register_schema_charges_lgt_via_bank`
- `submit_attestation_moves_real_lgt_to_treasury`
- `submit_attestation_routes_builder_share_via_bank` (25% routing, asserts 250 to builder + 750 to treasury via bank balances)
- `submit_attestation_fails_with_insufficient_balance` (sender at 0 `$LGT`, asserts `Err`, no attestation written, counter untouched)

## Local verification

- [x] `cargo test -p attestation`: 53/53
- [x] `cargo fmt --all -- --check`: clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items`: clean
- [x] `cargo check --workspace`: clean

## Known follow-ups (separate issues)

- Treasury withdrawals: gated on governance (#41, v1).
- Multi-token fees: v0 is `$LGT`-only.
- Sequencer fee distribution: separate from attestation fees.
- Burn fraction on fees: v1 config knob, not v0.
- Extract `lgt_token_address` to a chain-wide config primitive when the second consumer (Iris relayer module v0.5, `tokens` module v1) needs the same handle.
