### PR TITLE
Migrate client-rs to new SDK and re-include in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,6 +3066,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ligate-client"
+version = "0.0.1"
+dependencies = [
+ "attestation",
+ "borsh",
+ "ed25519-dalek",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sov-bank",
+ "sov-modules-api",
+ "sov-test-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,14 @@
 [workspace]
 resolver = "2"
-# `crates/stf`, `crates/rollup`, and `crates/client-rs` are
-# temporarily out of the workspace during the SDK upgrade (#59).
-# - `stf` and `rollup` need full rewrites against the new APIs and
-#   re-enter as part of this PR (Day 7).
-# - `client-rs` references attestation types that just changed shape
-#   (`Address`, `AttestationKey`); migrate it once the lib settles.
-#   Should be ~30 minutes once we're at the day-4-or-later checkpoint.
+# `crates/stf` and `crates/rollup` are out of the workspace during
+# Phase A.2 of #13 (the rollup binary on the new SDK). The new SDK
+# is much more opinionated about runtime composition than v0.3, so
+# both crates need ground-up rewrites that ship as their own PR.
 members = [
     "crates/modules/attestation",
+    "crates/client-rs",
 ]
-exclude = ["crates/stf", "crates/rollup", "crates/client-rs"]
+exclude = ["crates/stf", "crates/rollup"]
 
 [workspace.package]
 version = "0.0.1"

--- a/crates/client-rs/Cargo.toml
+++ b/crates/client-rs/Cargo.toml
@@ -11,7 +11,10 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-attestation = { path = "../modules/attestation" }
+attestation     = { path = "../modules/attestation" }
+sov-modules-api = { workspace = true }
+sov-bank        = { workspace = true }
+
 borsh.workspace = true
 ed25519-dalek.workspace = true
 serde.workspace = true
@@ -20,3 +23,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+sov-test-utils  = { workspace = true }

--- a/crates/client-rs/src/lib.rs
+++ b/crates/client-rs/src/lib.rs
@@ -1,171 +1,267 @@
 //! Rust client SDK for the Ligate attestation protocol.
 //!
 //! This crate provides typed builders for the three state-changing
-//! [`CallMessage`] variants accepted by the on-chain attestation module, plus
-//! helpers for computing the canonical attestation digest and producing
-//! ed25519 signatures over it.
+//! [`CallMessage`] variants accepted by the on-chain attestation
+//! module, plus helpers for computing the canonical attestation
+//! digest and producing ed25519 signatures over it.
 //!
-//! Actual JSON-RPC transport (submitting signed transactions to a Ligate
-//! node) lands in a separate issue (#21); the RPC endpoints do not exist yet.
-//! Today this crate is purely about typed message construction and signing,
-//! the pieces a test client, relayer, or attestor would need before any
-//! network code.
+//! Actual JSON-RPC transport (submitting signed transactions to a
+//! Ligate node) lands in a separate issue (#21); the RPC endpoints
+//! are still being wired up. Today this crate is purely about typed
+//! message construction and signing: the pieces a test client,
+//! relayer, or attestor would need before any network code.
+//!
+//! # Generic over `Spec`
+//!
+//! The Sovereign SDK parameterises chain-level types (addresses,
+//! storage backends, signature schemes) over a `Spec` trait. Every
+//! builder here is generic over `<S: Spec>` and produces a typed
+//! `CallMessage<S>` ready to embed in a transaction. Concrete
+//! callers (test harness, relayer, devnet CLI) pin `S` to a specific
+//! `Spec` implementation, typically `DefaultSpec` for native chain
+//! interaction or `sov_test_utils::TestSpec` for tests.
+//!
+//! # Bounded payload types
+//!
+//! `CallMessage` payloads use `SafeString` and `SafeVec<T, MAX>`
+//! rather than unbounded `String` / `Vec<T>` because the SDK's
+//! `UniversalWallet` derive requires fixed-size encodings on the
+//! wire. The builders here take ergonomic `Vec` / `String` inputs
+//! and return a [`ClientError`] if the input exceeds the wire-format
+//! cap. Caps are constants on the `attestation` crate; bumping them
+//! is a hard fork.
 //!
 //! # Re-exports
 //!
-//! The protocol types from the `attestation` crate are re-exported so
-//! downstream consumers of the SDK do not need a direct path dependency on
-//! the module crate.
+//! Protocol types from the `attestation` crate are re-exported so
+//! downstream consumers don't need a direct path dependency on the
+//! module crate.
 //!
 //! # Example
 //!
 //! ```no_run
 //! use ed25519_dalek::SigningKey;
 //! use ligate_client::{
-//!     build_signed_submit, register_attestor_set, register_schema, AttestorSet, Schema,
+//!     build_signed_submit, register_attestor_set, register_schema, AttestorSet, PayloadHash,
+//!     PubKey, Schema,
 //! };
+//! use sov_modules_api::{Address, Spec};
+//!
+//! type S = sov_test_utils::TestSpec;
 //!
 //! // Pretend these exist somewhere in your wallet.
-//! let signers: Vec<SigningKey> =
-//!     (1u8..=3).map(|i| SigningKey::from_bytes(&[i; 32])).collect();
-//! let members: Vec<[u8; 32]> =
-//!     signers.iter().map(|sk| sk.verifying_key().to_bytes()).collect();
+//! let signers: Vec<SigningKey> = (1u8..=3).map(|i| SigningKey::from_bytes(&[i; 32])).collect();
+//! let members: Vec<PubKey> =
+//!     signers.iter().map(|sk| PubKey::from(sk.verifying_key().to_bytes())).collect();
 //!
 //! // 1. Build a RegisterAttestorSet message.
-//! let _msg = register_attestor_set(members.clone(), 2);
+//! let _msg = register_attestor_set::<S>(members.clone(), 2).expect("members under cap");
 //!
 //! // 2. Build a RegisterSchema message (fee routing omitted).
 //! let attestor_set_id = AttestorSet::derive_id(&members, 2);
-//! let _msg = register_schema("themisra.proof-of-prompt".into(), 1, attestor_set_id, 0, None);
+//! let _msg = register_schema::<S>(
+//!     "themisra.proof-of-prompt".into(),
+//!     1,
+//!     attestor_set_id,
+//!     0,
+//!     None,
+//! )
+//! .expect("name under cap");
 //!
 //! // 3. Build a SubmitAttestation message signed by a 2-of-3 quorum.
-//! let submitter = [1u8; 32];
-//! let schema_id = Schema::derive_id(&submitter, "themisra.proof-of-prompt", 1);
-//! let payload_hash = [0x42u8; 32];
+//! let submitter: <S as Spec>::Address = Address::from([1u8; 28]);
+//! let schema_id = Schema::<S>::derive_id(&submitter, "themisra.proof-of-prompt", 1);
+//! let payload_hash = PayloadHash::from([0x42u8; 32]);
 //! let keys: Vec<&SigningKey> = signers.iter().take(2).collect();
-//! let _msg = build_signed_submit(&keys, schema_id, payload_hash, submitter, 0);
+//! let _msg = build_signed_submit::<S>(&keys, schema_id, payload_hash, submitter, 0)
+//!     .expect("signatures under cap");
 //! ```
 
 #![deny(missing_docs)]
 
-use borsh::BorshSerialize;
 use ed25519_dalek::{Signer, SigningKey};
+use sov_modules_api::{SafeString, SafeVec, Spec};
 use thiserror::Error as ThisError;
 
 pub use attestation::{
-    Address, Attestation, AttestationKey, AttestorSet, AttestorSetId, AttestorSignature,
-    CallMessage, Hash32, PubKey, Schema, SchemaId, SignedAttestationPayload,
+    Attestation, AttestationConfig, AttestationId, AttestorSet, AttestorSetId, AttestorSignature,
+    CallMessage, Hash32, PayloadHash, PubKey, Schema, SchemaId, SignedAttestationPayload,
+    MAX_ATTESTATION_SIGNATURES, MAX_ATTESTOR_SET_MEMBERS, MAX_ATTESTOR_SIGNATURE_BYTES,
+    MAX_BUILDER_BPS,
 };
 
 // ----- Errors -----------------------------------------------------------------
 
 /// Errors surfaced by the Ligate client SDK.
-///
-/// Reserved for future transport errors (JSON-RPC, signing adapters, etc).
-/// Empty today so the crate surface already has a stable typed error that
-/// downstream callers can depend on.
 #[derive(Debug, ThisError)]
-pub enum ClientError {}
+pub enum ClientError {
+    /// Caller supplied a `Vec<PubKey>` longer than
+    /// [`MAX_ATTESTOR_SET_MEMBERS`].
+    #[error("attestor set has {actual} members, max {max}")]
+    AttestorSetMembersOverCap {
+        /// Length supplied.
+        actual: usize,
+        /// Hard cap.
+        max: usize,
+    },
+
+    /// Caller supplied a `Vec<AttestorSignature>` longer than
+    /// [`MAX_ATTESTATION_SIGNATURES`].
+    #[error("attestation has {actual} signatures, max {max}")]
+    AttestationSignaturesOverCap {
+        /// Length supplied.
+        actual: usize,
+        /// Hard cap.
+        max: usize,
+    },
+
+    /// Caller supplied a signature byte string longer than
+    /// [`MAX_ATTESTOR_SIGNATURE_BYTES`].
+    #[error("signature has {actual} bytes, max {max}")]
+    SignatureBytesOverCap {
+        /// Length supplied.
+        actual: usize,
+        /// Hard cap.
+        max: usize,
+    },
+
+    /// Caller supplied a schema name longer than the SDK's
+    /// `SafeString` default cap.
+    #[error("schema name exceeds the SafeString default cap: {0}")]
+    SchemaNameOverCap(String),
+}
 
 // ----- Builders ---------------------------------------------------------------
 
 /// Build a [`CallMessage::RegisterAttestorSet`].
 ///
-/// The state transition re-derives [`AttestorSetId`] from `members` and
-/// `threshold` on submission; callers do not need to precompute it. Members
-/// are stored in sorted order on-chain regardless of submission order.
-pub fn register_attestor_set(members: Vec<PubKey>, threshold: u8) -> CallMessage {
-    CallMessage::RegisterAttestorSet { members, threshold }
+/// The state transition re-derives [`AttestorSetId`] from `members`
+/// and `threshold` on submission; callers don't need to precompute
+/// it. Members are stored in sorted order on-chain regardless of
+/// submission order.
+///
+/// Returns [`ClientError::AttestorSetMembersOverCap`] if `members`
+/// exceeds [`MAX_ATTESTOR_SET_MEMBERS`].
+pub fn register_attestor_set<S: Spec>(
+    members: Vec<PubKey>,
+    threshold: u8,
+) -> Result<CallMessage<S>, ClientError> {
+    let actual = members.len();
+    let members = SafeVec::<PubKey, MAX_ATTESTOR_SET_MEMBERS>::try_from(members).map_err(|_| {
+        ClientError::AttestorSetMembersOverCap { actual, max: MAX_ATTESTOR_SET_MEMBERS }
+    })?;
+    Ok(CallMessage::RegisterAttestorSet { members, threshold })
 }
 
 /// Build a [`CallMessage::RegisterSchema`].
 ///
 /// `fee_routing_addr` must be `Some` iff `fee_routing_bps > 0`, and
-/// `fee_routing_bps` must be `<= attestation::MAX_BUILDER_BPS` (5000 in v0).
-/// The state transition enforces these invariants; this builder is a thin
-/// typed wrapper around the enum variant.
-pub fn register_schema(
+/// `fee_routing_bps` must be `<= attestation::MAX_BUILDER_BPS` (5000
+/// in v0). The state transition enforces these invariants; this
+/// builder is a thin typed wrapper around the enum variant. Returns
+/// [`ClientError::SchemaNameOverCap`] if `name` exceeds the
+/// `SafeString` default cap.
+pub fn register_schema<S: Spec>(
     name: String,
     version: u32,
     attestor_set: AttestorSetId,
     fee_routing_bps: u16,
-    fee_routing_addr: Option<Address>,
-) -> CallMessage {
-    CallMessage::RegisterSchema { name, version, attestor_set, fee_routing_bps, fee_routing_addr }
+    fee_routing_addr: Option<S::Address>,
+) -> Result<CallMessage<S>, ClientError> {
+    let safe_name =
+        SafeString::try_from(name.clone()).map_err(|_| ClientError::SchemaNameOverCap(name))?;
+    Ok(CallMessage::RegisterSchema {
+        name: safe_name,
+        version,
+        attestor_set,
+        fee_routing_bps,
+        fee_routing_addr,
+    })
 }
 
 /// Build a [`CallMessage::SubmitAttestation`].
 ///
-/// Signatures must be over the canonical [`SignedAttestationPayload`] digest
-/// for this `(schema_id, payload_hash, submitter, timestamp)` tuple. Use
-/// [`attestation_digest`] to compute the exact digest and [`sign_attestation`]
-/// to sign it, or [`build_signed_submit`] for the combined flow.
-pub fn submit_attestation(
+/// Signatures must be over the canonical [`SignedAttestationPayload`]
+/// digest for this `(schema_id, payload_hash, submitter, timestamp)`
+/// tuple. Use [`attestation_digest`] to compute the exact digest and
+/// [`sign_attestation`] to sign it, or [`build_signed_submit`] for
+/// the combined flow. Returns
+/// [`ClientError::AttestationSignaturesOverCap`] if `signatures`
+/// exceeds [`MAX_ATTESTATION_SIGNATURES`].
+pub fn submit_attestation<S: Spec>(
     schema_id: SchemaId,
-    payload_hash: Hash32,
+    payload_hash: PayloadHash,
     signatures: Vec<AttestorSignature>,
-) -> CallMessage {
-    CallMessage::SubmitAttestation { schema_id, payload_hash, signatures }
+) -> Result<CallMessage<S>, ClientError> {
+    let actual = signatures.len();
+    let signatures = SafeVec::<AttestorSignature, MAX_ATTESTATION_SIGNATURES>::try_from(signatures)
+        .map_err(|_| ClientError::AttestationSignaturesOverCap {
+            actual,
+            max: MAX_ATTESTATION_SIGNATURES,
+        })?;
+    Ok(CallMessage::SubmitAttestation { schema_id, payload_hash, signatures })
 }
 
 // ----- Digest + signing -------------------------------------------------------
 
 /// Compute the canonical attestation digest for the given tuple.
 ///
-/// Constructs a [`SignedAttestationPayload`] with those fields and returns
-/// its `.digest()`, which is SHA-256 over the canonical Borsh encoding. This
-/// is the exact digest every attestor must sign over; the on-chain module
-/// recomputes it at submit time from the schema id, payload hash, message
-/// sender, and block timestamp, then verifies each signature against it.
-pub fn attestation_digest(
+/// Constructs a [`SignedAttestationPayload`] with those fields and
+/// returns its `.digest()`, which is SHA-256 over the canonical
+/// Borsh encoding. This is the exact digest every attestor must sign
+/// over; the on-chain module recomputes it at submit time from the
+/// schema id, payload hash, message sender, and block timestamp,
+/// then verifies each signature against it.
+pub fn attestation_digest<S: Spec>(
     schema_id: SchemaId,
-    payload_hash: Hash32,
-    submitter: Address,
+    payload_hash: PayloadHash,
+    submitter: S::Address,
     timestamp: u64,
 ) -> Hash32 {
-    SignedAttestationPayload { schema_id, payload_hash, submitter, timestamp }.digest()
+    SignedAttestationPayload::<S> { schema_id, payload_hash, submitter, timestamp }.digest()
 }
 
 /// Sign an attestation digest with an ed25519 key.
 ///
-/// Returns an [`AttestorSignature`] whose `pubkey` is the signing key's
-/// verifying key bytes and whose `sig` is the 64-byte ed25519 signature. The
-/// produced signature verifies under `ed25519_dalek::Verifier::verify`
-/// against `digest` and the same verifying key.
+/// Returns an [`AttestorSignature`] whose `pubkey` is the signing
+/// key's verifying-key bytes wrapped as a `PubKey` and whose `sig`
+/// is the 64-byte ed25519 signature wrapped in a
+/// `SafeVec<u8, MAX_ATTESTOR_SIGNATURE_BYTES>`. Infallible: ed25519
+/// signatures are 64 bytes, which always fits in 96.
 pub fn sign_attestation(signing_key: &SigningKey, digest: &Hash32) -> AttestorSignature {
     let signature = signing_key.sign(digest);
+    let sig_bytes: Vec<u8> = signature.to_bytes().to_vec();
     AttestorSignature {
-        pubkey: signing_key.verifying_key().to_bytes(),
-        sig: signature.to_bytes().to_vec(),
+        pubkey: PubKey::from(signing_key.verifying_key().to_bytes()),
+        // 64 bytes always fits in 96; unwrap is safe.
+        sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(sig_bytes)
+            .expect("ed25519 signature is 64 bytes; fits in 96"),
     }
 }
 
-/// Convenience: compute the digest, sign with every key, and return a
-/// [`CallMessage::SubmitAttestation`] ready to submit.
+/// Convenience: compute the digest, sign with every key, and return
+/// a [`CallMessage::SubmitAttestation`] ready to submit.
 ///
-/// This is the common relayer or test-client flow: take a quorum of signing
-/// keys, the submission tuple, and produce the final call message in one
-/// step. Each key must correspond to a member of the schema's attestor set,
-/// and the total number of signatures must meet the set's threshold; both
-/// are enforced server-side by the state transition.
-pub fn build_signed_submit(
+/// This is the common relayer or test-client flow: take a quorum of
+/// signing keys, the submission tuple, and produce the final call
+/// message in one step. Each key must correspond to a member of the
+/// schema's attestor set, and the total number of signatures must
+/// meet the set's threshold; both are enforced server-side by the
+/// state transition. Returns
+/// [`ClientError::AttestationSignaturesOverCap`] if more than
+/// [`MAX_ATTESTATION_SIGNATURES`] keys are supplied.
+pub fn build_signed_submit<S: Spec>(
     signing_keys: &[&SigningKey],
     schema_id: SchemaId,
-    payload_hash: Hash32,
-    submitter: Address,
+    payload_hash: PayloadHash,
+    submitter: S::Address,
     timestamp: u64,
-) -> CallMessage {
-    let digest = attestation_digest(schema_id, payload_hash, submitter, timestamp);
+) -> Result<CallMessage<S>, ClientError> {
+    let digest = attestation_digest::<S>(schema_id, payload_hash, submitter, timestamp);
     let signatures =
         signing_keys.iter().map(|sk| sign_attestation(sk, &digest)).collect::<Vec<_>>();
-    submit_attestation(schema_id, payload_hash, signatures)
+    submit_attestation::<S>(schema_id, payload_hash, signatures)
 }
-
-// Suppress "unused" lint on BorshSerialize; it's a transitive requirement
-// of the re-exported types and pulled in so doctests compile cleanly if a
-// downstream user encodes a CallMessage directly.
-#[allow(dead_code)]
-fn _assert_borsh_available<T: BorshSerialize>() {}
 
 // ============================================================================
 // Tests
@@ -174,19 +270,30 @@ fn _assert_borsh_available<T: BorshSerialize>() {}
 #[cfg(test)]
 mod tests {
     use ed25519_dalek::{Verifier, VerifyingKey};
+    use sov_modules_api::Address;
 
     use super::*;
+
+    type S = sov_test_utils::TestSpec;
 
     fn sample_signer(seed: u8) -> SigningKey {
         SigningKey::from_bytes(&[seed; 32])
     }
 
-    fn sample_address(n: u8) -> Address {
-        [n; 32]
+    fn sample_address(n: u8) -> <S as Spec>::Address {
+        Address::from([n; 28])
     }
 
     fn sample_pubkey(n: u8) -> PubKey {
-        [n; 32]
+        PubKey::from([n; 32])
+    }
+
+    fn sample_schema_id(n: u8) -> SchemaId {
+        SchemaId::from([n; 32])
+    }
+
+    fn sample_payload_hash(n: u8) -> PayloadHash {
+        PayloadHash::from([n; 32])
     }
 
     // ------ Builders ------------------------------------------------------
@@ -194,10 +301,12 @@ mod tests {
     #[test]
     fn register_attestor_set_builds_correct_variant() {
         let members = vec![sample_pubkey(1), sample_pubkey(2), sample_pubkey(3)];
-        let msg = register_attestor_set(members.clone(), 2);
+        let msg: CallMessage<S> =
+            register_attestor_set::<S>(members.clone(), 2).expect("members under cap");
         match msg {
             CallMessage::RegisterAttestorSet { members: got_members, threshold } => {
-                assert_eq!(got_members, members);
+                let got: Vec<PubKey> = got_members.into_iter().collect();
+                assert_eq!(got, members);
                 assert_eq!(threshold, 2);
             }
             other => panic!("expected RegisterAttestorSet, got {other:?}"),
@@ -205,16 +314,32 @@ mod tests {
     }
 
     #[test]
+    fn register_attestor_set_rejects_over_cap() {
+        // MAX_ATTESTOR_SET_MEMBERS + 1 members.
+        let too_many: Vec<PubKey> =
+            (0..=MAX_ATTESTOR_SET_MEMBERS as u8).map(sample_pubkey).collect();
+        let result = register_attestor_set::<S>(too_many, 2);
+        match result {
+            Err(ClientError::AttestorSetMembersOverCap { actual, max }) => {
+                assert_eq!(actual, MAX_ATTESTOR_SET_MEMBERS + 1);
+                assert_eq!(max, MAX_ATTESTOR_SET_MEMBERS);
+            }
+            other => panic!("expected AttestorSetMembersOverCap, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn register_schema_builds_correct_variant() {
-        let attestor_set_id = [7u8; 32];
+        let attestor_set_id = AttestorSetId::from([7u8; 32]);
         let fee_addr = sample_address(9);
-        let msg = register_schema(
+        let msg: CallMessage<S> = register_schema::<S>(
             "themisra.proof-of-prompt".to_string(),
             3,
             attestor_set_id,
             2500,
             Some(fee_addr),
-        );
+        )
+        .expect("name under cap");
         match msg {
             CallMessage::RegisterSchema {
                 name,
@@ -223,7 +348,7 @@ mod tests {
                 fee_routing_bps,
                 fee_routing_addr,
             } => {
-                assert_eq!(name, "themisra.proof-of-prompt");
+                assert_eq!(<SafeString as AsRef<str>>::as_ref(&name), "themisra.proof-of-prompt");
                 assert_eq!(version, 3);
                 assert_eq!(attestor_set, attestor_set_id);
                 assert_eq!(fee_routing_bps, 2500);
@@ -235,10 +360,15 @@ mod tests {
 
     #[test]
     fn submit_attestation_builds_correct_variant() {
-        let schema_id = [1u8; 32];
-        let payload_hash = [2u8; 32];
-        let signatures = vec![AttestorSignature { pubkey: sample_pubkey(1), sig: vec![0xab; 64] }];
-        let msg = submit_attestation(schema_id, payload_hash, signatures.clone());
+        let schema_id = sample_schema_id(1);
+        let payload_hash = sample_payload_hash(2);
+        let sig_bytes = vec![0xab; 64];
+        let signatures = vec![AttestorSignature {
+            pubkey: sample_pubkey(1),
+            sig: SafeVec::try_from(sig_bytes).unwrap(),
+        }];
+        let msg: CallMessage<S> =
+            submit_attestation::<S>(schema_id, payload_hash, signatures).expect("under cap");
         match msg {
             CallMessage::SubmitAttestation {
                 schema_id: got_schema_id,
@@ -247,7 +377,7 @@ mod tests {
             } => {
                 assert_eq!(got_schema_id, schema_id);
                 assert_eq!(got_payload_hash, payload_hash);
-                assert_eq!(got_signatures, signatures);
+                assert_eq!(got_signatures.len(), 1);
             }
             other => panic!("expected SubmitAttestation, got {other:?}"),
         }
@@ -257,26 +387,64 @@ mod tests {
 
     #[test]
     fn attestation_digest_matches_struct_digest() {
-        let schema_id = [1u8; 32];
-        let payload_hash = [2u8; 32];
+        let schema_id = sample_schema_id(1);
+        let payload_hash = sample_payload_hash(2);
         let submitter = sample_address(3);
         let timestamp = 1_700_000_000u64;
 
-        let via_helper = attestation_digest(schema_id, payload_hash, submitter, timestamp);
+        let via_helper = attestation_digest::<S>(schema_id, payload_hash, submitter, timestamp);
         let via_struct =
-            SignedAttestationPayload { schema_id, payload_hash, submitter, timestamp }.digest();
+            SignedAttestationPayload::<S> { schema_id, payload_hash, submitter, timestamp }
+                .digest();
 
         assert_eq!(via_helper, via_struct);
     }
 
     #[test]
     fn attestation_digest_is_field_sensitive() {
-        let base = attestation_digest([1u8; 32], [2u8; 32], sample_address(3), 1_000);
+        let base = attestation_digest::<S>(
+            sample_schema_id(1),
+            sample_payload_hash(2),
+            sample_address(3),
+            1_000,
+        );
         // Any single-field change must yield a different digest.
-        assert_ne!(base, attestation_digest([9u8; 32], [2u8; 32], sample_address(3), 1_000));
-        assert_ne!(base, attestation_digest([1u8; 32], [9u8; 32], sample_address(3), 1_000));
-        assert_ne!(base, attestation_digest([1u8; 32], [2u8; 32], sample_address(9), 1_000));
-        assert_ne!(base, attestation_digest([1u8; 32], [2u8; 32], sample_address(3), 1_001));
+        assert_ne!(
+            base,
+            attestation_digest::<S>(
+                sample_schema_id(9),
+                sample_payload_hash(2),
+                sample_address(3),
+                1_000,
+            )
+        );
+        assert_ne!(
+            base,
+            attestation_digest::<S>(
+                sample_schema_id(1),
+                sample_payload_hash(9),
+                sample_address(3),
+                1_000,
+            )
+        );
+        assert_ne!(
+            base,
+            attestation_digest::<S>(
+                sample_schema_id(1),
+                sample_payload_hash(2),
+                sample_address(9),
+                1_000,
+            )
+        );
+        assert_ne!(
+            base,
+            attestation_digest::<S>(
+                sample_schema_id(1),
+                sample_payload_hash(2),
+                sample_address(3),
+                1_001,
+            )
+        );
     }
 
     // ------ sign_attestation ----------------------------------------------
@@ -284,36 +452,45 @@ mod tests {
     #[test]
     fn sign_attestation_produces_verifiable_signature() {
         let signer = sample_signer(7);
-        let digest = attestation_digest([1u8; 32], [2u8; 32], sample_address(3), 42);
+        let digest = attestation_digest::<S>(
+            sample_schema_id(1),
+            sample_payload_hash(2),
+            sample_address(3),
+            42,
+        );
 
         let sig = sign_attestation(&signer, &digest);
 
-        // pubkey matches the key's verifying key bytes
-        assert_eq!(sig.pubkey, signer.verifying_key().to_bytes());
-        // signature is the ed25519 expected length (64 bytes)
+        // pubkey matches the key's verifying-key bytes.
+        assert_eq!(sig.pubkey, PubKey::from(signer.verifying_key().to_bytes()));
+        // signature is the ed25519 expected length (64 bytes).
         assert_eq!(sig.sig.len(), 64);
 
         // And it verifies.
-        let vk = VerifyingKey::from_bytes(&sig.pubkey).expect("pubkey should be valid ed25519");
-        let sig_bytes: [u8; 64] =
-            sig.sig.as_slice().try_into().expect("signature should be 64 bytes");
+        let vk = VerifyingKey::from_bytes(sig.pubkey.as_bytes()).expect("pubkey valid ed25519");
+        let sig_bytes: [u8; 64] = (&*sig.sig).try_into().expect("signature 64 bytes");
         let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
-        vk.verify(&digest, &signature).expect("signature should verify");
+        vk.verify(&digest, &signature).expect("signature verifies");
     }
 
     #[test]
     fn sign_attestation_rejects_wrong_digest_on_verify() {
-        // Sanity: the signature binds to the digest, flipping a byte in the
-        // digest after signing breaks verification.
+        // Sanity: the signature binds to the digest. Flipping a byte
+        // in the digest after signing breaks verification.
         let signer = sample_signer(7);
-        let digest = attestation_digest([1u8; 32], [2u8; 32], sample_address(3), 42);
+        let digest = attestation_digest::<S>(
+            sample_schema_id(1),
+            sample_payload_hash(2),
+            sample_address(3),
+            42,
+        );
         let sig = sign_attestation(&signer, &digest);
 
         let mut tampered = digest;
         tampered[0] ^= 0x01;
 
-        let vk = VerifyingKey::from_bytes(&sig.pubkey).unwrap();
-        let sig_bytes: [u8; 64] = sig.sig.as_slice().try_into().unwrap();
+        let vk = VerifyingKey::from_bytes(sig.pubkey.as_bytes()).unwrap();
+        let sig_bytes: [u8; 64] = (&*sig.sig).try_into().unwrap();
         let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
         assert!(vk.verify(&tampered, &signature).is_err());
     }
@@ -326,12 +503,14 @@ mod tests {
         let signer_b = sample_signer(2);
         let keys: Vec<&SigningKey> = vec![&signer_a, &signer_b];
 
-        let schema_id = [0xABu8; 32];
-        let payload_hash = [0xCDu8; 32];
+        let schema_id = sample_schema_id(0xAB);
+        let payload_hash = sample_payload_hash(0xCD);
         let submitter = sample_address(5);
         let timestamp = 1_234_567_890u64;
 
-        let msg = build_signed_submit(&keys, schema_id, payload_hash, submitter, timestamp);
+        let msg: CallMessage<S> =
+            build_signed_submit::<S>(&keys, schema_id, payload_hash, submitter, timestamp)
+                .expect("under cap");
 
         let (got_schema_id, got_payload_hash, signatures) = match msg {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures } => {
@@ -344,28 +523,39 @@ mod tests {
         assert_eq!(signatures.len(), 2);
 
         // Every signature must verify against the canonical digest.
-        let digest = attestation_digest(schema_id, payload_hash, submitter, timestamp);
+        let digest = attestation_digest::<S>(schema_id, payload_hash, submitter, timestamp);
         for sig in &signatures {
-            let vk = VerifyingKey::from_bytes(&sig.pubkey).expect("valid pubkey");
-            let sig_bytes: [u8; 64] = sig.sig.as_slice().try_into().expect("64-byte signature");
+            let vk = VerifyingKey::from_bytes(sig.pubkey.as_bytes()).expect("valid pubkey");
+            let sig_bytes: [u8; 64] = (&*sig.sig).try_into().expect("64-byte signature");
             let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
-            vk.verify(&digest, &signature).expect("signature must verify");
+            vk.verify(&digest, &signature).expect("signature verifies");
         }
 
         // And the two signatures come from the two distinct signing keys.
-        assert_eq!(signatures[0].pubkey, signer_a.verifying_key().to_bytes());
-        assert_eq!(signatures[1].pubkey, signer_b.verifying_key().to_bytes());
+        let sigs: Vec<AttestorSignature> = signatures.into_iter().collect();
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].pubkey, PubKey::from(signer_a.verifying_key().to_bytes()));
+        assert_eq!(sigs[1].pubkey, PubKey::from(signer_b.verifying_key().to_bytes()));
     }
 
     #[test]
     fn build_signed_submit_with_zero_keys_is_empty_submission() {
-        // Edge case, the builder itself does not enforce quorum. Zero
-        // keys produces an empty signatures vector; the on-chain state
+        // Edge case: the builder doesn't enforce quorum. Zero keys
+        // produces an empty signatures vector; the on-chain state
         // transition will reject below-threshold submissions.
         let keys: Vec<&SigningKey> = Vec::new();
-        let msg = build_signed_submit(&keys, [1u8; 32], [2u8; 32], sample_address(3), 0);
+        let msg: CallMessage<S> = build_signed_submit::<S>(
+            &keys,
+            sample_schema_id(1),
+            sample_payload_hash(2),
+            sample_address(3),
+            0,
+        )
+        .expect("under cap");
         match msg {
-            CallMessage::SubmitAttestation { signatures, .. } => assert!(signatures.is_empty()),
+            CallMessage::SubmitAttestation { signatures, .. } => {
+                assert_eq!(signatures.len(), 0);
+            }
             other => panic!("expected SubmitAttestation, got {other:?}"),
         }
     }
@@ -376,8 +566,8 @@ mod tests {
     fn re_exported_schema_derive_id_matches_upstream() {
         // The re-exports are the same types as in the `attestation` crate.
         let owner = sample_address(1);
-        let id = Schema::derive_id(&owner, "foo", 1);
-        let upstream = attestation::Schema::derive_id(&owner, "foo", 1);
+        let id = Schema::<S>::derive_id(&owner, "foo", 1);
+        let upstream = attestation::Schema::<S>::derive_id(&owner, "foo", 1);
         assert_eq!(id, upstream);
     }
 


### PR DESCRIPTION
## Summary

Migrates `crates/client-rs` to the new SDK and re-includes it in the workspace. It was excluded during the SDK upgrade (PR #60) because it referenced the old `Address`, `AttestationKey`, and ungeneric `CallMessage` types.

## What lands

### Builders are now generic over `<S: Spec>`
- `register_attestor_set::<S>(members, threshold) -> Result<CallMessage<S>, ClientError>`
- `register_schema::<S>(name, version, attestor_set, fee_routing_bps, fee_routing_addr) -> Result<CallMessage<S>, ClientError>`
- `submit_attestation::<S>(schema_id, payload_hash, signatures) -> Result<CallMessage<S>, ClientError>`
- `attestation_digest::<S>(schema_id, payload_hash, submitter, timestamp) -> Hash32`
- `build_signed_submit::<S>(signing_keys, schema_id, payload_hash, submitter, timestamp) -> Result<CallMessage<S>, ClientError>`

`sign_attestation` stays non-generic (it operates on raw bytes).

### Ergonomic input, bounded wire format
The builders take `Vec<PubKey>`, `String`, `Vec<AttestorSignature>` for ergonomics and convert to `SafeVec<T, MAX>` / `SafeString` internally. They return `ClientError::*OverCap` if input exceeds the SDK's wire-format hard caps (these caps are wire-format hard forks; locked at v0).

### Updated re-exports
- Dropped: `Address`, `AttestationKey` (don't exist in the new attestation API)
- Added: `AttestationConfig`, `AttestationId`, `PayloadHash`, plus all the bounded-payload constants (`MAX_ATTESTOR_SET_MEMBERS`, `MAX_ATTESTATION_SIGNATURES`, `MAX_ATTESTOR_SIGNATURE_BYTES`, `MAX_BUILDER_BPS`)
- Kept: `Schema`, `Attestation`, `AttestorSet`, `AttestorSetId`, `AttestorSignature`, `CallMessage`, `Hash32`, `PubKey`, `SchemaId`, `SignedAttestationPayload`

### Tests rebuilt against `TestSpec`
Same 12 test behaviours preserved from v0.3:
- Builders construct the right CallMessage variant
- Cap-overflow paths return the right `ClientError` (new test: `register_attestor_set_rejects_over_cap`)
- `attestation_digest` matches the struct method
- `attestation_digest` is field-sensitive (4 mutations tested)
- `sign_attestation` produces ed25519-verifiable signatures
- `sign_attestation` rejects tampered digests on verify
- `build_signed_submit` produces valid 2-of-N submissions
- `build_signed_submit` with zero keys returns empty signatures (server-side reject)
- Re-exported `Schema::derive_id` / `AttestorSet::derive_id` match upstream

### Workspace
- `crates/client-rs` re-added to `members`. Now `cargo check --workspace` and `cargo test --workspace` cover it again.
- Workspace exclusion list shrinks to `crates/stf` and `crates/rollup` (both Phase A.2 territory; deferred to a separate PR).

## Local verification

- [x] `cargo test --workspace`: 67 tests passing (54 attestation + 12 client unit + 1 doctest)
- [x] `cargo fmt --all -- --check`: clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items`: clean
- [x] `cargo check --workspace`: clean

## Out of scope

- JSON-RPC transport (submitting signed txs to a running node) — gated on the rollup binary, follows in Phase A.2.
- Wallet-codec / `UniversalWallet` integration on `CallMessage<S>` for CLI signing — also Phase A.2 territory.
