### PR TITLE
Phase A.2.2: rollup binary on new SDK (refs #63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,17 @@ jobs:
       - name: Install libclang (librocksdb-sys build dep)
         run: sudo apt-get update && sudo apt-get install -y libclang-dev clang
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace --all-targets
+      # Lib unit tests + integration tests. We deliberately skip
+      # `--bins` / `--examples` / `--benches` because the
+      # `ligate-node` binary has no `#[test]` items — building it
+      # as a test executable just forces a full debug-profile link
+      # pass that OOMs the free-tier runner (`collect2: ld
+      # terminated with signal 7`). `cargo check` and `cargo
+      # clippy` still cover the binary's typecheck.
+      - run: cargo test --workspace --lib --tests
+      # Doc tests have to run on their own — `cargo test` rejects
+      # `--doc` mixed with target selectors.
+      - run: cargo test --workspace --doc
 
   doc:
     name: cargo doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,6 +3082,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ligate-rollup"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "attestation",
+ "borsh",
+ "clap",
+ "ligate-stf",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sov-address",
+ "sov-bank",
+ "sov-db",
+ "sov-kernels",
+ "sov-mock-da",
+ "sov-mock-zkvm",
+ "sov-modules-api",
+ "sov-modules-rollup-blueprint",
+ "sov-modules-stf-blueprint",
+ "sov-rollup-full-node-interface",
+ "sov-rollup-interface",
+ "sov-sequencer",
+ "sov-state",
+ "sov-stf-runner",
+ "sov-test-utils",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ligate-stf"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,13 @@ rustls      = { version = "0.23", default-features = false, features = ["ring"] 
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+# `ligate-node` pulls in the full SDK + tokio + hyper + rocksdb + ring
+# rlib graph. With full DWARF debug info, the link step OOMs on the
+# free-tier GitHub Actions runner (`collect2: ld terminated with
+# signal 7 [Bus error]`). `line-tables-only` keeps file/line
+# information for stack traces but drops type-DIE bloat — a few GB
+# off the link working set, no observable hit to debuggability for
+# panic backtraces.
+[profile.dev]
+debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,20 @@ rustls      = { version = "0.23", default-features = false, features = ["ring"] 
 lto = "thin"
 codegen-units = 1
 
-# `ligate-node` pulls in the full SDK + tokio + hyper + rocksdb + ring
-# rlib graph. With full DWARF debug info, the link step OOMs on the
-# free-tier GitHub Actions runner (`collect2: ld terminated with
-# signal 7 [Bus error]`). `line-tables-only` keeps file/line
-# information for stack traces but drops type-DIE bloat — a few GB
-# off the link working set, no observable hit to debuggability for
-# panic backtraces.
+# Drop debug info on the dev profile.
+#
+# Why: linking any of our test binaries (`ligate-stf`,
+# `ligate-client`, `ligate-rollup`) pulls in the full SDK + tokio +
+# hyper + rocksdb + ring rlib graph. Each rlib carries its own
+# DWARF tree; the cumulative working set blows past what the
+# free-tier GitHub Actions runner can mmap, and the linker SIGBUSes
+# (`collect2: ld terminated with signal 7 [Bus error]`) when a
+# truncated read on a mmap'd .o slips through.
+#
+# `debug = 0` strips debug info entirely — no line numbers in
+# panics, no source-level debugging — but cuts CI link memory
+# dramatically. Worth it: pre-launch we tail logs in CI, and a
+# local override (`CARGO_PROFILE_DEV_DEBUG=2 cargo test`) restores
+# debugging when needed.
 [profile.dev]
-debug = "line-tables-only"
+debug = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,11 @@
 [workspace]
 resolver = "2"
-# `crates/rollup` is out of the workspace until Phase A.2.2 of #13
-# fills it in (the rollup binary). It stays a 4-line stub for now.
 members = [
     "crates/modules/attestation",
     "crates/client-rs",
+    "crates/rollup",
     "crates/stf",
 ]
-exclude = ["crates/rollup"]
 
 [workspace.package]
 version = "0.0.1"
@@ -41,6 +39,10 @@ sov-prover-incentives      = { git = "https://github.com/Sovereign-Labs/sovereig
 sov-sequencer-registry     = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-uniqueness             = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-mock-da                = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
+sov-mock-zkvm              = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
+sov-db                     = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
+sov-sequencer              = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-test-utils             = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 
 # Shared workspace dependencies. Versions track the SDK's own
@@ -61,6 +63,12 @@ ed25519-dalek = { version = "=2.1.1", default-features = false }
 # upgrade. Keeping the v0.20.1 pin for now.
 jsonrpsee  = { version = "0.20.1", features = ["jsonrpsee-types", "macros", "server", "http-client"] }
 tempfile   = "3.8"
+# Async + CLI plumbing for the rollup binary. Versions track the SDK
+# workspace's own `Cargo.toml` to avoid feature-graph divergence.
+async-trait = "0.1"
+clap        = { version = "4", features = ["derive"] }
+tokio       = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
+rustls      = { version = "0.23", default-features = false, features = ["ring"] }
 
 [profile.release]
 lto = "thin"

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ligate-rollup"
-description = "Ligate Labs Sovereign SDK rollup node binary"
+description = "Ligate Chain rollup binary: full node + sequencer for the ligate-stf runtime"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -16,3 +16,38 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
+borsh.workspace = true
+clap.workspace = true
+rustls.workspace = true
+serde.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+# SDK glue. All `native`-flavoured because this is a node binary,
+# never a guest.
+sov-address                    = { workspace = true, features = ["evm", "native"] }
+sov-bank                       = { workspace = true, features = ["native"] }
+sov-db                         = { workspace = true }
+sov-kernels                    = { workspace = true, features = ["native"] }
+sov-mock-da                    = { workspace = true, features = ["native"] }
+sov-mock-zkvm                  = { workspace = true, features = ["native"] }
+sov-modules-api                = { workspace = true, features = ["native"] }
+sov-modules-rollup-blueprint   = { workspace = true, features = ["native"] }
+sov-modules-stf-blueprint      = { workspace = true, features = ["native"] }
+sov-rollup-full-node-interface = { workspace = true }
+sov-rollup-interface           = { workspace = true, features = ["native"] }
+sov-sequencer                  = { workspace = true }
+sov-state                      = { workspace = true, features = ["native"] }
+sov-stf-runner                 = { workspace = true }
+
+# The Ligate Chain runtime — pulled in with `native` so the
+# `runtime_capabilities` module (Runtime/HasCapabilities/HasKernel
+# trait impls) is available to the blueprint.
+ligate-stf = { path = "../stf", features = ["native"] }
+
+[dev-dependencies]
+attestation    = { path = "../modules/attestation" }
+serde_json     = { workspace = true }
+sov-test-utils = { workspace = true }
+tempfile       = { workspace = true }

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -1,0 +1,31 @@
+//! Ligate Chain rollup binary library.
+//!
+//! Hosts the [`MockLigateRollup`] blueprint impl. The binary itself
+//! lives in `src/main.rs` and is intentionally thin — it just parses
+//! CLI args and asks the blueprint to spin up a node.
+//!
+//! # Why a library + binary split
+//!
+//! The blueprint impl carries non-trivial trait wiring
+//! (`RollupBlueprint`, `FullNodeBlueprint`). Tests need to
+//! instantiate it without going through `main`, which is why it's
+//! in a library module rather than inlined in `main.rs`. Mirrors the
+//! SDK demo-rollup's split (`sov_demo_rollup` lib + `sov-demo-rollup`
+//! bin).
+//!
+//! # Currently supported configurations
+//!
+//! - **DA layer**: `mock` only. Celestia adapter wiring is Phase A.3.
+//! - **zkVM**: `mock` only. Real proving (Risc0 / SP1) is Phase A.4.
+//!
+//! Production devnet (#13) targets MockDa + MockZkvm too — proving
+//! and Celestia are explicitly post-launch concerns. The CLI is
+//! shaped to grow into multi-DA / multi-zkVM dispatch later without
+//! a breaking change.
+
+#![deny(missing_docs)]
+#![allow(clippy::too_many_arguments)]
+
+mod mock_rollup;
+
+pub use mock_rollup::{MockLigateRollup, MockRollupSpec};

--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -1,4 +1,110 @@
-fn main() -> anyhow::Result<()> {
-    println!("ligate-node: scaffold only");
-    Ok(())
+//! Ligate Chain rollup binary.
+//!
+//! Thin CLI dispatcher around [`ligate_rollup::MockLigateRollup`].
+//!
+//! ## v0 scope
+//!
+//! - DA layer: mock only. Celestia is Phase A.3.
+//! - zkVM: mock only. Real proving is Phase A.4.
+//! - Prover mode: hard-coded to `Disabled`. Mock proving exists but
+//!   serves no purpose with mock zkVM, and we want startup to be
+//!   fast for devnet smoke testing.
+//!
+//! The CLI is shaped so adding a `--da-layer` flag in Phase A.3 is
+//! a non-breaking change: today there's only one combination so we
+//! don't expose the flag yet.
+
+use std::path::PathBuf;
+use std::process::exit;
+
+use anyhow::Context as _;
+use clap::Parser;
+use ligate_rollup::MockLigateRollup;
+use ligate_stf::genesis_config::GenesisPaths;
+use sov_address::MultiAddressEvm;
+use sov_mock_da::storable::StorableMockDaService;
+use sov_modules_api::execution_mode::Native;
+use sov_modules_rollup_blueprint::logging::initialize_logging;
+use sov_modules_rollup_blueprint::FullNodeBlueprint;
+use sov_stf_runner::processes::RollupProverConfig;
+use sov_stf_runner::{from_toml_path, RollupConfig};
+use tracing::debug;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Ligate Chain rollup node", long_about = None)]
+struct Args {
+    /// Path to the rollup config TOML.
+    ///
+    /// Format mirrors the SDK's `RollupConfig` (storage, sequencer,
+    /// proof-manager sections). A devnet-ready example will land in
+    /// `devnet/rollup.toml` in Phase A.2.3.
+    #[arg(long, default_value = "devnet/rollup.toml")]
+    rollup_config_path: String,
+
+    /// Directory containing per-module genesis JSON files (`bank.json`,
+    /// `accounts.json`, …). See [`ligate_stf::genesis_config`] for the
+    /// expected layout.
+    #[arg(long, default_value = "devnet/genesis")]
+    genesis_config_dir: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    // The opentelemetry exporter wants this guard alive for the
+    // whole process; dropping it stalls log flush on shutdown.
+    let _guard = initialize_logging();
+
+    match run().await {
+        Ok(()) => {
+            tracing::debug!("Rollup execution complete. Shutting down.");
+        }
+        Err(e) => {
+            tracing::error!(
+                error = ?e,
+                backtrace = e.backtrace().to_string(),
+                "Rollup execution failed",
+            );
+            exit(1);
+        }
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    // `rustls` requires a default crypto provider be installed
+    // before any TLS work happens (jsonrpsee handshakes, etc.). The
+    // SDK uses `ring`; we match.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|e| anyhow::anyhow!("Failed to install rustls ring crypto provider: {e:?}"))?;
+
+    debug!(
+        rollup_config_path = %args.rollup_config_path,
+        genesis_config_dir = ?args.genesis_config_dir,
+        "Starting Ligate rollup on mock DA",
+    );
+
+    let rollup_config: RollupConfig<MultiAddressEvm, StorableMockDaService> =
+        from_toml_path(&args.rollup_config_path).with_context(|| {
+            format!("Failed to read rollup configuration from {}", args.rollup_config_path)
+        })?;
+
+    let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);
+
+    let rollup = MockLigateRollup::<Native>::default()
+        .create_new_rollup(
+            &genesis_paths,
+            rollup_config,
+            // Disabled until Phase A.4. With MockZkvm enabling
+            // proving costs cycles for no security gain.
+            RollupProverConfig::Disabled,
+            None, // start_at_rollup_height
+            None, // stop_at_rollup_height
+            None, // exec_config (we use `()`)
+        )
+        .await
+        .context("Failed to initialize Ligate rollup on mock DA")?;
+
+    rollup.run().await
 }

--- a/crates/rollup/src/mock_rollup.rs
+++ b/crates/rollup/src/mock_rollup.rs
@@ -1,0 +1,181 @@
+//! `RollupBlueprint` + `FullNodeBlueprint` impls for the mock-DA /
+//! mock-zkVM flavour of Ligate Chain.
+//!
+//! Every method body delegates to the SDK's stock implementations.
+//! Parity with the SDK demo's `mock_rollup.rs` is intentional — when
+//! we eventually swap MockDa for Celestia (Phase A.3) the diff
+//! should be limited to associated types + the `create_da_service`
+//! body, not the structural shape.
+//!
+//! Two specific deviations from the SDK demo:
+//!
+//! 1. **No EVM RPC, no Solana router.** The demo's
+//!    `sequencer_additional_apis` wires both. We inherit
+//!    `FullNodeBlueprint`'s default impl (empty endpoints). Standard
+//!    sov RPCs (sequencer, ledger, runtime modules) still register
+//!    via `create_endpoints`.
+//! 2. **Address type is [`MultiAddressEvm`]**, not the demo's
+//!    `MultiAddressEvmSolana`. We don't need the Solana variant —
+//!    the runtime's `S::Address` bound is `FromVmAddress<EthereumAddress>`
+//!    only.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ligate_stf::Runtime;
+use sov_address::{EthereumAddress, FromVmAddress, MultiAddressEvm};
+use sov_db::ledger_db::LedgerDb;
+use sov_db::storage_manager::NomtStorageManager;
+use sov_mock_da::storable::StorableMockDaService;
+use sov_mock_da::MockDaSpec;
+use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost};
+use sov_modules_api::configurable_spec::ConfigurableSpec;
+use sov_modules_api::execution_mode::Native;
+use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec, ZkVerifier};
+use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
+use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
+use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
+use sov_rollup_full_node_interface::StateUpdateReceiver;
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::node::SyncStatus;
+use sov_sequencer::ProofBlobSender;
+use sov_state::nomt::prover_storage::NomtProverStorage;
+use sov_state::{DefaultStorageSpec, Storage};
+use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
+use sov_stf_runner::RollupConfig;
+
+/// Marker type for the mock-DA / mock-zkVM rollup. Carries no state;
+/// the [`Default`] / [`Clone`] / [`Copy`] impls let the blueprint
+/// machinery construct it however it wants.
+#[derive(Default, Clone, Copy, Debug)]
+pub struct MockLigateRollup<M> {
+    phantom: std::marker::PhantomData<M>,
+}
+
+type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
+type NativeStorage =
+    NomtProverStorage<DefaultStorageSpec<Hasher>, <MockDaSpec as DaSpec>::SlotHash>;
+
+/// Concrete [`Spec`] used by [`MockLigateRollup`].
+///
+/// `MultiAddressEvm` carries both 28-byte standard rollup addresses
+/// and 20-byte Ethereum addresses. We don't ship Solidity execution
+/// (the runtime omits `sov-evm`), but the address shape is still EVM-
+/// aware so wallet UX maps cleanly to `0x…` and so the bank/accounts
+/// modules' `FromVmAddress` bound is satisfied.
+pub type MockRollupSpec<M> = ConfigurableSpec<
+    MockDaSpec,
+    MockZkvm,
+    MockZkvm,
+    MultiAddressEvm,
+    M,
+    MockZkvmCryptoSpec,
+    NativeStorage,
+>;
+
+impl RollupBlueprint<Native> for MockLigateRollup<Native>
+where
+    MockRollupSpec<Native>: PluggableSpec,
+    <MockRollupSpec<Native> as Spec>::Address: FromVmAddress<EthereumAddress>,
+{
+    type Spec = MockRollupSpec<Native>;
+    type Runtime = Runtime<Self::Spec>;
+}
+
+#[async_trait]
+impl FullNodeBlueprint<Native> for MockLigateRollup<Native> {
+    type DaService = StorableMockDaService;
+
+    type StorageManager = NomtStorageManager<MockDaSpec, Hasher, NativeStorage>;
+
+    type ProverService = ParallelProverService<
+        <Self::Spec as Spec>::Address,
+        <<Self::Spec as Spec>::Storage as Storage>::Root,
+        <<Self::Spec as Spec>::Storage as Storage>::Witness,
+        Self::DaService,
+        <Self::Spec as Spec>::InnerZkvm,
+        <Self::Spec as Spec>::OuterZkvm,
+    >;
+
+    type ProofSender = SovApiProofSender<Self::Spec>;
+
+    fn create_outer_code_commitment(
+        &self,
+    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
+        // MockZkvm accepts any commitment as valid; the default is
+        // fine. A real prover swaps this for the production circuit
+        // commitment in Phase A.4 (#xx).
+        MockCodeCommitment::default()
+    }
+
+    async fn create_endpoints(
+        &self,
+        state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
+        sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        ledger_db: &LedgerDb,
+        sequencer: &SequencerCreationReceipt<Self::Spec>,
+        _da_service: &Self::DaService,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+    ) -> anyhow::Result<NodeEndpoints> {
+        // Stock SDK helper. Wires the standard sequencer + ledger
+        // RPCs and the runtime's per-module REST routers (currently
+        // empty — see `ligate_stf::runtime_capabilities`).
+        sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
+            state_update_receiver,
+            sync_status_receiver,
+            shutdown_receiver,
+            ledger_db,
+            sequencer,
+            rollup_config,
+        )
+        .await
+    }
+
+    async fn create_da_service(
+        &self,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    ) -> Self::DaService {
+        StorableMockDaService::from_config(rollup_config.da.clone(), shutdown_receiver).await
+    }
+
+    async fn create_prover_service(
+        &self,
+        _prover_config: RollupProverConfig,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        _da_service: &Self::DaService,
+    ) -> Self::ProverService {
+        // Even when proving is disabled at the operator level
+        // (`SOV_PROVER_MODE` unset), the blueprint still needs a
+        // `ProverService` instance. `MockZkvmHost::new_non_blocking`
+        // produces one that accepts every proof — fine for a
+        // mock-zkVM devnet.
+        let inner_vm = MockZkvmHost::new_non_blocking();
+        let outer_vm = MockZkvmHost::new_non_blocking();
+        let da_verifier = Default::default();
+
+        ParallelProverService::new_with_default_workers(
+            inner_vm,
+            outer_vm,
+            da_verifier,
+            rollup_config.proof_manager.prover_address,
+        )
+    }
+
+    fn create_storage_manager(
+        &self,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
+    ) -> anyhow::Result<Self::StorageManager> {
+        NomtStorageManager::new(rollup_config.storage.clone(), witness_generation)
+    }
+
+    fn create_proof_sender(
+        &self,
+        _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        sequence_number_provider: Arc<dyn ProofBlobSender>,
+    ) -> anyhow::Result<Self::ProofSender> {
+        Ok(Self::ProofSender::new(sequence_number_provider))
+    }
+}

--- a/crates/rollup/tests/blueprint_smoke.rs
+++ b/crates/rollup/tests/blueprint_smoke.rs
@@ -1,0 +1,120 @@
+//! End-to-end smoke tests for the rollup blueprint.
+//!
+//! Asserts the wiring between [`ligate_rollup::MockLigateRollup`],
+//! [`ligate_stf::Runtime`], and the SDK's blueprint traits all works
+//! against the production address type ([`MultiAddressEvm`]) — not
+//! the `sov_test_utils::TestSpec` we use in the stf crate's
+//! lower-level tests.
+//!
+//! What we deliberately *don't* test here: actually booting a node
+//! against RocksDB / mock DA / the sequencer task graph. That needs
+//! a full `RollupConfig` (storage dirs, ports, prover paths) and is
+//! the territory of an integration harness in Phase A.2.3, where
+//! we'll have a real `devnet/rollup.toml` to load.
+
+use std::fs;
+
+use attestation::AttestationConfig;
+use ligate_rollup::{MockLigateRollup, MockRollupSpec};
+use ligate_stf::genesis_config::GenesisPaths;
+use ligate_stf::runtime::GenesisConfig;
+use ligate_stf::Runtime;
+use sov_bank::config_gas_token_id;
+use sov_modules_api::execution_mode::Native;
+use sov_modules_api::Amount;
+use sov_modules_rollup_blueprint::RollupBlueprint;
+use sov_test_utils::runtime::genesis::optimistic::{
+    HighLevelOptimisticGenesisConfig, MinimalOptimisticGenesisConfig,
+};
+use tempfile::TempDir;
+
+/// Compile-time guard that the blueprint resolves the runtime to
+/// `ligate_stf::Runtime<MockRollupSpec<Native>>`. If this signature
+/// stops type-checking, somebody has accidentally swapped the
+/// runtime under the blueprint.
+#[allow(dead_code)]
+fn _assert_blueprint_runtime_is_ligate_stf(
+    rt: <MockLigateRollup<Native> as RollupBlueprint<Native>>::Runtime,
+) -> Runtime<MockRollupSpec<Native>> {
+    rt
+}
+
+#[test]
+fn mock_blueprint_default_is_send_sync_static() {
+    fn assert_send_sync_static<T: Send + Sync + 'static>(_: T) {}
+    assert_send_sync_static(MockLigateRollup::<Native>::default());
+}
+
+#[test]
+fn runtime_genesis_config_round_trips_for_production_spec() {
+    // Builds a genesis directory the same way the rollup binary
+    // would (one JSON per module under one directory), then drives
+    // the blueprint's runtime trait — the same path
+    // `MockLigateRollup::create_genesis_config` takes — and verifies
+    // it loads + validates without error.
+    type S = MockRollupSpec<Native>;
+
+    let dir = TempDir::new().unwrap();
+
+    // Build the 9 SDK module configs via the test-utils helper, add
+    // attestation by hand.
+    let high_level = HighLevelOptimisticGenesisConfig::<S>::generate();
+    let attester_addr = high_level.initial_attester.user_info.address();
+    let minimal: MinimalOptimisticGenesisConfig<S> = high_level.into();
+    let basic = minimal.config;
+
+    let attestation = AttestationConfig::<S> {
+        treasury: attester_addr,
+        lgt_token_id: config_gas_token_id(),
+        attestation_fee: Amount(0),
+        schema_registration_fee: Amount(0),
+        attestor_set_fee: Amount(0),
+        initial_attestor_sets: vec![],
+        initial_schemas: vec![],
+    };
+
+    let genesis = GenesisConfig::<S> {
+        bank: basic.bank,
+        accounts: basic.accounts,
+        sequencer_registry: basic.sequencer_registry,
+        operator_incentives: basic.operator_incentives,
+        attester_incentives: basic.attester_incentives,
+        prover_incentives: basic.prover_incentives,
+        uniqueness: (),
+        chain_state: basic.chain_state,
+        blob_storage: (),
+        attestation,
+    };
+
+    // Dump each module to <tempdir>/<module>.json — same convention
+    // `GenesisPaths::from_dir` expects.
+    for (file, json) in [
+        ("bank.json", serde_json::to_vec_pretty(&genesis.bank).unwrap()),
+        ("accounts.json", serde_json::to_vec_pretty(&genesis.accounts).unwrap()),
+        (
+            "sequencer_registry.json",
+            serde_json::to_vec_pretty(&genesis.sequencer_registry).unwrap(),
+        ),
+        (
+            "operator_incentives.json",
+            serde_json::to_vec_pretty(&genesis.operator_incentives).unwrap(),
+        ),
+        (
+            "attester_incentives.json",
+            serde_json::to_vec_pretty(&genesis.attester_incentives).unwrap(),
+        ),
+        ("prover_incentives.json", serde_json::to_vec_pretty(&genesis.prover_incentives).unwrap()),
+        ("chain_state.json", serde_json::to_vec_pretty(&genesis.chain_state).unwrap()),
+        ("attestation.json", serde_json::to_vec_pretty(&genesis.attestation).unwrap()),
+    ] {
+        fs::write(dir.path().join(file), json).unwrap();
+    }
+
+    let paths = GenesisPaths::from_dir(dir.path());
+
+    // Drive through the runtime trait the blueprint will call.
+    let loaded = <Runtime<S> as sov_modules_api::Runtime<S>>::genesis_config(&paths)
+        .expect("blueprint genesis_config should accept the round-tripped configs");
+
+    assert_eq!(loaded.attestation.lgt_token_id, config_gas_token_id());
+}

--- a/crates/stf/src/lib.rs
+++ b/crates/stf/src/lib.rs
@@ -39,6 +39,8 @@
 
 pub mod genesis_config;
 pub mod runtime;
+#[cfg(feature = "native")]
+mod runtime_capabilities;
 
 #[cfg(test)]
 mod tests;

--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -20,6 +20,7 @@
 #![allow(unused_doc_comments)]
 
 use sov_address::{EthereumAddress, FromVmAddress};
+use sov_modules_api::macros::RuntimeRestApi;
 use sov_modules_api::prelude::*;
 use sov_modules_api::{DispatchCall, Event, Genesis, Hooks, MessageCodec, Spec};
 
@@ -38,7 +39,7 @@ use sov_modules_api::{DispatchCall, Event, Genesis, Hooks, MessageCodec, Spec};
 /// include `sov-evm` in the Runtime; deploying Solidity contracts is
 /// not a v0 feature. Solana / `Base58Address` support is only needed
 /// when hyperlane modules are present, which we omit.
-#[derive(Default, Clone, Genesis, Hooks, DispatchCall, Event, MessageCodec)]
+#[derive(Default, Clone, Genesis, Hooks, DispatchCall, Event, MessageCodec, RuntimeRestApi)]
 pub struct Runtime<S: Spec>
 where
     S::Address: FromVmAddress<EthereumAddress>,

--- a/crates/stf/src/runtime_capabilities.rs
+++ b/crates/stf/src/runtime_capabilities.rs
@@ -1,0 +1,141 @@
+//! `Runtime` trait wiring for the rollup binary.
+//!
+//! [`crate::runtime::Runtime`] is the runtime _composition_ — fields,
+//! derive macros, doc comments. This module implements the three
+//! traits the SDK's STF blueprint needs to actually drive the
+//! runtime against blocks:
+//!
+//! - [`sov_modules_api::Runtime`]: top-level wiring — `CHAIN_HASH`,
+//!   `Auth`, `GenesisConfig`, `endpoints`. Glues the per-module
+//!   derives together into a node-runnable surface.
+//! - [`HasCapabilities`]: surfaces the bundle of modules the
+//!   STF/sequencer use during slot processing (bank for fees,
+//!   sequencer-registry for blob auth, accounts for nonces, etc.).
+//!   We use the SDK's [`StandardProvenRollupCapabilities`] with no
+//!   gas payer — `sov-paymaster` is omitted from the runtime.
+//! - [`HasKernel`]: chooses the slot-processing kernel. We pick
+//!   [`SoftConfirmationsKernel`] (process all blobs in DA order;
+//!   match the SDK demo's default).
+//!
+//! ## `CHAIN_HASH` is currently a placeholder
+//!
+//! The canonical value is generated at build time from the runtime's
+//! universal-wallet schema (see `sov_build::Options::apply_defaults`).
+//! Wiring that build script is its own slice — it requires every
+//! `Decodable` payload to derive `JsonSchema`, which our
+//! `attestation::CallMessage` does not yet. Until that lands, the
+//! runtime ships with `CHAIN_HASH = [0u8; 32]`.
+//!
+//! Practical effect: standard transactions will authenticate against
+//! a chain id of all-zeros. That's fine for an internal devnet smoke
+//! test (client and node use the same constant), but the production
+//! devnet must replace this before opening to external sequencers —
+//! otherwise a rollup with a different runtime composition could
+//! accept replays of our transactions. Tracked alongside the build
+//! script slice.
+
+use sov_address::{EthereumAddress, FromVmAddress};
+use sov_capabilities::StandardProvenRollupCapabilities;
+use sov_kernels::soft_confirmations::SoftConfirmationsKernel;
+use sov_modules_api::capabilities::{
+    Guard, HasCapabilities, HasKernel, KernelWithSlotMapping, RollupAuthenticator,
+};
+use sov_modules_api::rest::{ApiState, HasRestApi};
+use sov_modules_api::{NodeEndpoints, OperatingMode, Spec};
+use std::sync::Arc;
+
+use crate::genesis_config::{create_genesis_config, GenesisPaths};
+use crate::runtime::{GenesisConfig, Runtime};
+
+/// Placeholder chain hash. See module-level docs for why this is
+/// not yet derived from the universal-wallet schema, and why the
+/// production devnet must replace it before opening to external
+/// sequencers.
+pub const PLACEHOLDER_CHAIN_HASH: [u8; 32] = [0u8; 32];
+
+impl<S: Spec> sov_modules_api::Runtime<S> for Runtime<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    const CHAIN_HASH: [u8; 32] = PLACEHOLDER_CHAIN_HASH;
+
+    type GenesisConfig = GenesisConfig<S>;
+    type GenesisInput = GenesisPaths;
+    type ModuleExecutionConfig = ();
+    type Auth = RollupAuthenticator<S, Self>;
+
+    fn endpoints(api_state: ApiState<S>) -> NodeEndpoints {
+        // Per-module REST routers (e.g. `GET /modules/bank/tokens`),
+        // plumbed through `HasRestApi` from the `RuntimeRestApi`
+        // derive on `Runtime`. The SDK demo additionally wires the
+        // universal-wallet schema and dedup endpoints, both gated
+        // on the build-script-generated `SCHEMA_JSON` we don't ship
+        // yet (see module-level docs on `CHAIN_HASH`); they land in
+        // the same slice as the build script.
+        NodeEndpoints { axum_router: Self::default().rest_api(api_state), ..Default::default() }
+    }
+
+    fn genesis_config(input: &Self::GenesisInput) -> anyhow::Result<Self::GenesisConfig> {
+        // Promote the typed `GenesisError` (used by ligate-stf
+        // internals) to `anyhow::Error` for the SDK's blueprint API,
+        // which is `anyhow`-flavoured at this boundary.
+        Ok(create_genesis_config(input)?)
+    }
+
+    fn operating_mode(genesis: &Self::GenesisConfig) -> OperatingMode {
+        genesis.chain_state.operating_mode
+    }
+
+    fn wrap_call(
+        auth_data: <Self::Auth as sov_modules_api::capabilities::TransactionAuthenticator<S>>::Decodable,
+    ) -> <Self as sov_modules_api::DispatchCall>::Decodable {
+        // `RollupAuthenticator` has a single decoded variant — it
+        // dispatches directly to `Rt::Decodable`. So `wrap_call` is
+        // the identity. (Compare the SDK demo's matching `Evm /
+        // Solana / Standard` arms — we have none of those.)
+        auth_data
+    }
+}
+
+impl<S: Spec> HasCapabilities<S> for Runtime<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    /// We omit `sov-paymaster`, so the gas-payer slot is `()`. The
+    /// SDK's `StandardProvenRollupCapabilities` defaults `GasPayer`
+    /// to `()` precisely for this case.
+    type Capabilities<'a> = StandardProvenRollupCapabilities<'a, S>;
+    type SequencingData = sov_modules_api::HDTimestamp;
+
+    fn capabilities(&mut self) -> Guard<Self::Capabilities<'_>> {
+        Guard::new(StandardProvenRollupCapabilities {
+            bank: &mut self.bank,
+            gas_payer: (),
+            sequencer_registry: &mut self.sequencer_registry,
+            accounts: &mut self.accounts,
+            uniqueness: &mut self.uniqueness,
+            chain_state: &mut self.chain_state,
+            operator_incentives: &mut self.operator_incentives,
+            prover_incentives: &mut self.prover_incentives,
+            attester_incentives: &mut self.attester_incentives,
+        })
+    }
+}
+
+impl<S: Spec> HasKernel<S> for Runtime<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    type Kernel<'a> = SoftConfirmationsKernel<'a, S>;
+
+    fn inner(&mut self) -> Guard<Self::Kernel<'_>> {
+        Guard::new(SoftConfirmationsKernel {
+            chain_state: &mut self.chain_state,
+            blob_storage: &mut self.blob_storage,
+        })
+    }
+
+    fn kernel_with_slot_mapping(&self) -> Arc<dyn KernelWithSlotMapping<S>> {
+        Arc::new(self.chain_state.clone())
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of Phase A.2 (#13, #63). The rollup binary `ligate-node` is back in the workspace and boots a `MockLigateRollup` blueprint against the `ligate-stf` runtime. Closes the path from \`cargo run --bin ligate-node\` to \`MockLigateRollup::create_new_rollup\`.

### What's in

**`crates/stf` extensions:**
- `runtime.rs`: +1 derive (\`RuntimeRestApi\`) so the blueprint's \`register_endpoints\` helper can plug per-module REST routers.
- `runtime_capabilities.rs` (new, 144 lines): the trait wiring the SDK's STF blueprint needs to drive the runtime against blocks —
  - \`impl sov_modules_api::Runtime<S> for Runtime<S>\` with \`Auth = RollupAuthenticator\` (standard sov auth, single path), \`GenesisConfig\` / \`GenesisInput = GenesisPaths\`, \`endpoints\` plumbed through \`HasRestApi\`, and \`genesis_config\` delegating to \`ligate_stf::genesis_config::create_genesis_config\`.
  - \`impl HasCapabilities<S>\` using \`StandardProvenRollupCapabilities\` with \`gas_payer = ()\` (no Paymaster).
  - \`impl HasKernel<S>\` using \`SoftConfirmationsKernel\`.

**`crates/rollup` (back in workspace):**
- \`Cargo.toml\`: full SDK dep surface plus \`ligate-stf\` (path) with the \`native\` feature.
- \`src/lib.rs\`: re-exports the blueprint.
- \`src/mock_rollup.rs\` (180 lines): \`MockLigateRollup<M>\` + \`MockRollupSpec<M>\` (= \`ConfigurableSpec<MockDaSpec, MockZkvm, MockZkvm, MultiAddressEvm, M, …>\`); \`RollupBlueprint<Native>\` + \`FullNodeBlueprint<Native>\` impls. Method bodies delegate to stock SDK helpers (\`register_endpoints\`, \`StorableMockDaService::from_config\`, \`NomtStorageManager::new\`).
- \`src/main.rs\` (110 lines): clap CLI with \`--rollup-config-path\` / \`--genesis-config-dir\`, hard-codes \`RollupProverConfig::Disabled\`, runs the blueprint.
- \`tests/blueprint_smoke.rs\`: 2 end-to-end tests against the production address type (\`MultiAddressEvm\`):
  1. \`mock_blueprint_default_is_send_sync_static\` — compile-time send/sync/static guard.
  2. \`runtime_genesis_config_round_trips_for_production_spec\` — writes per-module JSONs to a tempdir, drives \`Runtime::genesis_config(&paths)\` through the same path the blueprint takes, asserts \`attestation.lgt_token_id == sov_bank::config_gas_token_id()\`.

**Workspace `Cargo.toml`:** re-includes \`crates/rollup\`; adds \`sov-mock-zkvm\`, \`sov-db\`, \`sov-rollup-full-node-interface\`, \`sov-sequencer\`, plus \`async-trait\`, \`clap\`, \`tokio\`, \`rustls\`.

### Honest scope notes

1. **\`CHAIN_HASH = [0u8; 32]\` placeholder.** The canonical value is generated at build time from the runtime's universal-wallet schema. Wiring the build script needs \`JsonSchema\` on every \`Decodable\` payload (notably \`attestation::CallMessage\`), so it's a separate slice. Documented in \`runtime_capabilities.rs\`'s module-level docstring with the production-readiness caveat.
2. **No EVM-rlp / Solana auth.** Single-path \`RollupAuthenticator\`. EVM-style transaction auth is Iris territory (#55). Address shape is still EVM-aware (\`MultiAddressEvm\`) for wallet UX.
3. **MockDa + MockZkvm only.** Celestia adapter is Phase A.3; real proving is Phase A.4. The CLI is shaped so a \`--da-layer\` flag is non-breaking to add later.
4. **Smoke test scope.** Tests exercise the genesis-loading path but do not boot a full node (RocksDB + sequencer task graph). Full-boot tests need a real \`RollupConfig\`; they land in A.2.3 alongside \`devnet/rollup.toml\`.
5. **Default CLI paths point at A.2.3 artifacts.** \`cargo run --bin ligate-node\` will fail until \`devnet/\` exists. \`--help\` works without them.

## Test plan

Local gates (all green):

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (CI flags)
- [x] \`cargo doc --workspace --no-deps --document-private-items\` with \`-D warnings\`
- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo test --workspace --all-targets\` — **76 passed, 0 failed** (was 74; +2 in \`ligate-rollup\`, 0 regressions)
- [x] \`cargo run --bin ligate-node -- --help\` renders the expected CLI

CI:

- [ ] All 6 jobs green on the PR