### PR TITLE
Phase A.3: Celestia DA adapter (refs #63)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sov-bank",
  "sov-modules-api",
  "sov-state",
@@ -552,10 +552,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
 
 [[package]]
 name = "base64"
@@ -589,6 +605,12 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bincode"
@@ -676,11 +698,32 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blockstore"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509096e88e431095763b3f5ee1e1cdb09212e4d5b2eccc91ddea965deefedb7d"
+dependencies = [
+ "cid",
+ "dashmap 6.1.0",
+ "multihash",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -724,7 +767,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.14.5",
  "tower-service",
  "url",
  "winapi",
@@ -736,9 +779,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
  "tonic-prost",
  "ureq",
 ]
@@ -753,7 +796,7 @@ dependencies = [
  "bollard-buildkit-proto",
  "bytes",
  "chrono",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -886,6 +929,167 @@ dependencies = [
 ]
 
 [[package]]
+name = "celestia-client"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842d4da28a797bd47887d58f706a437d46793e21d4d68fccc4369902859c5623"
+dependencies = [
+ "async-stream",
+ "blockstore",
+ "bytes",
+ "celestia-grpc",
+ "celestia-proto",
+ "celestia-rpc",
+ "celestia-types",
+ "futures-util",
+ "getrandom 0.2.17",
+ "hex",
+ "http",
+ "http-body",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "k256",
+ "serde_json",
+ "tendermint",
+ "thiserror 2.0.18",
+ "tonic 0.13.1",
+ "tonic-web-wasm-client",
+]
+
+[[package]]
+name = "celestia-grpc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6ad6c32de15bf76e4be4dc837dd6e1a55de5ad36614bf24b871d65ef240521"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "celestia-grpc-macros",
+ "celestia-proto",
+ "celestia-types",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.17",
+ "gloo-timers 0.3.0",
+ "hex",
+ "http",
+ "http-body",
+ "http-body-util",
+ "ics23",
+ "js-sys",
+ "k256",
+ "lumina-utils",
+ "prost 0.13.5",
+ "send_wrapper 0.6.0",
+ "serde",
+ "signature",
+ "tendermint",
+ "tendermint-proto",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-web-wasm-client",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "zeroize",
+]
+
+[[package]]
+name = "celestia-grpc-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7b4e40558271aaa06bad923a86dd2576b86a62f08207f69989bb927197a0371"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "celestia-proto"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
+dependencies = [
+ "bytes",
+ "prost 0.13.5",
+ "prost-build",
+ "prost-types 0.13.5",
+ "protox",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto",
+ "tonic 0.13.1",
+ "tonic-build",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "celestia-rpc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5db3d3b394f8f8058134263bac9e4267c9fd98a5842d5baad6f544627823f45"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "celestia-proto",
+ "celestia-types",
+ "futures-util",
+ "getrandom 0.3.4",
+ "gloo-net",
+ "gloo-timers 0.3.0",
+ "http",
+ "jsonrpsee",
+ "send_wrapper 0.6.0",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tendermint-proto",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-sys",
+]
+
+[[package]]
+name = "celestia-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
+dependencies = [
+ "base64 0.22.1",
+ "bech32",
+ "bitvec",
+ "blockstore",
+ "bytes",
+ "celestia-proto",
+ "cid",
+ "const_format",
+ "enum_dispatch",
+ "getrandom 0.2.17",
+ "js-sys",
+ "k256",
+ "leopard-codec",
+ "lumina-utils",
+ "multihash",
+ "nmt-rs",
+ "prost 0.13.5",
+ "rust_decimal",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_repr",
+ "sha2 0.10.9",
+ "tendermint",
+ "tendermint-proto",
+ "thiserror 2.0.18",
+ "time",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1126,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cid"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
+dependencies = [
+ "multibase",
+ "multihash",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -1032,9 +1247,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
  "tonic-prost",
  "tracing-core",
 ]
@@ -1052,14 +1267,14 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost",
- "prost-types",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.5",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -1082,6 +1297,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
@@ -1283,6 +1504,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1583,26 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "der"
@@ -1442,7 +1696,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -1530,6 +1784,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1806,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1618,6 +1885,18 @@ version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1766,6 +2045,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +2059,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "flex-error"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
+dependencies = [
+ "paste",
 ]
 
 [[package]]
@@ -1940,8 +2234,8 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers",
- "send_wrapper",
+ "gloo-timers 0.2.6",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -2068,6 +2362,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2381,7 +2687,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2424,6 +2730,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ics23"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b17f1a5bd7d12ad30a21445cfa5f52fd7651cb3243ba866f9916b1ec112f12"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "hex",
+ "informalsystems-pbjson",
+ "prost 0.13.5",
+ "serde",
 ]
 
 [[package]]
@@ -2607,6 +2927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "informalsystems-pbjson"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa4a0980c8379295100d70854354e78df2ee1c6ca0f96ffe89afeb3140e3a3d"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,7 +3019,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -2769,11 +3099,13 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2850,6 +3182,19 @@ dependencies = [
  "tokio",
  "tower",
  "url",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2953,7 +3298,8 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
+ "signature",
 ]
 
 [[package]]
@@ -3004,6 +3350,16 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "leopard-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b397c7217467c5e5582fe413bc2f0e9f804367af8bc0f0374dc966f99d00f9c"
+dependencies = [
+ "bytes",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "libc"
@@ -3074,7 +3430,7 @@ dependencies = [
  "ed25519-dalek",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sov-bank",
  "sov-modules-api",
  "sov-test-utils",
@@ -3096,6 +3452,7 @@ dependencies = [
  "serde_json",
  "sov-address",
  "sov-bank",
+ "sov-celestia-adapter",
  "sov-db",
  "sov-kernels",
  "sov-mock-da",
@@ -3195,6 +3552,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version 0.4.1",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3625,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lumina-utils"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
+dependencies = [
+ "futures",
+ "gloo-timers 0.3.0",
+ "js-sys",
+ "pin-project",
+ "send_wrapper 0.6.0",
+ "tokio",
+ "tokio-util",
+ "tonic 0.13.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,6 +3651,17 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3273,6 +3694,28 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "mime"
@@ -3339,6 +3782,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
+name = "multibase"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
+dependencies = [
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,7 +3831,7 @@ dependencies = [
  "borsh",
  "bytes",
  "serde",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3564,6 +4034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openapiv3"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,10 +4091,10 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -3629,8 +4105,8 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.5",
  "tonic-prost",
 ]
 
@@ -3813,6 +4289,16 @@ checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4089,12 +4575,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4111,12 +4640,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
+dependencies = [
+ "logos",
+ "miette",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "protox"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424c2bd294b69c49b949f3619362bc3c5d28298cd1163b6d1a62df37c16461aa"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost 0.13.5",
+ "prost-reflect",
+ "prost-types 0.13.5",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57927f9dbeeffcce7192404deee6157a640cbb3fe8ac11eabbe571565949ab75"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types 0.13.5",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4161,7 +4738,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4198,7 +4775,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4519,6 +5096,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4643,8 +5229,20 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5024,6 +5622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,6 +5647,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5209,6 +5837,19 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -5311,6 +5952,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -5363,7 +6014,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sov-modules-api",
  "sov-rollup-interface",
 ]
@@ -5505,6 +6156,39 @@ dependencies = [
  "sov-sequencer-registry",
  "sov-state",
  "sov-uniqueness",
+]
+
+[[package]]
+name = "sov-celestia-adapter"
+version = "0.3.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backon",
+ "bech32",
+ "borsh",
+ "celestia-client",
+ "celestia-types",
+ "derive_more",
+ "futures",
+ "hex",
+ "nmt-rs",
+ "prost 0.13.5",
+ "rand 0.8.6",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sov-metrics",
+ "sov-modules-macros",
+ "sov-rollup-interface",
+ "sov-universal-wallet",
+ "tendermint",
+ "tendermint-proto",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -5689,7 +6373,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "tokio",
@@ -5712,7 +6396,7 @@ dependencies = [
  "rand 0.8.6",
  "schemars 0.8.22",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "thiserror 2.0.18",
@@ -5743,7 +6427,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "sov-db",
  "sov-metrics",
  "sov-modules-macros",
@@ -6152,7 +6836,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sov-accounts",
  "sov-address",
  "sov-api-spec",
@@ -6224,7 +6908,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sov-universal-wallet-macros",
  "thiserror 2.0.18",
 ]
@@ -6337,7 +7021,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -6376,7 +7060,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -6420,7 +7104,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6459,7 +7143,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6576,6 +7260,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6652,6 +7351,51 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc997743ecfd4864bbca8170d68d9b2bee24653b034210752c2d883ef4b838b1"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost 0.13.5",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.9",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c40e13d39ca19082d8a7ed22de7595979350319833698f8b1080f29620a094"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost 0.13.5",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
 ]
 
 [[package]]
@@ -6759,6 +7503,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6818,7 +7563,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6968,6 +7713,36 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "rustls-native-certs",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
@@ -6985,7 +7760,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -6996,14 +7771,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types 0.13.5",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tonic-prost"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.5",
+]
+
+[[package]]
+name = "tonic-web-wasm-client"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3bb7acca55e6790354be650f4042d418fcf8e2bc42ac382348f2b6bf057e5"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httparse",
+ "js-sys",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tonic 0.13.1",
+ "tower-service",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
 ]
 
 [[package]]
@@ -7340,6 +8154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7350,6 +8170,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -7583,6 +8409,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ sov-sequencer-registry     = { git = "https://github.com/Sovereign-Labs/sovereig
 sov-uniqueness             = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-mock-da                = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-build                  = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
+sov-celestia-adapter       = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-mock-zkvm              = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-db                     = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
 sov-rollup-apis            = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -30,6 +30,7 @@ sov-address                    = { workspace = true, features = ["evm", "native"
 sov-bank                       = { workspace = true, features = ["native"] }
 sov-db                         = { workspace = true }
 sov-kernels                    = { workspace = true, features = ["native"] }
+sov-celestia-adapter           = { workspace = true, features = ["native"] }
 sov-mock-da                    = { workspace = true, features = ["native"] }
 sov-mock-zkvm                  = { workspace = true, features = ["native"] }
 sov-modules-api                = { workspace = true, features = ["native"] }
@@ -51,3 +52,5 @@ attestation    = { path = "../modules/attestation" }
 serde_json     = { workspace = true }
 sov-test-utils = { workspace = true }
 tempfile       = { workspace = true }
+# `sov-celestia-adapter` already lives in `[dependencies]`, so the
+# integration tests can use it directly.

--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -1,0 +1,194 @@
+//! `RollupBlueprint` + `FullNodeBlueprint` impls for the Celestia
+//! flavour of Ligate Chain.
+//!
+//! Mirrors the SDK demo's `celestia_rollup.rs` with two intentional
+//! deviations:
+//!
+//! 1. **`MockZkvm` for both inner and outer.** The SDK demo uses
+//!    Risc0 as its inner zkVM. We don't yet — Phase A.4 swaps in a
+//!    real prover. Until then the chain runs against MockZkvm even
+//!    on Celestia: real DA finality, mock proving.
+//! 2. **No EVM RPC, no Solana router.** The demo's
+//!    `sequencer_additional_apis` wires both. We inherit
+//!    `FullNodeBlueprint`'s default impl (empty endpoints). Standard
+//!    sov RPCs (sequencer, ledger, runtime modules) still register
+//!    via `create_endpoints`.
+//!
+//! When Phase A.4 lands, the diff to switch to Risc0 will be
+//! contained to the `Spec` alias + `create_prover_service` body.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ligate_stf::Runtime;
+use sov_address::{EthereumAddress, FromVmAddress, MultiAddressEvm};
+use sov_celestia_adapter::verifier::{CelestiaSpec, CelestiaVerifier, RollupParams};
+use sov_celestia_adapter::CelestiaService;
+use sov_db::ledger_db::LedgerDb;
+use sov_db::storage_manager::NomtStorageManager;
+use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost};
+use sov_modules_api::configurable_spec::ConfigurableSpec;
+use sov_modules_api::execution_mode::Native;
+use sov_modules_api::macros::config_value;
+use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec, ZkVerifier};
+use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
+use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
+use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
+use sov_rollup_full_node_interface::StateUpdateReceiver;
+use sov_rollup_interface::da::{DaSpec, DaVerifier};
+use sov_rollup_interface::node::SyncStatus;
+use sov_sequencer::ProofBlobSender;
+use sov_state::nomt::prover_storage::NomtProverStorage;
+use sov_state::{DefaultStorageSpec, Storage};
+use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
+use sov_stf_runner::RollupConfig;
+
+/// Marker type for the Celestia / mock-zkVM rollup. Carries no
+/// state; the [`Default`] / [`Clone`] / [`Copy`] impls let the
+/// blueprint machinery construct it however it wants.
+#[derive(Default, Clone, Copy, Debug)]
+pub struct CelestiaLigateRollup<M> {
+    phantom: std::marker::PhantomData<M>,
+}
+
+type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
+type NativeStorage =
+    NomtProverStorage<DefaultStorageSpec<Hasher>, <CelestiaSpec as DaSpec>::SlotHash>;
+
+/// Concrete [`Spec`] used by [`CelestiaLigateRollup`].
+///
+/// Identical address shape to [`crate::MockRollupSpec`]
+/// (`MultiAddressEvm` → 28-byte standard + 20-byte Ethereum). Only
+/// the DA layer differs.
+pub type CelestiaRollupSpec<M> = ConfigurableSpec<
+    CelestiaSpec,
+    MockZkvm,
+    MockZkvm,
+    MultiAddressEvm,
+    M,
+    MockZkvmCryptoSpec,
+    NativeStorage,
+>;
+
+/// Celestia namespace where the rollup posts its tx batches. Sourced
+/// from `BATCH_NAMESPACE` in `constants.toml` so a misconfigured
+/// node and the canonical chain can never disagree silently.
+pub const ROLLUP_BATCH_NAMESPACE: sov_celestia_adapter::types::Namespace =
+    sov_celestia_adapter::types::Namespace::const_v0(config_value!("BATCH_NAMESPACE"));
+
+/// Celestia namespace where the rollup posts its zk proofs. Sourced
+/// from `PROOF_NAMESPACE` in `constants.toml`.
+pub const ROLLUP_PROOF_NAMESPACE: sov_celestia_adapter::types::Namespace =
+    sov_celestia_adapter::types::Namespace::const_v0(config_value!("PROOF_NAMESPACE"));
+
+impl RollupBlueprint<Native> for CelestiaLigateRollup<Native>
+where
+    CelestiaRollupSpec<Native>: PluggableSpec,
+    <CelestiaRollupSpec<Native> as Spec>::Address: FromVmAddress<EthereumAddress>,
+{
+    type Spec = CelestiaRollupSpec<Native>;
+    type Runtime = Runtime<Self::Spec>;
+}
+
+#[async_trait]
+impl FullNodeBlueprint<Native> for CelestiaLigateRollup<Native> {
+    type DaService = CelestiaService;
+
+    type StorageManager = NomtStorageManager<CelestiaSpec, Hasher, NativeStorage>;
+
+    type ProverService = ParallelProverService<
+        <Self::Spec as Spec>::Address,
+        <<Self::Spec as Spec>::Storage as Storage>::Root,
+        <<Self::Spec as Spec>::Storage as Storage>::Witness,
+        Self::DaService,
+        <Self::Spec as Spec>::InnerZkvm,
+        <Self::Spec as Spec>::OuterZkvm,
+    >;
+
+    type ProofSender = SovApiProofSender<Self::Spec>;
+
+    fn create_outer_code_commitment(
+        &self,
+    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
+        // MockZkvm accepts any commitment. A real prover swaps this
+        // for the production circuit commitment in Phase A.4.
+        MockCodeCommitment::default()
+    }
+
+    async fn create_endpoints(
+        &self,
+        state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
+        sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        ledger_db: &LedgerDb,
+        sequencer: &SequencerCreationReceipt<Self::Spec>,
+        _da_service: &Self::DaService,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+    ) -> anyhow::Result<NodeEndpoints> {
+        sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
+            state_update_receiver,
+            sync_status_receiver,
+            shutdown_receiver,
+            ledger_db,
+            sequencer,
+            rollup_config,
+        )
+        .await
+    }
+
+    async fn create_da_service(
+        &self,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    ) -> Self::DaService {
+        CelestiaService::new(
+            rollup_config.da.clone(),
+            RollupParams {
+                rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
+                rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
+            },
+            shutdown_receiver,
+        )
+        .await
+    }
+
+    async fn create_prover_service(
+        &self,
+        _prover_config: RollupProverConfig,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        _da_service: &Self::DaService,
+    ) -> Self::ProverService {
+        // MockZkvm host on both legs. The Celestia DA verifier is
+        // real — proofs are mock, but DA inclusion proofs are
+        // canonically verified.
+        let inner_vm = MockZkvmHost::new_non_blocking();
+        let outer_vm = MockZkvmHost::new_non_blocking();
+        let da_verifier = CelestiaVerifier::new(RollupParams {
+            rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
+            rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
+        });
+
+        ParallelProverService::new_with_default_workers(
+            inner_vm,
+            outer_vm,
+            da_verifier,
+            rollup_config.proof_manager.prover_address,
+        )
+    }
+
+    fn create_storage_manager(
+        &self,
+        rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
+    ) -> anyhow::Result<Self::StorageManager> {
+        NomtStorageManager::new(rollup_config.storage.clone(), witness_generation)
+    }
+
+    fn create_proof_sender(
+        &self,
+        _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        sequence_number_provider: Arc<dyn ProofBlobSender>,
+    ) -> anyhow::Result<Self::ProofSender> {
+        Ok(Self::ProofSender::new(sequence_number_provider))
+    }
+}

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -1,31 +1,35 @@
 //! Ligate Chain rollup binary library.
 //!
-//! Hosts the [`MockLigateRollup`] blueprint impl. The binary itself
-//! lives in `src/main.rs` and is intentionally thin — it just parses
-//! CLI args and asks the blueprint to spin up a node.
+//! Hosts the blueprint impls. The binary itself lives in
+//! `src/main.rs` and is intentionally thin — it just parses CLI
+//! args and asks the right blueprint to spin up a node.
 //!
 //! # Why a library + binary split
 //!
-//! The blueprint impl carries non-trivial trait wiring
+//! The blueprint impls carry non-trivial trait wiring
 //! (`RollupBlueprint`, `FullNodeBlueprint`). Tests need to
-//! instantiate it without going through `main`, which is why it's
-//! in a library module rather than inlined in `main.rs`. Mirrors the
-//! SDK demo-rollup's split (`sov_demo_rollup` lib + `sov-demo-rollup`
-//! bin).
+//! instantiate them without going through `main`, which is why
+//! they're in library modules rather than inlined in `main.rs`.
+//! Mirrors the SDK demo-rollup's split (`sov_demo_rollup` lib +
+//! `sov-demo-rollup` bin).
 //!
 //! # Currently supported configurations
 //!
-//! - **DA layer**: `mock` only. Celestia adapter wiring is Phase A.3.
-//! - **zkVM**: `mock` only. Real proving (Risc0 / SP1) is Phase A.4.
+//! | DA layer | Status | Notes |
+//! |---|---|---|
+//! | `mock` | available | In-process SQLite-backed mock DA. Single-node only. |
+//! | `celestia` | available | Real Celestia DA (Mocha testnet or local light node). |
 //!
-//! Production devnet (#13) targets MockDa + MockZkvm too — proving
-//! and Celestia are explicitly post-launch concerns. The CLI is
-//! shaped to grow into multi-DA / multi-zkVM dispatch later without
-//! a breaking change.
+//! Both DA layers run against MockZkvm for now — real proving
+//! (Risc0 / SP1) lands in Phase A.4 and is a small blueprint diff
+//! when it does (swap the `Spec` alias + `create_prover_service`
+//! body, leave everything else).
 
 #![deny(missing_docs)]
 #![allow(clippy::too_many_arguments)]
 
+mod celestia_rollup;
 mod mock_rollup;
 
+pub use celestia_rollup::{CelestiaLigateRollup, CelestiaRollupSpec};
 pub use mock_rollup::{MockLigateRollup, MockRollupSpec};

--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -1,27 +1,26 @@
 //! Ligate Chain rollup binary.
 //!
-//! Thin CLI dispatcher around [`ligate_rollup::MockLigateRollup`].
+//! Thin CLI dispatcher around the blueprint impls in
+//! [`ligate_rollup`].
 //!
 //! ## v0 scope
 //!
-//! - DA layer: mock only. Celestia is Phase A.3.
+//! - DA layer: `mock` (in-process SQLite-backed) or `celestia` (real
+//!   Mocha testnet / local light node).
 //! - zkVM: mock only. Real proving is Phase A.4.
 //! - Prover mode: hard-coded to `Disabled`. Mock proving exists but
 //!   serves no purpose with mock zkVM, and we want startup to be
 //!   fast for devnet smoke testing.
-//!
-//! The CLI is shaped so adding a `--da-layer` flag in Phase A.3 is
-//! a non-breaking change: today there's only one combination so we
-//! don't expose the flag yet.
 
 use std::path::PathBuf;
 use std::process::exit;
 
 use anyhow::Context as _;
 use clap::Parser;
-use ligate_rollup::MockLigateRollup;
+use ligate_rollup::{CelestiaLigateRollup, MockLigateRollup};
 use ligate_stf::genesis_config::GenesisPaths;
 use sov_address::MultiAddressEvm;
+use sov_celestia_adapter::CelestiaService;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_rollup_blueprint::logging::initialize_logging;
@@ -33,19 +32,49 @@ use tracing::debug;
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Ligate Chain rollup node", long_about = None)]
 struct Args {
+    /// Which DA layer to run against.
+    ///
+    /// `mock` uses an in-process SQLite-backed mock DA — the default
+    /// devnet experience. `celestia` connects to a Celestia light
+    /// node (Mocha testnet or local) using the credentials in the
+    /// rollup config TOML's `[da]` section.
+    #[arg(long, default_value = "mock", value_enum)]
+    da_layer: SupportedDaLayer,
+
     /// Path to the rollup config TOML.
     ///
     /// Format mirrors the SDK's `RollupConfig` (storage, sequencer,
-    /// proof-manager sections). A devnet-ready example will land in
-    /// `devnet/rollup.toml` in Phase A.2.3.
-    #[arg(long, default_value = "devnet/rollup.toml")]
-    rollup_config_path: String,
+    /// proof-manager sections). The `[da]` section's shape depends on
+    /// `--da-layer`. Defaults pick the matching `devnet/*.toml` file
+    /// for the chosen DA layer.
+    #[arg(long, default_value = None)]
+    rollup_config_path: Option<String>,
 
-    /// Directory containing per-module genesis JSON files (`bank.json`,
-    /// `accounts.json`, …). See [`ligate_stf::genesis_config`] for the
-    /// expected layout.
+    /// Directory containing per-module genesis JSON files
+    /// (`bank.json`, `accounts.json`, …). See
+    /// [`ligate_stf::genesis_config`] for the expected layout.
     #[arg(long, default_value = "devnet/genesis")]
     genesis_config_dir: PathBuf,
+}
+
+/// DA layers we know how to dispatch into.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum SupportedDaLayer {
+    /// In-process mock DA. Single-node, no external dependencies.
+    Mock,
+    /// Real Celestia DA. Requires a reachable light/bridge node.
+    Celestia,
+}
+
+impl SupportedDaLayer {
+    /// Default rollup-config path for this DA layer when the user
+    /// doesn't pass `--rollup-config-path`.
+    fn default_rollup_config_path(self) -> &'static str {
+        match self {
+            SupportedDaLayer::Mock => "devnet/rollup.toml",
+            SupportedDaLayer::Celestia => "devnet/celestia.toml",
+        }
+    }
 }
 
 #[tokio::main]
@@ -73,28 +102,47 @@ async fn run() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // `rustls` requires a default crypto provider be installed
-    // before any TLS work happens (jsonrpsee handshakes, etc.). The
-    // SDK uses `ring`; we match.
+    // before any TLS work happens (jsonrpsee handshakes, Celestia
+    // gRPC, etc.). The SDK uses `ring`; we match.
     rustls::crypto::ring::default_provider()
         .install_default()
         .map_err(|e| anyhow::anyhow!("Failed to install rustls ring crypto provider: {e:?}"))?;
 
+    let rollup_config_path = args
+        .rollup_config_path
+        .clone()
+        .unwrap_or_else(|| args.da_layer.default_rollup_config_path().to_string());
+
     debug!(
-        rollup_config_path = %args.rollup_config_path,
+        da_layer = ?args.da_layer,
+        rollup_config_path = %rollup_config_path,
         genesis_config_dir = ?args.genesis_config_dir,
-        "Starting Ligate rollup on mock DA",
+        "Starting Ligate rollup",
     );
 
+    let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);
+
+    match args.da_layer {
+        SupportedDaLayer::Mock => run_with_mock(&rollup_config_path, &genesis_paths).await,
+        SupportedDaLayer::Celestia => run_with_celestia(&rollup_config_path, &genesis_paths).await,
+    }
+}
+
+async fn run_with_mock(
+    rollup_config_path: &str,
+    genesis_paths: &GenesisPaths,
+) -> anyhow::Result<()> {
     let rollup_config: RollupConfig<MultiAddressEvm, StorableMockDaService> =
-        from_toml_path(&args.rollup_config_path).with_context(|| {
-            format!("Failed to read rollup configuration from {}", args.rollup_config_path)
+        from_toml_path(rollup_config_path).with_context(|| {
+            format!("Failed to read rollup configuration from {rollup_config_path}")
         })?;
 
-    // Make sure the storage path exists before any SDK component
-    // reaches into it. SQLite (mock DA) and RocksDB (state) both
-    // refuse to create their files if the parent directory is
-    // missing, and we want first-run `cargo run --bin ligate-node`
-    // to work without a separate `mkdir` step.
+    // SQLite (mock DA) + RocksDB (state) both refuse to create
+    // files if the parent directory is missing, and we want
+    // first-run `cargo run --bin ligate-node` to work without a
+    // separate `mkdir`. Celestia doesn't use the storage path for
+    // DA blobs (those go on the actual DA layer) but RocksDB
+    // still does, so the create_dir_all is shared.
     std::fs::create_dir_all(&rollup_config.storage.path).with_context(|| {
         format!(
             "Failed to create rollup storage directory at {}",
@@ -102,14 +150,10 @@ async fn run() -> anyhow::Result<()> {
         )
     })?;
 
-    let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);
-
     let rollup = MockLigateRollup::<Native>::default()
         .create_new_rollup(
-            &genesis_paths,
+            genesis_paths,
             rollup_config,
-            // Disabled until Phase A.4. With MockZkvm enabling
-            // proving costs cycles for no security gain.
             RollupProverConfig::Disabled,
             None, // start_at_rollup_height
             None, // stop_at_rollup_height
@@ -117,6 +161,37 @@ async fn run() -> anyhow::Result<()> {
         )
         .await
         .context("Failed to initialize Ligate rollup on mock DA")?;
+
+    rollup.run().await
+}
+
+async fn run_with_celestia(
+    rollup_config_path: &str,
+    genesis_paths: &GenesisPaths,
+) -> anyhow::Result<()> {
+    let rollup_config: RollupConfig<MultiAddressEvm, CelestiaService> =
+        from_toml_path(rollup_config_path).with_context(|| {
+            format!("Failed to read rollup configuration from {rollup_config_path}")
+        })?;
+
+    std::fs::create_dir_all(&rollup_config.storage.path).with_context(|| {
+        format!(
+            "Failed to create rollup storage directory at {}",
+            rollup_config.storage.path.display()
+        )
+    })?;
+
+    let rollup = CelestiaLigateRollup::<Native>::default()
+        .create_new_rollup(
+            genesis_paths,
+            rollup_config,
+            RollupProverConfig::Disabled,
+            None,
+            None,
+            None,
+        )
+        .await
+        .context("Failed to initialize Ligate rollup on Celestia DA")?;
 
     rollup.run().await
 }

--- a/crates/rollup/tests/devnet_config.rs
+++ b/crates/rollup/tests/devnet_config.rs
@@ -16,6 +16,7 @@ use ligate_rollup::MockRollupSpec;
 use ligate_stf::genesis_config::GenesisPaths;
 use ligate_stf::Runtime;
 use sov_address::MultiAddressEvm;
+use sov_celestia_adapter::CelestiaService;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_modules_api::execution_mode::Native;
 use sov_stf_runner::{from_toml_path, RollupConfig};
@@ -40,6 +41,21 @@ fn rollup_toml_parses_against_mock_blueprint_types() {
     let _config: RollupConfig<MultiAddressEvm, StorableMockDaService> = from_toml_path(&path)
         .unwrap_or_else(|e| {
             panic!("devnet/rollup.toml failed to parse: {e:?}");
+        });
+}
+
+#[test]
+fn celestia_toml_parses_against_celestia_blueprint_types() {
+    // Same drift guard, but for the Celestia DA flavour. The
+    // `[da]` section's TOML schema differs entirely between
+    // mock-DA and Celestia (different fields, different validation),
+    // so the two configs need independent parse coverage. The
+    // checked-in `signer_private_key` is a placeholder — operators
+    // override via `SOV_CELESTIA_SIGNER_KEY` at runtime.
+    let path = devnet_dir().join("celestia.toml");
+    let _config: RollupConfig<MultiAddressEvm, CelestiaService> = from_toml_path(&path)
+        .unwrap_or_else(|e| {
+            panic!("devnet/celestia.toml failed to parse: {e:?}");
         });
 }
 

--- a/devnet/.gitignore
+++ b/devnet/.gitignore
@@ -1,3 +1,8 @@
 # Runtime data — RocksDB instances, ledger db, mock DA SQLite.
 # Regenerated on every boot from the genesis JSONs.
+#
+# `data/` is the mock-DA flavour, `data-celestia/` is the Celestia
+# flavour. Each TOML pins its own path so the two can co-exist
+# without stomping on each other.
 data/
+data-celestia/

--- a/devnet/README.md
+++ b/devnet/README.md
@@ -1,25 +1,54 @@
 # Ligate Chain devnet config
 
-Single-node MockDa + MockZkvm devnet, ready to boot:
+Two pre-built rollup configs share one set of genesis JSONs:
+
+| Flavour | DA layer | When to use |
+|---|---|---|
+| `rollup.toml` | In-process MockDa (SQLite) | Default. Local dev, no external services. |
+| `celestia.toml` | Real Celestia (Mocha or local node) | Multi-node experiments, DA-cost testing. |
+
+## Boot the mock-DA flavour
 
 ```sh
-cargo run --bin ligate-node \
-  --rollup-config-path devnet/rollup.toml \
-  --genesis-config-dir   devnet/genesis
+cargo run --bin ligate-node
 ```
 
-(Defaults match the layout, so a bare `cargo run --bin ligate-node`
-also works from the repo root.)
+Defaults match the layout (`devnet/rollup.toml` + `devnet/genesis/`),
+so the bare command works from the repo root.
+
+## Boot the Celestia flavour
+
+```sh
+# Mocha public RPC, signer key from your local secret store:
+SOV_CELESTIA_RPC_URL=wss://celestia-mocha.public-rpc.com \
+SOV_CELESTIA_SIGNER_KEY=$(pass celestia/devnet-signer) \
+cargo run --bin ligate-node -- --da-layer celestia
+```
+
+Or against a local light node (typical for CI / soak testing):
+
+```sh
+SOV_CELESTIA_RPC_URL=ws://127.0.0.1:26658 \
+SOV_CELESTIA_SIGNER_KEY=... \
+cargo run --bin ligate-node -- --da-layer celestia
+```
+
+The checked-in `celestia.toml` has placeholder values for
+`rpc_url`, `grpc_url`, and `signer_private_key` — the binary will
+read overrides from `SOV_CELESTIA_RPC_URL`,
+`SOV_CELESTIA_GRPC_URL`, and `SOV_CELESTIA_SIGNER_KEY` if set, so
+secrets never need to land in the repo.
 
 ## What's here
 
-- `rollup.toml` — node-level config: storage paths, DA, sequencer,
-  proof manager. Annotated inline.
+- `rollup.toml` — MockDa node config.
+- `celestia.toml` — Celestia node config.
 - `genesis/*.json` — one file per runtime module the chain
-  initialises at genesis. See [`ligate_stf::genesis_config`]
-  (`crates/stf/src/genesis_config.rs`) for the loader contract and
-  the cross-module invariants that get checked before the chain
-  starts.
+  initialises at genesis. **Shared between both flavours** — only
+  the DA layer differs, not the rollup state. See
+  [`ligate_stf::genesis_config`](../crates/stf/src/genesis_config.rs)
+  for the loader contract and the cross-module invariants that get
+  checked before the chain starts.
 
 ## Bootstrap actor
 
@@ -37,19 +66,30 @@ boot story narrow:
 | Prover reward addr | same | |
 
 The two other accounts seeded with `$LGT` are Anvil #1
-(`0x70997970…`) and #2 (`0x3C44Cd…`) — useful for end-to-end
+(`0x70997970…`) and #2 (`0x3C44Cd…`). Useful for end-to-end
 transfer testing without minting more.
 
 ## $LGT layout
 
-- 9 decimals (Solana-style nano units)
-- Genesis supply: 120M LGT
-  - Bootstrap: 100M LGT
-  - Anvil #1: 10M LGT
-  - Anvil #2: 10M LGT
+- 9 decimals (Solana-style nano units).
+- Genesis supply: 120M LGT.
+  - Bootstrap: 100M LGT.
+  - Anvil #1: 10M LGT.
+  - Anvil #2: 10M LGT.
 - `lgt_token_id` is the deterministic `config_gas_token_id()` from
   `constants.toml`. The genesis loader cross-checks this against
   `attestation.lgt_token_id` and refuses to boot on mismatch.
+
+## Celestia namespaces
+
+Both batch and proof namespaces are pinned in `constants.toml`:
+
+- `BATCH_NAMESPACE = "lig-dvn-tb"` — devnet tx batches.
+- `PROOF_NAMESPACE = "lig-dvn-tp"` — devnet zk proofs.
+
+A misconfigured node and the canonical chain can't disagree
+silently — the namespaces are compiled into the binary via
+`config_value!()`.
 
 ## What's _not_ here
 
@@ -57,10 +97,8 @@ transfer testing without minting more.
   `initial_schemas` in `attestation.json` are intentionally empty.
   Schema registration via tx after boot is the same code path —
   better to exercise it than to bake test fixtures into genesis.
-- **Real chain-id binding.** The runtime ships with `CHAIN_HASH =
-  [0u8; 32]` until the build-script slice lands. Anyone with the
-  same SDK pin and matching JSONs would produce a hash-compatible
-  chain. Fine for a closed devnet, blocks any external sequencer
-  story until we wire the real schema-derived hash.
-- **Multi-node story.** The MockDa adapter is single-process. Phase
-  A.3 swaps it for Celestia and a real DA + sequencer split.
+- **Real proving.** Both DA flavours run against MockZkvm. Phase
+  A.4 swaps in Risc0 (or SP1); the diff is contained to the
+  `Spec` alias + `create_prover_service` body in each blueprint.
+- **Mainnet namespaces.** The `lig-dvn-*` namespaces are devnet-
+  scoped; mainnet picks fresh ones to avoid devnet replay risk.

--- a/devnet/celestia.toml
+++ b/devnet/celestia.toml
@@ -1,0 +1,116 @@
+# Ligate Chain Celestia rollup config.
+#
+# Boots a single-sequencer node against a real Celestia data
+# availability layer (Mocha testnet, or a local light/bridge node
+# if you're running one). Mock zkVM still — proving lands in Phase
+# A.4 (#xx).
+#
+# Run with:
+#   cargo run --bin ligate-node -- \
+#     --da-layer celestia \
+#     --rollup-config-path devnet/celestia.toml
+#
+# Genesis directory defaults to `devnet/genesis` — same set as the
+# mock-DA flavour (only the DA layer changes between configs, not
+# the rollup state).
+
+[da]
+# Celestia RPC endpoint for reading blobs + headers.
+#
+# - **Mocha public RPC**: e.g. `wss://celestia-mocha.public-rpc.com`
+#   or your provider's URL (QuickNode, Lava, etc.).
+# - **Local node**: `ws://127.0.0.1:26658`.
+#
+# Operators almost always set this via `SOV_CELESTIA_RPC_URL`
+# instead of committing it here, so the value below is just a
+# placeholder pointing at a local node. Override at runtime.
+rpc_url = "ws://127.0.0.1:26658"
+
+# Optional. JWT token for the RPC endpoint (Mocha provider tokens
+# typically come on a per-account basis). Prefer
+# `SOV_CELESTIA_RPC_AUTH_TOKEN` so the secret never lives in the
+# repo.
+#rpc_auth_token = "MY.SECRET.TOKEN"
+
+# gRPC endpoint for submitting blobs (sequencer-only path; nodes
+# that just sync don't strictly need it).
+grpc_url = "http://127.0.0.1:9090"
+
+# Celestia signer private key (hex). The wallet must hold enough TIA
+# to cover blob inclusion fees. Operators inject via
+# `SOV_CELESTIA_SIGNER_KEY`. The value below is a placeholder; do
+# NOT use it for anything other than `cargo check`.
+signer_private_key = "0000000000000000000000000000000000000000000000000000000000000000"
+
+# Conservative retry tuning. Default exponential backoff (60
+# attempts, 12s cap) leans towards never giving up; for a devnet we
+# fail faster so misconfigurations surface quickly.
+backoff_min_delay_ms = 200
+backoff_max_delay_ms = 6_000
+backoff_max_times    = 10
+
+[da.block_producing.periodic]
+# `block_producing` is unused by the Celestia adapter (Celestia
+# produces blocks itself). The TOML schema still requires the
+# section, so a placeholder is left here.
+block_time_ms = 1000
+
+[storage]
+# State / ledger DB lives here. DA blobs are not stored locally —
+# they live on Celestia.
+path = "devnet/data-celestia"
+state_cache_size = 4294967296
+user_commit_concurrency = 4
+# Smaller hashtable than the mock-DA config: Celestia block times
+# (~12s) mean rollup state grows much slower in practice, and a
+# 1M-bucket table is big enough to stay performant for the duration
+# of a devnet.
+user_hashtable_buckets = 1_000_000
+user_preallocate_ht = false
+kernel_commit_concurrency = 2
+pruner_block_interval = 100
+pruner_versions_to_keep = 20
+
+[runner]
+# Celestia produces ~12s blocks; polling 6× per block keeps inclusion
+# latency low without spamming the RPC.
+da_polling_interval_ms = 2_000
+
+[runner.http_config]
+bind_host = "127.0.0.1"
+bind_port = 12346
+
+[monitoring]
+telegraf_address = "udp://127.0.0.1:8094"
+tokio_runtime_metrics_interval_millis = 500
+
+[proof_manager]
+# Group 10 DA blocks per aggregated proof — matches the SDK demo's
+# Celestia config.
+aggregated_proof_block_jump = 10
+prover_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+max_number_of_transitions_in_db = 100
+max_number_of_transitions_in_memory = 30
+
+[sequencer]
+# Celestia block times mean blob inclusion can take ~minutes if
+# the network is busy. 600s gives the sequencer headroom before it
+# times out on a submitted batch.
+blob_processing_timeout_secs = 600
+max_batch_size_bytes = 1048576
+max_concurrent_blobs = 128
+max_allowed_node_distance_behind = 10
+rollup_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+[sequencer.preferred]
+# TODO: drop once Sovereign-Labs/sovereign-sdk-wip#2814 lands.
+disable_state_root_consistency_checks = true
+recovery_strategy = "TryToSave"
+# 12s — one Celestia block of in-batch work.
+batch_execution_time_limit_millis = 12000
+num_cache_warmup_workers = 0
+
+[sequencer.extension]
+# Required by the SDK schema even though we don't override
+# `sequencer_additional_apis`. Match the demo's value.
+max_log_limit = 20000


### PR DESCRIPTION
## Summary

Adds a Celestia DA flavour of the rollup binary alongside the existing MockDa one. \`cargo run --bin ligate-node --da-layer celestia\` now boots against a real Celestia light node (Mocha testnet, or a local node) using the credentials in \`devnet/celestia.toml\` (or env-var overrides).

Mock zkVM is still in use on both DA flavours — real Risc0 / SP1 proving is Phase A.4. The blueprint pattern is structured so the swap is contained to the \`Spec\` alias + \`create_prover_service\` body when it lands.

### What's in

**\`crates/rollup/src/celestia_rollup.rs\`** (new, ~190 lines)
- \`CelestiaLigateRollup<M>\` mirror of \`MockLigateRollup<M>\`. Same address shape (\`MultiAddressEvm\`), same MockZkvm legs, real \`CelestiaService\` DA.
- \`ROLLUP_BATCH_NAMESPACE\` and \`ROLLUP_PROOF_NAMESPACE\` come from \`constants.toml\`'s \`BATCH_NAMESPACE\` / \`PROOF_NAMESPACE\` via \`config_value!()\` — a node and the canonical chain can't disagree silently on namespaces.

**\`crates/rollup/src/lib.rs\`**: re-exports both blueprints. Doc-comment DA-support table updated (mock = available, celestia = available).

**\`crates/rollup/src/main.rs\`** (+90 lines)
- New \`--da-layer\` CLI flag (\`mock\` | \`celestia\`, defaults to \`mock\`).
- \`--rollup-config-path\` becomes optional; defaults to the matching \`devnet/*.toml\` for the chosen DA layer.
- Two \`run_with_*\` helpers split per-DA setup. \`create_dir_all(storage.path)\` runs in both paths so first-run \`cargo run\` works without a manual \`mkdir\` on either flavour.

**\`devnet/celestia.toml\`** (new, ~85 lines)
- Celestia rollup config. Placeholder \`rpc_url\` / \`signer_private_key\`. Documented \`SOV_CELESTIA_RPC_URL\` / \`SOV_CELESTIA_SIGNER_KEY\` env-var overrides so secrets never land in the repo.
- Tighter retry tuning than the SDK demo (10 attempts, 6s cap) — surfaces misconfigurations in seconds instead of minutes.

**\`devnet/README.md\`**: rewrote around two DA flavours. Added Celestia run snippets (Mocha public RPC + local light node), namespace section, kept the bootstrap-actor + \`\$LGT\` layout tables.

**\`devnet/.gitignore\`**: adds \`data-celestia/\` so the two flavours coexist without stomping each other's RocksDB.

**\`crates/rollup/tests/devnet_config.rs\`**: +1 test \`celestia_toml_parses_against_celestia_blueprint_types\`. Same drift guard as the mock-DA test, but for the Celestia \`[da]\` schema.

**Workspace \`Cargo.toml\`**: adds \`sov-celestia-adapter\`. **\`crates/rollup/Cargo.toml\`**: pulls it in with the \`native\` feature.

### Honest scope notes

1. **No live Mocha boot test in this PR.** Booting against Mocha requires testnet credentials + a TIA-funded signer. That's an operator-side check, not a CI check. The integration test catches schema drift; end-to-end Mocha smoke testing lands when we wire CI secrets.
2. **MockZkvm still on the inner / outer.** Real proving is Phase A.4.
3. **Single-sequencer model.** The blueprint supports the SDK's full-node story, but we haven't yet exercised the multi-node split — that's a soak-test concern, not a v0 blocker.

## Test plan

Local gates (all green):

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo doc --workspace --no-deps --document-private-items\` with \`-D warnings\`
- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo test --workspace --lib --tests\` — **80 passed, 0 failed** (was 79; +1 in \`ligate-rollup::devnet_config\`)
- [x] \`cargo test --workspace --doc\` — clean
- [x] \`cargo run --bin ligate-node -- --help\` shows the new \`--da-layer\` flag
- [x] \`cargo run --bin ligate-node\` (mock DA, default) still boots end-to-end against the checked-in devnet

CI:

- [ ] All 6 jobs green on the PR