### PR TITLE
Phase A.2.3: checked-in devnet config (refs #63)

### DIFF
--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -90,6 +90,18 @@ async fn run() -> anyhow::Result<()> {
             format!("Failed to read rollup configuration from {}", args.rollup_config_path)
         })?;
 
+    // Make sure the storage path exists before any SDK component
+    // reaches into it. SQLite (mock DA) and RocksDB (state) both
+    // refuse to create their files if the parent directory is
+    // missing, and we want first-run `cargo run --bin ligate-node`
+    // to work without a separate `mkdir` step.
+    std::fs::create_dir_all(&rollup_config.storage.path).with_context(|| {
+        format!(
+            "Failed to create rollup storage directory at {}",
+            rollup_config.storage.path.display()
+        )
+    })?;
+
     let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);
 
     let rollup = MockLigateRollup::<Native>::default()

--- a/crates/rollup/tests/devnet_config.rs
+++ b/crates/rollup/tests/devnet_config.rs
@@ -1,0 +1,58 @@
+//! Validate the checked-in `devnet/` config end-to-end.
+//!
+//! These tests guard against drift between the runtime types and the
+//! committed JSON / TOML. If a module's `Config` shape changes, or a
+//! cross-module invariant tightens, the failure surfaces here before
+//! anyone runs the binary.
+//!
+//! Tests are gated to the same `MockLigateRollup` blueprint shape the
+//! binary uses, so the address type (`MultiAddressEvm`) and DA
+//! service (`StorableMockDaService`) are exactly what production
+//! code paths see.
+
+use std::path::PathBuf;
+
+use ligate_rollup::MockRollupSpec;
+use ligate_stf::genesis_config::GenesisPaths;
+use ligate_stf::Runtime;
+use sov_address::MultiAddressEvm;
+use sov_mock_da::storable::StorableMockDaService;
+use sov_modules_api::execution_mode::Native;
+use sov_stf_runner::{from_toml_path, RollupConfig};
+
+/// Path to the repo's checked-in `devnet/` directory, regardless of
+/// where `cargo test` is invoked from.
+fn devnet_dir() -> PathBuf {
+    // `CARGO_MANIFEST_DIR` is `crates/rollup/`; the devnet lives two
+    // levels up.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("crates/rollup/ has a workspace-root grandparent")
+        .join("devnet")
+}
+
+#[test]
+fn rollup_toml_parses_against_mock_blueprint_types() {
+    // Catches TOML keys renamed/removed in the SDK between pins, or
+    // keys we typoed in `devnet/rollup.toml`.
+    let path = devnet_dir().join("rollup.toml");
+    let _config: RollupConfig<MultiAddressEvm, StorableMockDaService> = from_toml_path(&path)
+        .unwrap_or_else(|e| {
+            panic!("devnet/rollup.toml failed to parse: {e:?}");
+        });
+}
+
+#[test]
+fn genesis_jsons_load_and_pass_cross_module_validation() {
+    // End-to-end through the same path the binary takes:
+    //   GenesisPaths -> create_genesis_config -> validate_config
+    // Catches schema mismatches in any per-module JSON, plus the
+    // `attestation.lgt_token_id == config_gas_token_id()` invariant.
+    type S = MockRollupSpec<Native>;
+    let paths = GenesisPaths::from_dir(devnet_dir().join("genesis"));
+    let _config = <Runtime<S> as sov_modules_api::Runtime<S>>::genesis_config(&paths)
+        .unwrap_or_else(|e| {
+            panic!("devnet/genesis/ failed to load + validate: {e:?}");
+        });
+}

--- a/devnet/.gitignore
+++ b/devnet/.gitignore
@@ -1,0 +1,3 @@
+# Runtime data — RocksDB instances, ledger db, mock DA SQLite.
+# Regenerated on every boot from the genesis JSONs.
+data/

--- a/devnet/README.md
+++ b/devnet/README.md
@@ -1,0 +1,66 @@
+# Ligate Chain devnet config
+
+Single-node MockDa + MockZkvm devnet, ready to boot:
+
+```sh
+cargo run --bin ligate-node \
+  --rollup-config-path devnet/rollup.toml \
+  --genesis-config-dir   devnet/genesis
+```
+
+(Defaults match the layout, so a bare `cargo run --bin ligate-node`
+also works from the repo root.)
+
+## What's here
+
+- `rollup.toml` — node-level config: storage paths, DA, sequencer,
+  proof manager. Annotated inline.
+- `genesis/*.json` — one file per runtime module the chain
+  initialises at genesis. See [`ligate_stf::genesis_config`]
+  (`crates/stf/src/genesis_config.rs`) for the loader contract and
+  the cross-module invariants that get checked before the chain
+  starts.
+
+## Bootstrap actor
+
+A single Anvil dev account does everything at genesis to keep the
+boot story narrow:
+
+| Role | Address | Notes |
+|---|---|---|
+| Treasury / bank admin | `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` | Anvil #0. Receives attestation fees. |
+| Initial sequencer (rollup) | same | Locks 5 000 LGT collateral |
+| Initial sequencer (DA) | `0x0000…0000` | 32-byte mock-DA address |
+| Initial attester | same | Bonds 1 000 LGT |
+| Initial prover | same | Bonds 1 000 LGT |
+| Operator reward addr | same | |
+| Prover reward addr | same | |
+
+The two other accounts seeded with `$LGT` are Anvil #1
+(`0x70997970…`) and #2 (`0x3C44Cd…`) — useful for end-to-end
+transfer testing without minting more.
+
+## $LGT layout
+
+- 9 decimals (Solana-style nano units)
+- Genesis supply: 120M LGT
+  - Bootstrap: 100M LGT
+  - Anvil #1: 10M LGT
+  - Anvil #2: 10M LGT
+- `lgt_token_id` is the deterministic `config_gas_token_id()` from
+  `constants.toml`. The genesis loader cross-checks this against
+  `attestation.lgt_token_id` and refuses to boot on mismatch.
+
+## What's _not_ here
+
+- **Real attestor sets / schemas.** `initial_attestor_sets` and
+  `initial_schemas` in `attestation.json` are intentionally empty.
+  Schema registration via tx after boot is the same code path —
+  better to exercise it than to bake test fixtures into genesis.
+- **Real chain-id binding.** The runtime ships with `CHAIN_HASH =
+  [0u8; 32]` until the build-script slice lands. Anyone with the
+  same SDK pin and matching JSONs would produce a hash-compatible
+  chain. Fine for a closed devnet, blocks any external sequencer
+  story until we wire the real schema-derived hash.
+- **Multi-node story.** The MockDa adapter is single-process. Phase
+  A.3 swaps it for Celestia and a real DA + sequencer split.

--- a/devnet/genesis/accounts.json
+++ b/devnet/genesis/accounts.json
@@ -1,0 +1,4 @@
+{
+  "accounts": [],
+  "enable_custom_account_mappings": true
+}

--- a/devnet/genesis/attestation.json
+++ b/devnet/genesis/attestation.json
@@ -1,0 +1,9 @@
+{
+  "treasury": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "lgt_token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
+  "attestation_fee": "100000",
+  "schema_registration_fee": "100000000",
+  "attestor_set_fee": "50000000",
+  "initial_attestor_sets": [],
+  "initial_schemas": []
+}

--- a/devnet/genesis/attester_incentives.json
+++ b/devnet/genesis/attester_incentives.json
@@ -1,0 +1,10 @@
+{
+  "minimum_attester_bond": [1000, 1000],
+  "minimum_challenger_bond": [1000, 1000],
+  "initial_attesters": [
+    ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "1000000000000"]
+  ],
+  "rollup_finality_period": 5,
+  "maximum_attested_height": 0,
+  "light_client_finalized_height": 0
+}

--- a/devnet/genesis/bank.json
+++ b/devnet/genesis/bank.json
@@ -1,0 +1,15 @@
+{
+  "gas_token_config": {
+    "token_name": "$LGT",
+    "token_decimals": 9,
+    "address_and_balances": [
+      ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "100000000000000000"],
+      ["0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "10000000000000000"],
+      ["0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", "10000000000000000"]
+    ],
+    "admins": [
+      "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    ]
+  },
+  "tokens": []
+}

--- a/devnet/genesis/chain_state.json
+++ b/devnet/genesis/chain_state.json
@@ -1,0 +1,7 @@
+{
+  "current_time": 0,
+  "operating_mode": "zk",
+  "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
+  "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
+  "genesis_da_height": 0
+}

--- a/devnet/genesis/operator_incentives.json
+++ b/devnet/genesis/operator_incentives.json
@@ -1,0 +1,3 @@
+{
+  "reward_address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+}

--- a/devnet/genesis/prover_incentives.json
+++ b/devnet/genesis/prover_incentives.json
@@ -1,0 +1,7 @@
+{
+  "proving_penalty": [10, 10],
+  "minimum_bond": [1000, 1000],
+  "initial_provers": [
+    ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "1000000000000"]
+  ]
+}

--- a/devnet/genesis/sequencer_registry.json
+++ b/devnet/genesis/sequencer_registry.json
@@ -1,0 +1,9 @@
+{
+  "minimum_bond": "1000000000000",
+  "sequencer_config": {
+    "seq_rollup_address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "seq_da_address": "0000000000000000000000000000000000000000000000000000000000000000",
+    "seq_bond": "5000000000000",
+    "is_preferred_sequencer": true
+  }
+}

--- a/devnet/rollup.toml
+++ b/devnet/rollup.toml
@@ -1,0 +1,98 @@
+# Ligate Chain devnet rollup config.
+#
+# Boots a single-node devnet against MockDa (in-process DA via SQLite)
+# with mock zkVM proving. Production targets — Celestia DA (Phase
+# A.3), real proving (Phase A.4) — get their own config files when
+# they land.
+#
+# Run with:
+#   cargo run --bin ligate-node \
+#     --rollup-config-path devnet/rollup.toml \
+#     --genesis-config-dir   devnet/genesis
+#
+# All paths relative to wherever the node is invoked from. The
+# defaults below assume you run from the repo root.
+
+[da]
+# In-process MockDa backed by SQLite. Use `mode=memory` if you want
+# an ephemeral chain that resets on every restart.
+connection_string = "sqlite://devnet/data/da.sqlite?mode=rwc"
+# 32-byte hex address the node uses to "post" blobs on the mock DA
+# layer. Matches `seq_da_address` in `genesis/sequencer_registry.json`.
+sender_address = "0000000000000000000000000000000000000000000000000000000000000000"
+# Instant finality — every produced block is final. Fine for a
+# single-node devnet.
+finalization_blocks = 0
+
+[da.block_producing.periodic]
+# 1s block time — fast enough for interactive demos, slow enough that
+# logs are readable.
+block_time_ms = 1000
+
+[storage]
+# Rollup's data directory. RocksDB lives under `<path>/{user,kernel}-db`,
+# the ledger under `<path>/ledger-db`.
+path = "devnet/data"
+# 4 GiB in-memory state cache. Way more than the devnet needs but
+# matches what the SDK demo ships and keeps slot processing fast.
+state_cache_size = 4294967296
+user_commit_concurrency = 4
+# 15M expected state entries. Sized for a devnet — production
+# revisits this once we know real workload shape.
+user_hashtable_buckets = 15_000_000
+user_preallocate_ht = false
+kernel_commit_concurrency = 2
+# Keep the last 20 versions queryable; prune anything older every
+# 100 DA blocks.
+pruner_block_interval = 100
+pruner_versions_to_keep = 20
+
+[runner]
+# Poll the DA layer 20 times per block (50ms × 20 = 1000ms = 1
+# block). Catches new blobs with negligible latency.
+da_polling_interval_ms = 50
+
+[runner.http_config]
+bind_host = "127.0.0.1"
+bind_port = 12346
+
+[monitoring]
+# Telegraf endpoint (UDP). The devnet doesn't need metrics shipping;
+# pointing at a port nothing's listening on is harmless — UDP just
+# drops the packets.
+telegraf_address = "udp://127.0.0.1:8094"
+tokio_runtime_metrics_interval_millis = 500
+
+[proof_manager]
+aggregated_proof_block_jump = 1
+# Same Anvil dev address as the bootstrap actor. It receives
+# proving rewards in zk mode (chosen via `chain_state.json`).
+prover_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+max_number_of_transitions_in_db = 100
+max_number_of_transitions_in_memory = 30
+
+[sequencer]
+blob_processing_timeout_secs = 3000
+max_batch_size_bytes = 1048576
+max_concurrent_blobs = 128
+max_allowed_node_distance_behind = 10
+# The devnet sequencer is the same Anvil dev actor that owns the
+# treasury / attester / prover roles. Single-actor genesis simplifies
+# the boot story.
+rollup_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+[sequencer.preferred]
+# TODO: drop once Sovereign-Labs/sovereign-sdk-wip#2814 lands.
+disable_state_root_consistency_checks = true
+recovery_strategy = "TryToSave"
+batch_execution_time_limit_millis = 2000
+num_cache_warmup_workers = 0
+ideal_lag_behind_finalized_slot = 3
+
+[sequencer.extension]
+# `RollupConfig::extension_or_panic()` is called from
+# `FullNodeBlueprint::sequencer_additional_apis`. We don't override
+# that hook, so the field is unused — but the SDK still requires the
+# section to exist. Keep this matching the demo so any future
+# override picks up sensible defaults.
+max_log_limit = 20000


### PR DESCRIPTION
## Summary

Final slice of Phase A.2 (#13, #63). With the rollup binary in place from #67, this PR ships a checked-in `devnet/` directory so `cargo run --bin ligate-node` boots end-to-end against real config files. Phase A.2 is now feature-complete.

### What's in

**`devnet/` (12 new files):**

| file | purpose |
|---|---|
| `rollup.toml` | node config — storage, DA (sqlite mock), sequencer, proof manager, monitoring. Inline-annotated. |
| `README.md` | bootstrap actor table, `$LGT` layout, what's intentionally not here yet |
| `.gitignore` | excludes runtime `data/` (RocksDB + SQLite) |
| `genesis/bank.json` | gas token `$LGT` (9 decimals), 120M genesis supply across treasury + 2 dev wallets |
| `genesis/accounts.json` | empty accounts, custom credential mappings on |
| `genesis/sequencer_registry.json` | bootstrap sequencer with 5 000 LGT bond |
| `genesis/operator_incentives.json` | reward address |
| `genesis/attester_incentives.json` | bootstrap attester with 1 000 LGT bond, 5-slot finality |
| `genesis/prover_incentives.json` | bootstrap prover with 1 000 LGT bond |
| `genesis/chain_state.json` | `operating_mode: zk`, default mock code commitments |
| `genesis/attestation.json` | treasury, `lgt_token_id` matching `config_gas_token_id()`, fees in nano-LGT |

Bootstrap actor is Anvil dev account #0 (`0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`) — same address fills every role at genesis (treasury, sequencer, attester, prover, operator). Anvil #1 / #2 also seeded with `$LGT` for transfer testing.

**`crates/rollup/src/main.rs` (+12 lines):** auto-\`mkdir -p\` the storage path before SDK components reach into it. Without this, first-run errors out on \`SQLite: unable to open database file\` because the parent dir doesn't exist yet.

**`crates/rollup/tests/devnet_config.rs` (new, 60 lines):** 2 integration tests loading the checked-in TOML + JSONs through the same code paths the binary uses. Catches drift between SDK config types and our committed configs.

### End-to-end boot proven

\`cargo run --bin ligate-node\` against the checked-in devnet:

- ✅ Parsed \`devnet/rollup.toml\`
- ✅ Auto-created \`devnet/data/\`
- ✅ Loaded all 8 genesis JSONs via \`create_genesis_config\`
- ✅ Passed cross-module validation (\`attestation.lgt_token_id == config_gas_token_id()\`)
- ✅ Initialized RocksDB + NOMT storage manager
- ✅ Initialized SQLite mock DA layer
- ✅ Started block production (1s slot time)
- ✅ Computed state roots for blocks 1, 2, … and submitted batches
- ✅ Clean shutdown on SIGTERM

### Honest scope notes

1. **\`CHAIN_HASH = [0u8; 32]\` placeholder still.** Closed devnet only — anyone with the same SDK pin and matching JSONs would produce a hash-compatible chain. Production-readiness blocked on the build-script slice that derives \`CHAIN_HASH\` from the runtime's universal-wallet schema.
2. **\`initial_attestor_sets\` and \`initial_schemas\` empty.** Schema registration via post-genesis tx exercises the same code path; no fixture maintenance burden, and it forces the live registration UX to actually work.
3. **Single-node only.** MockDa is in-process. Multi-node story requires Celestia (Phase A.3).
4. **Operating mode is \`zk\`.** Matches the SDK demo. With MockZkvm everything passes anyway, and a real prover swap (Phase A.4) is one runtime config change away.

## Test plan

Local gates (all green):

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo doc --workspace --no-deps --document-private-items\` with \`-D warnings\`
- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo test --workspace --lib --tests\` — **78 passed, 0 failed** (was 76; +2 new in \`ligate-rollup::devnet_config\`)
- [x] \`cargo test --workspace --doc\` — 1 passed
- [x] \`cargo run --bin ligate-node\` boots end-to-end and produces blocks against the checked-in devnet

CI:

- [ ] All 6 jobs green on the PR