### PR TITLE
Skip code-checking jobs on docs-only PRs via paths-filter + CI summary check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,45 @@ env:
   # shell — it's a per-machine workaround, not a CI-wide one.
 
 jobs:
+  # Detect whether the PR or push touches anything that affects the
+  # Rust build. Docs-only PRs (README, /docs, license, gitignore,
+  # issue templates) don't need fmt/clippy/check/test/doc to run -
+  # they can't change the compile result. The `code` output is
+  # consumed by every code-checking job below; if it's `false`, those
+  # jobs are skipped and the `CI pass` summary at the bottom accepts
+  # the skipped state as a pass.
+  #
+  # `cargo audit` deliberately ignores this filter: new RUSTSEC
+  # advisories appear independent of our diff, so we want every PR
+  # (including docs PRs) to surface them.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Negative-list filter: every path is "code" *except* the
+          # patterns below. Safer default than enumerating code paths
+          # because anything new (a new crate, a new toml, a new
+          # workflow) is gated on as code by default.
+          filters: |
+            code:
+              - '**'
+              - '!**.md'
+              - '!docs/**'
+              - '!LICENSE*'
+              - '!.gitignore'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/CODEOWNERS'
+
   fmt:
     name: cargo fmt
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +86,8 @@ jobs:
 
   clippy:
     name: cargo clippy
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +102,8 @@ jobs:
 
   check:
     name: cargo check
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +117,8 @@ jobs:
 
   test:
     name: cargo test
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +142,8 @@ jobs:
 
   doc:
     name: cargo doc
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -D warnings
@@ -112,6 +157,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --workspace --no-deps --document-private-items
 
+  # `cargo audit` runs on every PR including docs-only changes.
+  # New RUSTSEC advisories can appear at any time independent of the
+  # diff, and we want every PR to be a checkpoint for security
+  # signal even if it's just a typo fix.
   audit:
     name: cargo audit
     runs-on: ubuntu-latest
@@ -131,3 +180,53 @@ jobs:
             --ignore RUSTSEC-2026-0066 \
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2025-0055
+
+  # Single summary check that the branch ruleset can require. By
+  # gating only on `CI pass`, docs-only PRs (where fmt/clippy/check/
+  # test/doc are skipped by `paths-filter`) can still merge: this job
+  # accepts `skipped` as a pass for the code-checking jobs when the
+  # `changes` job reported no code change. Real failures still fail.
+  #
+  # Replaces the previous setup where each individual job was a
+  # required check, which would deadlock docs-only PRs forever.
+  ci-pass:
+    name: CI pass
+    if: always()
+    needs: [changes, fmt, clippy, check, test, doc, audit]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required checks
+        env:
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          AUDIT_RESULT: ${{ needs.audit.result }}
+          FMT_RESULT: ${{ needs.fmt.result }}
+          CLIPPY_RESULT: ${{ needs.clippy.result }}
+          CHECK_RESULT: ${{ needs.check.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          DOC_RESULT: ${{ needs.doc.result }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          # cargo audit runs on every PR; it must succeed.
+          if [[ "$AUDIT_RESULT" != "success" ]]; then
+            echo "::error::cargo audit: $AUDIT_RESULT"
+            fail=1
+          fi
+
+          # Docs-only change: code-checking jobs are correctly skipped.
+          # Otherwise: every code-checking job must succeed.
+          if [[ "$CODE_CHANGED" == "true" ]]; then
+            for var in FMT_RESULT CLIPPY_RESULT CHECK_RESULT TEST_RESULT DOC_RESULT; do
+              result="${!var}"
+              if [[ "$result" != "success" ]]; then
+                echo "::error::${var,,}: $result"
+                fail=1
+              fi
+            done
+          else
+            echo "Docs-only change. Code-checking jobs correctly skipped."
+          fi
+
+          if [[ $fail -ne 0 ]]; then exit 1; fi
+          echo "All required checks succeeded."


### PR DESCRIPTION
## Summary

The current CI runs all six jobs (`fmt`, `clippy`, `check`, `test`, `doc`, `audit`) on every PR, including docs-only changes like #75 and #53. That's about 14 minutes of runner time on a PR that touched zero Rust.

This PR introduces the canonical "summary job + path filter" pattern so docs-only PRs skip the heavy jobs and still satisfy branch protection.

## What changes

- New **`changes`** job (runs first, ~5s) uses `dorny/paths-filter@v3` to detect whether the diff touches anything that affects the Rust build. Negative-list filter: every path is "code" *except* `**.md`, `docs/**`, `LICENSE*`, `.gitignore`, `.github/ISSUE_TEMPLATE/**`, `.github/CODEOWNERS`. New crates / new TOMLs / new workflow files are gated as "code" by default — safer than enumerating code paths and forgetting to add a new crate.
- The five code-checking jobs (`fmt`, `clippy`, `check`, `test`, `doc`) gain `needs: changes` + `if: needs.changes.outputs.code == 'true'`. They are skipped on docs-only PRs.
- **`audit`** deliberately ignores the filter and runs on every PR. RUSTSEC advisories appear independent of our diff, so we want every PR to be a security checkpoint even if it's just a typo fix. ~17s cost.
- New **`CI pass`** summary job (`if: always()`) runs after every other job and reports a single status check that the branch ruleset can require. Accepts `skipped` for the five code-checking jobs *only when* the `changes` job reported no code change. `audit` must always be `success`. Real failures still fail.

## Why

Without this, when the `Protect main` ruleset enforces the six individual checks as required (which it now does), a docs-only PR triggers `paths-ignore` → CI is skipped → required checks show as missing → PR is permanently blocked. The summary-job pattern is the standard fix.

Six-line config diff to follow in the GitHub UI after merge: replace the six required checks under `Protect main` → `Require status checks to pass` with a single required check named **`CI pass`**.

## Test plan

This PR itself touches `.github/workflows/ci.yml`, which means `changes.outputs.code == 'true'`, which means all six original jobs run alongside the new summary job. If the green checks here include both the six legacy jobs AND `CI pass`, the wiring works end to end.

Subsequent docs-only PRs will only run `changes` + `audit` + `CI pass` (~30s total instead of ~14 min).

## After merge

1. GitHub → Settings → Rules → Rulesets → Protect main → Require status checks to pass: remove the six entries (`cargo audit/check/clippy/doc/fmt/test`), add a single entry `CI pass`. Save.
2. The next docs-only PR (license, README polish) will validate the new path.