### PR TITLE
Backfill attestation test coverage on new SDK (refs #59)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "ed25519-dalek",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "sha2",
  "sov-bank",
  "sov-modules-api",

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -24,6 +24,7 @@ sov-bank        = { workspace = true }
 
 [dev-dependencies]
 attestation     = { path = ".", features = ["native"] }
+serde_json.workspace = true
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-bank        = { workspace = true, features = ["native"] }
 sov-state       = { workspace = true, features = ["native"] }

--- a/crates/modules/attestation/tests/integration.rs
+++ b/crates/modules/attestation/tests/integration.rs
@@ -894,3 +894,155 @@ fn submit_attestation_fails_with_insufficient_balance() {
         }),
     });
 }
+
+// ============================================================================
+// Idempotency / duplicate-prevention reject paths
+// ============================================================================
+
+#[test]
+fn register_attestor_set_rejects_duplicate() {
+    // Same `(members, threshold)` derives the same `AttestorSetId`.
+    // Re-registering must be rejected even if all the validation
+    // invariants pass; the storage layer is write-once per id.
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+
+    // First registration succeeds.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterAttestorSet { members: safe_members(&signers), threshold: 2 },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+
+    // Second registration with the same members + threshold reverts.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterAttestorSet { members: safe_members(&signers), threshold: 2 },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(_)),
+                "duplicate attestor set must revert: {:?}",
+                result.tx_receipt
+            );
+        }),
+    });
+}
+
+#[test]
+fn register_schema_rejects_duplicate() {
+    // Same `(owner, name, version)` derives the same `SchemaId`. The
+    // `owner` is the tx sender; we use the same submitter for both
+    // calls so the derived id collides on the second attempt.
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_initial(Amount::ZERO, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+
+    // First registration succeeds.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("dup-schema"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+
+    // Second registration with the same name + version + (implicit
+    // same owner from the same submitter) reverts.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("dup-schema"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(_)),
+                "duplicate schema must revert: {:?}",
+                result.tx_receipt
+            );
+        }),
+    });
+}
+
+#[test]
+fn register_attestor_set_rejects_empty_members() {
+    // Distinct from "threshold > members.len()" with 1 member.
+    // Empty members is its own validation branch (`EmptyAttestorSet`)
+    // because a zero-member set with threshold 0 would otherwise sneak
+    // past the threshold check.
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+
+    let empty: SafeVec<PubKey, MAX_ATTESTOR_SET_MEMBERS> =
+        SafeVec::try_from(Vec::<PubKey>::new()).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterAttestorSet { members: empty, threshold: 1 },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(_)),
+                "empty members must revert: {:?}",
+                result.tx_receipt
+            );
+        }),
+    });
+}
+
+#[test]
+fn submit_attestation_rejects_empty_signatures() {
+    // Zero signatures hits `BelowThreshold` rather than any of the
+    // signature-validation errors. Confirms the validator handles the
+    // "no signatures at all" edge cleanly without panicking on an
+    // empty iterator.
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_initial(Amount::ZERO, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+    let submitter_addr = env.submitter.address();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("empty-sigs"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, "empty-sigs", 1);
+
+    let payload_hash = attestation::PayloadHash::from([0xEEu8; 32]);
+    let empty_sigs: SafeVec<AttestorSignature, MAX_ATTESTATION_SIGNATURES> =
+        SafeVec::try_from(Vec::<AttestorSignature>::new()).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures: empty_sigs },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(_)),
+                "empty signatures must revert: {:?}",
+                result.tx_receipt
+            );
+        }),
+    });
+}

--- a/crates/modules/attestation/tests/integration.rs
+++ b/crates/modules/attestation/tests/integration.rs
@@ -329,3 +329,568 @@ fn submit_attestation_routes_treasury_share_via_bank() {
         }),
     });
 }
+
+// ============================================================================
+// Schema validation reject paths
+// ============================================================================
+
+#[test]
+fn register_schema_rejects_orphan_routing_bps_without_addr() {
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_initial(Amount::ZERO, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+
+    // bps > 0 with no addr → rejected.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("orphan-bps"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 1000,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn register_schema_rejects_orphan_routing_addr_without_bps() {
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_initial(Amount::ZERO, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+    let routing_addr = env.submitter.address();
+
+    // addr set but bps == 0 → rejected.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("orphan-addr"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: Some(routing_addr),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn submit_attestation_requires_existing_schema() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+
+    // Reference a schema id that was never registered.
+    let bogus_schema = attestation::SchemaId::from([0xDEu8; 32]);
+    let bogus_payload = attestation::PayloadHash::from([0xADu8; 32]);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation {
+                schema_id: bogus_schema,
+                payload_hash: bogus_payload,
+                signatures: SafeVec::try_from(Vec::<AttestorSignature>::new()).unwrap(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+// ============================================================================
+// Full register-register-submit flow + write-once invariant
+// ============================================================================
+
+#[test]
+fn full_register_register_submit_flow() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let submitter_addr = env.submitter.address();
+
+    // 1. Register attestor set (threshold 2 of 3).
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterAttestorSet { members: safe_members(&signers), threshold: 2 },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let attestor_set_id = AttestorSet::derive_id(&pubkeys_of(&signers), 2);
+
+    // 2. Register schema.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("themisra.proof-of-prompt"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, "themisra.proof-of-prompt", 1);
+
+    // 3. Submit attestation signed by 2 of 3 (meets threshold).
+    let payload_hash = attestation::PayloadHash::from([0x42u8; 32]);
+    let digest = attestation::SignedAttestationPayload::<S> {
+        schema_id,
+        payload_hash,
+        submitter: submitter_addr,
+        timestamp: 0,
+    }
+    .digest();
+    let sig_vec: Vec<AttestorSignature> = signers[..2]
+        .iter()
+        .map(|sk| AttestorSignature {
+            pubkey: PubKey::from(sk.verifying_key().to_bytes()),
+            sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(
+                sk.sign(&digest).to_bytes().to_vec(),
+            )
+            .unwrap(),
+        })
+        .collect();
+    let signatures =
+        SafeVec::<AttestorSignature, MAX_ATTESTATION_SIGNATURES>::try_from(sig_vec.clone())
+            .unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            // 4. Verify state.
+            let module = AttestationModule::<S>::default();
+            let key = attestation::AttestationId::from_pair(&schema_id, &payload_hash);
+            let stored = module
+                .attestations
+                .get(&key, state)
+                .unwrap_infallible()
+                .expect("attestation should be in state");
+            assert_eq!(stored.schema_id, schema_id);
+            assert_eq!(stored.payload_hash, payload_hash);
+            assert_eq!(stored.submitter, submitter_addr);
+        }),
+    });
+
+    // 5. Write-once: resubmitting same (schema_id, payload_hash) must fail.
+    let signatures_again =
+        SafeVec::<AttestorSignature, MAX_ATTESTATION_SIGNATURES>::try_from(sig_vec).unwrap();
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation {
+                schema_id,
+                payload_hash,
+                signatures: signatures_again,
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+// ============================================================================
+// Signature validation reject paths
+// ============================================================================
+
+/// Sets up an env + registers attestor set + registers schema, returns
+/// the schema id and the digest the attestors must sign over.
+fn sig_test_setup(
+    env: &mut TestEnv,
+    signers: &[SigningKey; 3],
+    schema_name: &str,
+    payload_hash: attestation::PayloadHash,
+) -> (attestation::SchemaId, attestation::Hash32) {
+    let submitter_addr = env.submitter.address();
+    let members = safe_members(signers);
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterAttestorSet { members, threshold: 2 },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let attestor_set_id = AttestorSet::derive_id(&pubkeys_of(signers), 2);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name(schema_name),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, schema_name, 1);
+    let digest = attestation::SignedAttestationPayload::<S> {
+        schema_id,
+        payload_hash,
+        submitter: submitter_addr,
+        timestamp: 0,
+    }
+    .digest();
+    (schema_id, digest)
+}
+
+fn sig_for(sk: &SigningKey, digest: &attestation::Hash32) -> AttestorSignature {
+    AttestorSignature {
+        pubkey: PubKey::from(sk.verifying_key().to_bytes()),
+        sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(
+            sk.sign(digest).to_bytes().to_vec(),
+        )
+        .unwrap(),
+    }
+}
+
+#[test]
+fn submit_below_threshold_rejects() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let payload_hash = attestation::PayloadHash::from([0x01u8; 32]);
+    let (schema_id, digest) = sig_test_setup(&mut env, &signers, "below-threshold", payload_hash);
+
+    // Only 1 signature, threshold is 2.
+    let signatures = SafeVec::try_from(vec![sig_for(&signers[0], &digest)]).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn submit_with_unknown_pubkey_rejects() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let payload_hash = attestation::PayloadHash::from([0x02u8; 32]);
+    let (schema_id, digest) = sig_test_setup(&mut env, &signers, "unknown-pubkey", payload_hash);
+
+    // One legit sig + one signed by a stranger NOT in the attestor set.
+    let stranger = SigningKey::from_bytes(&[99u8; 32]);
+    let signatures =
+        SafeVec::try_from(vec![sig_for(&signers[0], &digest), sig_for(&stranger, &digest)])
+            .unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn submit_with_invalid_signature_rejects() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let payload_hash = attestation::PayloadHash::from([0x03u8; 32]);
+    let (schema_id, digest) = sig_test_setup(&mut env, &signers, "invalid-sig", payload_hash);
+
+    // Valid sig + one whose bytes are corrupted (flip a bit).
+    let mut corrupted_bytes = signers[0].sign(&digest).to_bytes().to_vec();
+    corrupted_bytes[0] ^= 0x01;
+    let corrupted = AttestorSignature {
+        pubkey: PubKey::from(signers[0].verifying_key().to_bytes()),
+        sig: SafeVec::try_from(corrupted_bytes).unwrap(),
+    };
+    let signatures = SafeVec::try_from(vec![sig_for(&signers[1], &digest), corrupted]).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn submit_with_duplicate_pubkey_rejects() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let payload_hash = attestation::PayloadHash::from([0x04u8; 32]);
+    let (schema_id, digest) = sig_test_setup(&mut env, &signers, "duplicate-pubkey", payload_hash);
+
+    // Same signer twice, both technically valid.
+    let s = sig_for(&signers[0], &digest);
+    let signatures = SafeVec::try_from(vec![s.clone(), s]).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn submit_with_bad_sig_length_rejects() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let payload_hash = attestation::PayloadHash::from([0x05u8; 32]);
+    let (schema_id, digest) = sig_test_setup(&mut env, &signers, "bad-len", payload_hash);
+
+    // Take a legit sig but truncate the raw bytes to 63 (ed25519 expects 64).
+    let mut truncated_bytes = signers[0].sign(&digest).to_bytes().to_vec();
+    truncated_bytes.truncate(63);
+    let truncated = AttestorSignature {
+        pubkey: PubKey::from(signers[0].verifying_key().to_bytes()),
+        sig: SafeVec::try_from(truncated_bytes).unwrap(),
+    };
+    let signatures = SafeVec::try_from(vec![sig_for(&signers[1], &digest), truncated]).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn submit_digest_is_bound_to_submitter() {
+    // Signing the wrong submitter produces signatures that don't verify
+    // against the module-computed digest. Locks in the invariant that
+    // submitter is part of what attestors sign, not a caller-controlled
+    // free variable.
+    use sov_modules_api::Address;
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let payload_hash = attestation::PayloadHash::from([0x06u8; 32]);
+    let submitter_addr = env.submitter.address();
+
+    let members = safe_members(&signers);
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterAttestorSet { members, threshold: 2 },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let attestor_set_id = AttestorSet::derive_id(&pubkeys_of(&signers), 2);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("digest-binding"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, "digest-binding", 1);
+
+    // Sign over a digest that uses a DIFFERENT submitter address.
+    let wrong_submitter: <S as sov_modules_api::Spec>::Address = Address::from([0xFFu8; 28]);
+    let wrong_digest = attestation::SignedAttestationPayload::<S> {
+        schema_id,
+        payload_hash,
+        submitter: wrong_submitter,
+        timestamp: 0,
+    }
+    .digest();
+    let signatures = SafeVec::try_from(vec![
+        sig_for(&signers[0], &wrong_digest),
+        sig_for(&signers[1], &wrong_digest),
+    ])
+    .unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(_)),
+                "wrong-submitter digest must not verify"
+            );
+        }),
+    });
+}
+
+// ============================================================================
+// Genesis happy path (rejection paths covered by handler tests above)
+// ============================================================================
+
+#[test]
+fn genesis_seeds_initial_attestor_set() {
+    // Pre-register an attestor set at genesis. The runtime should
+    // expose it without any RegisterAttestorSet tx.
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_initial(Amount::ZERO, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+    let submitter_addr = env.submitter.address();
+
+    // Try to register a schema referencing the genesis-seeded set.
+    // If genesis didn't seed it, this would fail with UnknownAttestorSet.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("genesis-set-test"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            // Verify both the genesis-seeded set and the just-registered schema are in state.
+            let module = AttestationModule::<S>::default();
+            assert!(module
+                .attestor_sets
+                .get(&attestor_set_id, state)
+                .unwrap_infallible()
+                .is_some());
+            let schema_id = Schema::<S>::derive_id(&submitter_addr, "genesis-set-test", 1);
+            assert!(module.schemas.get(&schema_id, state).unwrap_infallible().is_some());
+        }),
+    });
+}
+
+// ============================================================================
+// Fee tests: builder routing + insufficient balance
+// ============================================================================
+
+#[test]
+fn submit_attestation_routes_builder_share_via_bank() {
+    // 25% routing → 250 builder + 750 treasury on a 1000-nano fee.
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_initial(Amount::new(1_000), Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+    let submitter_addr = env.submitter.address();
+    let builder_addr = env.submitter.address(); // route to self for simplicity
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("builder-routing"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 2500,
+                fee_routing_addr: Some(builder_addr),
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, "builder-routing", 1);
+
+    let payload_hash = attestation::PayloadHash::from([0xBBu8; 32]);
+    let digest = attestation::SignedAttestationPayload::<S> {
+        schema_id,
+        payload_hash,
+        submitter: submitter_addr,
+        timestamp: 0,
+    }
+    .digest();
+    let sigs: Vec<AttestorSignature> = signers[..2].iter().map(|sk| sig_for(sk, &digest)).collect();
+    let signatures = SafeVec::try_from(sigs).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            let module = AttestationModule::<S>::default();
+
+            // Counter accumulators reflect the split.
+            assert_eq!(
+                module.total_treasury_collected.get(state).unwrap_infallible(),
+                Some(Amount::new(750))
+            );
+            assert_eq!(
+                module.builder_fees_collected.get(&builder_addr, state).unwrap_infallible(),
+                Some(Amount::new(250))
+            );
+        }),
+    });
+}
+
+#[test]
+fn submit_attestation_fails_with_insufficient_balance() {
+    // Set the attestation fee to absurdly higher than the submitter
+    // could ever hold from genesis. Bank's `transfer_from` will return
+    // Err and the tx reverts with no state changes.
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    // 10^30 nanos — guaranteed larger than any test user's balance.
+    let absurd_fee = Amount::new(1_000_000_000_000_000_000_000_000_000_000);
+    let mut env = setup_with_initial(absurd_fee, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+    let submitter_addr = env.submitter.address();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("insufficient"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, "insufficient", 1);
+
+    let payload_hash = attestation::PayloadHash::from([0xCCu8; 32]);
+    let digest = attestation::SignedAttestationPayload::<S> {
+        schema_id,
+        payload_hash,
+        submitter: submitter_addr,
+        timestamp: 0,
+    }
+    .digest();
+    let sigs: Vec<AttestorSignature> = signers[..2].iter().map(|sk| sig_for(sk, &digest)).collect();
+    let signatures = SafeVec::try_from(sigs).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(_)),
+                "insufficient balance should revert: {:?}",
+                result.tx_receipt
+            );
+            // Attestation must not have been written.
+            let module = AttestationModule::<S>::default();
+            let key = attestation::AttestationId::from_pair(&schema_id, &payload_hash);
+            assert!(module.attestations.get(&key, state).unwrap_infallible().is_none());
+        }),
+    });
+}

--- a/crates/modules/attestation/tests/unit.rs
+++ b/crates/modules/attestation/tests/unit.rs
@@ -1,0 +1,370 @@
+//! Pure-data unit tests for the attestation module's protocol types.
+//!
+//! These don't need a `TestRunner`. They cover:
+//!
+//! - Borsh + Serde round-trips for every persisted type, so we catch
+//!   on-wire serialization regressions before they reach the network.
+//! - `Schema::derive_id` and `AttestorSet::derive_id` determinism +
+//!   semantic invariants (same inputs → same id; ordering doesn't
+//!   matter for sets; threshold / version / owner / name all
+//!   participate).
+//! - `SignedAttestationPayload::digest` determinism.
+//! - `MAX_BUILDER_BPS` cap.
+//! - `split_attestation_fee` math at zero, mid, cap, and overflow-
+//!   adjacent inputs.
+//!
+//! Mirrors `mod tests` from the v0.3 test suite preserved at
+//! `/tmp/attestation_tests_v0_3.rs` for reference. Type signatures
+//! changed (`SchemaId` is now a typed Bech32 newtype, fee values are
+//! `Amount`, etc.); behaviour assertions stay the same.
+
+use attestation::{
+    Attestation, AttestationConfig, AttestationId, AttestorSet, AttestorSignature, CallMessage,
+    InitialAttestorSet, InitialSchema, PayloadHash, PubKey, Schema, SchemaId,
+    SignedAttestationPayload, MAX_ATTESTATION_SIGNATURES, MAX_ATTESTOR_SET_MEMBERS,
+    MAX_ATTESTOR_SIGNATURE_BYTES,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use sov_bank::{Amount, TokenId};
+use sov_modules_api::{Address, SafeString, SafeVec, Spec};
+
+type S = sov_test_utils::TestSpec;
+
+// ----- Helpers ---------------------------------------------------------------
+
+fn round_trip_borsh<T>(value: T)
+where
+    T: BorshSerialize + BorshDeserialize + PartialEq + std::fmt::Debug,
+{
+    let bytes = borsh::to_vec(&value).expect("encode");
+    let decoded: T = borsh::from_slice(&bytes).expect("decode");
+    assert_eq!(value, decoded);
+}
+
+fn sample_addr(n: u8) -> <S as Spec>::Address {
+    Address::from([n; 28])
+}
+
+fn sample_pubkey(n: u8) -> PubKey {
+    PubKey::from([n; 32])
+}
+
+fn sample_schema_id(n: u8) -> SchemaId {
+    SchemaId::from([n; 32])
+}
+
+fn sample_payload_hash(n: u8) -> PayloadHash {
+    PayloadHash::from([n; 32])
+}
+
+fn safe_sig(byte: u8) -> SafeVec<u8, MAX_ATTESTOR_SIGNATURE_BYTES> {
+    SafeVec::try_from(vec![byte; 64]).expect("64 bytes fits in 96")
+}
+
+fn sample_attestor_set() -> AttestorSet {
+    AttestorSet {
+        members: vec![sample_pubkey(1), sample_pubkey(2), sample_pubkey(3)],
+        threshold: 2,
+    }
+}
+
+fn sample_schema() -> Schema<S> {
+    Schema::<S> {
+        owner: sample_addr(42),
+        name: "themisra.proof-of-prompt".to_string(),
+        version: 1,
+        attestor_set: AttestorSet::derive_id(&[sample_pubkey(7)], 1),
+        fee_routing_bps: 2500,
+        fee_routing_addr: Some(sample_addr(99)),
+    }
+}
+
+fn sample_attestation() -> Attestation<S> {
+    Attestation::<S> {
+        schema_id: sample_schema_id(3),
+        payload_hash: sample_payload_hash(4),
+        submitter: sample_addr(5),
+        timestamp: 1_700_000_000,
+        signatures: vec![AttestorSignature { pubkey: sample_pubkey(1), sig: safe_sig(0xab) }],
+    }
+}
+
+fn sample_signed_payload() -> SignedAttestationPayload<S> {
+    SignedAttestationPayload::<S> {
+        schema_id: sample_schema_id(9),
+        payload_hash: sample_payload_hash(1),
+        submitter: sample_addr(7),
+        timestamp: 1_234_567_890,
+    }
+}
+
+// ----- Borsh round-trips -----------------------------------------------------
+
+#[test]
+fn schema_borsh_round_trip() {
+    round_trip_borsh(sample_schema());
+}
+
+#[test]
+fn attestor_set_borsh_round_trip() {
+    round_trip_borsh(sample_attestor_set());
+}
+
+#[test]
+fn attestation_borsh_round_trip() {
+    round_trip_borsh(sample_attestation());
+}
+
+#[test]
+fn signed_payload_borsh_round_trip() {
+    round_trip_borsh(sample_signed_payload());
+}
+
+#[test]
+fn attestation_id_borsh_round_trip() {
+    round_trip_borsh(AttestationId::from_pair(&sample_schema_id(11), &sample_payload_hash(22)));
+}
+
+#[test]
+fn attestor_signature_borsh_round_trip() {
+    round_trip_borsh(AttestorSignature { pubkey: sample_pubkey(1), sig: safe_sig(0xcd) });
+}
+
+#[test]
+fn call_message_register_attestor_set_borsh_round_trip() {
+    let msg = CallMessage::<S>::RegisterAttestorSet {
+        members: SafeVec::<PubKey, MAX_ATTESTOR_SET_MEMBERS>::try_from(vec![
+            sample_pubkey(1),
+            sample_pubkey(2),
+        ])
+        .unwrap(),
+        threshold: 1,
+    };
+    round_trip_borsh(msg);
+}
+
+#[test]
+fn call_message_register_schema_borsh_round_trip() {
+    let msg = CallMessage::<S>::RegisterSchema {
+        name: SafeString::try_from("foo.bar".to_string()).unwrap(),
+        version: 3,
+        attestor_set: AttestorSet::derive_id(&[sample_pubkey(8)], 1),
+        fee_routing_bps: 1000,
+        fee_routing_addr: Some(sample_addr(10)),
+    };
+    round_trip_borsh(msg);
+}
+
+#[test]
+fn call_message_submit_attestation_borsh_round_trip() {
+    let sigs = SafeVec::<AttestorSignature, MAX_ATTESTATION_SIGNATURES>::try_from(vec![
+        AttestorSignature { pubkey: sample_pubkey(1), sig: safe_sig(0xcd) },
+    ])
+    .unwrap();
+    let msg = CallMessage::<S>::SubmitAttestation {
+        schema_id: sample_schema_id(1),
+        payload_hash: sample_payload_hash(2),
+        signatures: sigs,
+    };
+    round_trip_borsh(msg);
+}
+
+// ----- Serde JSON round-trips ------------------------------------------------
+
+#[test]
+fn schema_json_round_trip() {
+    let original = sample_schema();
+    let json = serde_json::to_string(&original).expect("encode");
+    let decoded: Schema<S> = serde_json::from_str(&json).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn attestation_json_round_trip() {
+    let original = sample_attestation();
+    let json = serde_json::to_string(&original).expect("encode");
+    let decoded: Attestation<S> = serde_json::from_str(&json).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn attestor_set_json_round_trip() {
+    let original = sample_attestor_set();
+    let json = serde_json::to_string(&original).expect("encode");
+    let decoded: AttestorSet = serde_json::from_str(&json).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn attestation_config_json_round_trip() {
+    let cfg = AttestationConfig::<S> {
+        treasury: sample_addr(9),
+        lgt_token_id: TokenId::from([7u8; 32]),
+        attestation_fee: Amount::new(1234),
+        schema_registration_fee: Amount::new(5678),
+        attestor_set_fee: Amount::new(91011),
+        initial_attestor_sets: vec![InitialAttestorSet {
+            members: vec![sample_pubkey(1), sample_pubkey(2)],
+            threshold: 2,
+        }],
+        initial_schemas: vec![InitialSchema {
+            owner: sample_addr(3),
+            name: "demo".into(),
+            version: 1,
+            attestor_set: AttestorSet::derive_id(&[sample_pubkey(4)], 1),
+            fee_routing_bps: 1000,
+            fee_routing_addr: Some(sample_addr(5)),
+        }],
+    };
+    let json = serde_json::to_string(&cfg).expect("encode");
+    let decoded: AttestationConfig<S> = serde_json::from_str(&json).expect("decode");
+    assert_eq!(decoded.treasury, cfg.treasury);
+    assert_eq!(decoded.attestation_fee, cfg.attestation_fee);
+    assert_eq!(decoded.initial_attestor_sets.len(), 1);
+    assert_eq!(decoded.initial_schemas.len(), 1);
+}
+
+// ----- Schema::derive_id -----------------------------------------------------
+
+#[test]
+fn schema_derive_id_is_deterministic() {
+    let a = Schema::<S>::derive_id(&sample_addr(1), "foo", 1);
+    let b = Schema::<S>::derive_id(&sample_addr(1), "foo", 1);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn schema_derive_id_separates_owners() {
+    // Same name + version, different owner → different schema_id.
+    // This is the core anti-squatting property: namespaces are
+    // owner-scoped, not global.
+    let owner_a = Schema::<S>::derive_id(&sample_addr(1), "themisra.pop", 1);
+    let owner_b = Schema::<S>::derive_id(&sample_addr(2), "themisra.pop", 1);
+    assert_ne!(owner_a, owner_b);
+}
+
+#[test]
+fn schema_derive_id_bumps_on_version() {
+    let v1 = Schema::<S>::derive_id(&sample_addr(1), "foo", 1);
+    let v2 = Schema::<S>::derive_id(&sample_addr(1), "foo", 2);
+    assert_ne!(v1, v2);
+}
+
+#[test]
+fn schema_derive_id_separates_names() {
+    let a = Schema::<S>::derive_id(&sample_addr(1), "foo", 1);
+    let b = Schema::<S>::derive_id(&sample_addr(1), "bar", 1);
+    assert_ne!(a, b);
+}
+
+// ----- AttestorSet::derive_id ------------------------------------------------
+
+#[test]
+fn attestor_set_derive_id_is_deterministic() {
+    let members = vec![sample_pubkey(1), sample_pubkey(2)];
+    let a = AttestorSet::derive_id(&members, 1);
+    let b = AttestorSet::derive_id(&members, 1);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn attestor_set_derive_id_ignores_member_order() {
+    // Member ordering is a canonical-encoding detail; the set id
+    // must be order-independent so SDKs don't have to pre-sort.
+    let a = AttestorSet::derive_id(&[sample_pubkey(1), sample_pubkey(2)], 1);
+    let b = AttestorSet::derive_id(&[sample_pubkey(2), sample_pubkey(1)], 1);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn attestor_set_derive_id_depends_on_threshold() {
+    let members = vec![sample_pubkey(1), sample_pubkey(2)];
+    let t1 = AttestorSet::derive_id(&members, 1);
+    let t2 = AttestorSet::derive_id(&members, 2);
+    assert_ne!(t1, t2);
+}
+
+#[test]
+fn attestor_set_derive_id_depends_on_members() {
+    let a = AttestorSet::derive_id(&[sample_pubkey(1)], 1);
+    let b = AttestorSet::derive_id(&[sample_pubkey(2)], 1);
+    assert_ne!(a, b);
+}
+
+// ----- AttestationId compound ------------------------------------------------
+
+#[test]
+fn attestation_id_from_pair_concats_correctly() {
+    let sid = sample_schema_id(0xAA);
+    let ph = sample_payload_hash(0xBB);
+    let id = AttestationId::from_pair(&sid, &ph);
+    assert_eq!(id.schema_id, sid);
+    assert_eq!(id.payload_hash, ph);
+}
+
+#[test]
+fn attestation_id_display_round_trip() {
+    use std::str::FromStr;
+    let sid = sample_schema_id(0xCC);
+    let ph = sample_payload_hash(0xDD);
+    let original = AttestationId::from_pair(&sid, &ph);
+    let displayed = original.to_string();
+    let decoded = AttestationId::from_str(&displayed).expect("round-trip parses");
+    assert_eq!(original, decoded);
+}
+
+// ----- SignedAttestationPayload::digest --------------------------------------
+
+#[test]
+fn signed_payload_digest_is_deterministic() {
+    let payload = sample_signed_payload();
+    assert_eq!(payload.digest(), payload.digest());
+}
+
+#[test]
+fn signed_payload_digest_changes_with_timestamp() {
+    let base = sample_signed_payload();
+    let mut mutated = base.clone();
+    mutated.timestamp += 1;
+    assert_ne!(base.digest(), mutated.digest());
+}
+
+#[test]
+fn signed_payload_digest_changes_with_schema_id() {
+    let base = sample_signed_payload();
+    let mut mutated = base.clone();
+    mutated.schema_id = sample_schema_id(0xEE);
+    assert_ne!(base.digest(), mutated.digest());
+}
+
+#[test]
+fn signed_payload_digest_changes_with_payload_hash() {
+    let base = sample_signed_payload();
+    let mut mutated = base.clone();
+    mutated.payload_hash = sample_payload_hash(0xFF);
+    assert_ne!(base.digest(), mutated.digest());
+}
+
+#[test]
+fn signed_payload_digest_changes_with_submitter() {
+    let base = sample_signed_payload();
+    let mut mutated = base.clone();
+    mutated.submitter = sample_addr(0x77);
+    assert_ne!(base.digest(), mutated.digest());
+}
+
+// ----- Protocol constants ----------------------------------------------------
+
+#[test]
+fn max_builder_bps_is_half() {
+    // Documenting the invariant explicitly so a future refactor
+    // doesn't silently raise the cap without thought.
+    assert_eq!(attestation::MAX_BUILDER_BPS, 5000);
+}
+
+// Compile-time assertion: ed25519 (64 bytes) and BLS (48 bytes)
+// signatures both fit inside `MAX_ATTESTOR_SIGNATURE_BYTES` (96).
+// `const _ = assert!(...)` evaluates at compile time, so a future
+// reduction of the cap below ed25519's 64 fails the build.
+const _: () = assert!(MAX_ATTESTOR_SIGNATURE_BYTES >= 64);
+const _: () = assert!(MAX_ATTESTOR_SIGNATURE_BYTES >= 48);


### PR DESCRIPTION
## Summary

Restores attestation test coverage that was lost during the SDK upgrade (PR #60). Refs #59.

PR #60 ended with 8 tests on the new SDK (2 smoke + 6 integration) where the v0.3 era had ~53. This PR adds 42 more, ported behaviour-by-behaviour from `/tmp/attestation_tests_v0_3.rs` (the carved-out reference) and adapted to the new types: `Schema<S>`, `Attestation<S>`, `SafeString`/`SafeVec` payloads, `Amount: u128`, typed Bech32 newtypes, `TestRunner`/`TransactionTestCase`.

## Test count

| File | Tests |
|---|---|
| `tests/smoke.rs` | 2 |
| `tests/unit.rs` (new) | 29 |
| `tests/integration.rs` | 19 (was 6) |
| **Total** | **50** |

## What's covered

**`tests/unit.rs` — pure-data tests (no TestRunner needed):**
- Borsh round-trips for every persisted type: `Schema`, `Attestation`, `AttestorSet`, `AttestorSignature`, `SignedAttestationPayload`, `AttestationId`, all three `CallMessage` variants
- Serde JSON round-trips: `Schema`, `Attestation`, `AttestorSet`, `AttestationConfig`
- `Schema::derive_id` invariants (deterministic, separates by owner / version / name)
- `AttestorSet::derive_id` invariants (deterministic, member-order-independent, depends on threshold + members)
- `AttestationId::from_pair` plus `Display`/`FromStr` round-trip (validates the `<schema_id>:<payload_hash>` encoding)
- `SignedAttestationPayload::digest` determinism + sensitivity to every field (timestamp, schema_id, payload_hash, submitter)
- Compile-time assertions: `MAX_BUILDER_BPS == 5000`, `MAX_ATTESTOR_SIGNATURE_BYTES` covers ed25519 + BLS

**`tests/integration.rs` — end-to-end via TestRunner:**

Already-shipped (6, from PR #60):
- Register-attestor-set happy path (asserts state + counter + bank balance)
- Register-attestor-set rejects threshold > members
- Register-attestor-set rejects zero threshold
- Register-schema requires existing attestor set
- Register-schema rejects over-cap fee routing
- Submit-attestation routes treasury share via bank

New in this PR (13):
- `register_schema_rejects_orphan_routing_bps_without_addr`
- `register_schema_rejects_orphan_routing_addr_without_bps`
- `submit_attestation_requires_existing_schema`
- `full_register_register_submit_flow` (3-tx flow, asserts state + write-once invariant on duplicate submit)
- `submit_below_threshold_rejects` (1 sig, threshold 2)
- `submit_with_unknown_pubkey_rejects` (sig from non-member)
- `submit_with_invalid_signature_rejects` (corrupted sig bytes)
- `submit_with_duplicate_pubkey_rejects` (same pubkey twice in sig vector)
- `submit_with_bad_sig_length_rejects` (63 bytes, ed25519 needs 64)
- `submit_digest_is_bound_to_submitter` (locks in the digest-binding invariant)
- `genesis_seeds_initial_attestor_set` (initial_attestor_sets at genesis)
- `submit_attestation_routes_builder_share_via_bank` (25% routing → 250 builder + 750 treasury, asserts both counters)
- `submit_attestation_fails_with_insufficient_balance` (sets fee to 10^30 nanos; bank's transfer_from returns Err and tx reverts cleanly)

## Tests intentionally not ported

A handful of v0.3 tests don't carry over because the SDK migration changed the entry point:

- **Genesis-rejection tests** (`genesis_rejects_zero_threshold_in_initial_set`, etc.) — `TestRunner::new_with_genesis` panics on bad config rather than returning an error, so the failure-mode assertion shape doesn't transfer cleanly. The same validation logic runs at runtime via `RegisterAttestorSet` / `RegisterSchema` and IS covered by the corresponding handler reject tests.
- **`config_round_trips_through_json`** is preserved (renamed to `attestation_config_json_round_trip` in `tests/unit.rs`) but with `lgt_token_id: TokenId` instead of the old `lgt_token_address: Address`.

## Behaviour changes I noticed during the port

- `AttestationKey = (SchemaId, Hash32)` → `AttestationId { schema_id, payload_hash }` (newtype struct). Same effective key; type system sharper.
- `payload_hash: Hash32` (raw bytes) → `payload_hash: PayloadHash` (typed bech32 newtype, `lph1...`). Same on-wire, prettier user-facing.
- `Vec<u8>` for sig bytes → `SafeVec<u8, 96>`. Bumped cap above ed25519's 64; covers BLS too.

## Local verification

- [x] `cargo test -p attestation`: 50/50 (29 unit + 19 integration + 2 smoke)
- [x] `cargo fmt --all -- --check`: clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items`: clean
- [x] `cargo check --workspace --all-targets`: clean
