### PR TITLE
Polish README: brand lockup, badges, quick-start, AI-positioning tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://ligate.io">
-    <img src="docs/assets/lockup.svg" alt="Ligate Labs" width="200">
+    <img src="docs/assets/mark.svg" alt="Ligate" width="80">
   </a>
 </p>
 
@@ -22,21 +22,39 @@
 
 ## Quick start
 
+### Build and test
+
 ```bash
 # Clone
 git clone https://github.com/ligate-io/ligate-chain
 cd ligate-chain
 
 # Build the workspace (Rust 1.93 auto-installs via rust-toolchain.toml).
-# On Ubuntu / Debian first install: sudo apt install -y libclang-dev clang
-# On macOS first install: xcode-select --install
+# Ubuntu / Debian first install: sudo apt install -y libclang-dev clang
+# macOS first install:           xcode-select --install
 cargo build --workspace
 
 # Run the full test suite
 cargo test --workspace --lib --tests
 ```
 
-A public devnet is targeted for **Q2 2026**. Until then the protocol works end-to-end against a local Celestia mocha-testnet — see [`devnet/`](devnet) for the genesis configs and [`docs/development/devnet.md`](docs/development/devnet.md) for the operator runbook.
+### Run a node
+
+The `ligate-node` binary boots a single-node rollup against the checked-in devnet genesis. Two flavours, sharing the same chain state and only differing in DA layer:
+
+```bash
+# Default: in-process MockDa (SQLite). Single command, no external services.
+cargo run --bin ligate-node
+
+# Real Celestia DA (Mocha public RPC). Needs a Celestia signer key.
+SOV_CELESTIA_RPC_URL=wss://celestia-mocha.public-rpc.com \
+SOV_CELESTIA_SIGNER_KEY=$(pass celestia/devnet-signer) \
+cargo run --bin ligate-node -- --da-layer celestia
+```
+
+Defaults pick up `devnet/rollup.toml` (or `devnet/celestia.toml`) and the `devnet/genesis/*.json` files. The bootstrap account holds treasury, sequencer, attester, and prover roles for v0; two extra accounts (`lig1d0vqhk…` and `lig1njjery…`) ship with `$LGT` so you can exercise transfers without minting.
+
+A public devnet with federated attestor orgs is targeted for **Q2 2026**. Until then the protocol runs single-node locally as above. Full operator runbook (genesis ceremony, attestor key generation, multi-org topology) lives in [`docs/development/devnet.md`](docs/development/devnet.md); per-flavour boot details are in [`devnet/README.md`](devnet/README.md).
 
 ## What is this repo
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,80 @@ Ligate Chain is a **specialized app-chain**, not a general-purpose smart-contrac
 
 If you want to build a generalised dApp, this is the wrong chain. If you want verifiable on-chain receipts for AI activity at scale, this is the chain we are building for that.
 
+## Architecture
+
+```mermaid
+flowchart TB
+    User["Users / Apps<br/>(client SDK)"]
+    Celestia[("Celestia DA<br/>Mocha testnet")]
+
+    subgraph chain["Ligate Chain (Sovereign SDK rollup)"]
+        Sequencer["Sequencer<br/>tx ordering + batching"]
+        FullNode["Full Node<br/>cargo run --bin ligate-node"]
+        Prover["Risc0 Prover<br/>ZK state proofs"]
+    end
+
+    subgraph offchain["Off-chain attestor quorum (per schema)"]
+        Quorum["Quorum Service"]
+        Attestors["Attestor Nodes<br/>ed25519 signers"]
+    end
+
+    User -->|submit_tx| Sequencer
+    User -->|JSON-RPC query| FullNode
+    User -.->|attestation request| Quorum
+    Quorum --> Attestors
+    Attestors -.->|signed digests| Quorum
+    Quorum -.->|signed attestation| User
+
+    Sequencer -->|blob| Celestia
+    Celestia -->|blob stream| FullNode
+    Celestia -->|blob stream| Prover
+    Prover -.->|state proof| FullNode
+```
+
+### How nodes coordinate
+
+Ligate Chain is a **sovereign rollup**, not a peer-to-peer blockchain. Full nodes do not gossip with each other. Each node:
+
+1. Subscribes to a Celestia namespace and pulls the rollup's blobs as they appear.
+2. Independently runs the STF over each blob to derive the chain state.
+3. Serves JSON-RPC queries against its own derived state.
+
+Coordination happens through two places, **never through node-to-node messaging**:
+
+- **The sequencer** is the canonical entry point for transactions. Users submit transactions to its RPC; it batches them, picks an order, and posts the batch as a blob to Celestia. In v0, Ligate Labs runs the only sequencer; multi-sequencer (leader rotation, based-rollup) is a v1+ direction.
+- **Celestia** is the source of truth for inclusion and ordering. Every node sees the same blob stream and therefore reaches the same state. The chain's "consensus" is delegated to Celestia's DA + ordering — the rollup itself only enforces the STF. Disagreements about state are impossible if a node has correctly executed the STF over the same blobs.
+
+This is the standard rollup model. Same shape as every Sovereign SDK rollup, every modern Cosmos app-chain on Celestia (Stride, Dymension), and every Ethereum L2 (Optimism, Arbitrum, Base) — minus settlement back to Ethereum, since we are sovereign and don't post proofs to an L1.
+
+### Attestors are application-layer, not consensus
+
+Attestor nodes are **not** chain consensus participants. They sign attestation digests off-chain on behalf of a particular schema's quorum:
+
+1. The schema's off-chain **quorum service** (e.g. Themisra's attestor service for `themisra.proof-of-prompt/v1`) receives a sign request from the user.
+2. It produces a canonical digest and forwards it to each attestor node in its set.
+3. Each **attestor node** holds an ed25519 keypair, signs the digest, returns the signature.
+4. The quorum service collects the M-of-N signatures and hands the user a fully-signed attestation.
+5. The user's client SDK submits a `SubmitAttestation` transaction containing the signatures to the sequencer.
+6. The on-chain `attestation` module verifies the signatures match the schema's registered attestor set and writes the attestation to state.
+
+Each schema gets its own attestor set with its own threshold. Different schemas can share attestor pools, or each can run its own. The chain layer stays neutral; signing logic stays in product-specific quorum services.
+
+### What's centralised in v0, and what isn't
+
+For v0 devnet:
+
+| Layer | Status | Path to decentralise |
+|---|---|---|
+| Data availability | **Decentralised** via Celestia | Already there |
+| State verification | **Decentralised** — anyone runs `ligate-node` and re-derives | Already there |
+| Sequencer | **Centralised** (Ligate Labs) | v1+: leader rotation / shared sequencer |
+| Public RPC endpoint | **Centralised** (Ligate Labs hosted) | Anyone runs their own full node today; community RPCs over time |
+| Schema attestor sets | **Federated per-schema** (3–5 orgs each for first-party schemas) | Permissionless: any project registers its own |
+| Prover | **Centralised** (Ligate Labs) | v2: prover marketplace (#39) |
+
+The attestation primitive itself is permissionless from day one — anyone can register a new schema with a new attestor set without asking us. The infrastructure around it (sequencer, RPC, prover) decentralises over the v1 → v2 horizon.
+
 ## Workspace layout
 
 Cargo workspace (resolver 2). Members:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ cd ligate-chain
 # macOS first install:           xcode-select --install
 cargo build --workspace
 
-# Run the full test suite
-cargo test --workspace --lib --tests
+# Run the workspace tests (lib + integration + doctests)
+cargo test --workspace
 ```
 
 ### Run a node
@@ -54,7 +54,7 @@ cargo run --bin ligate-node -- --da-layer celestia
 
 Defaults pick up `devnet/rollup.toml` (or `devnet/celestia.toml`) and the `devnet/genesis/*.json` files. The bootstrap account holds treasury, sequencer, attester, and prover roles for v0; two extra accounts (`lig1d0vqhk…` and `lig1njjery…`) ship with `$LGT` so you can exercise transfers without minting.
 
-A public devnet with federated attestor orgs is targeted for **Q2 2026**. Until then the protocol runs single-node locally as above. Full operator runbook (genesis ceremony, attestor key generation, multi-org topology) lives in [`docs/development/devnet.md`](docs/development/devnet.md); per-flavour boot details are in [`devnet/README.md`](devnet/README.md).
+A public devnet with federated attestor orgs is targeted for **Q2 2026**. Until then the protocol runs single-node locally as above. Per-flavour boot details (Mock / Celestia, env vars, secret-store helpers) live in [`devnet/README.md`](devnet/README.md). Forward-looking operator notes (genesis ceremony, attestor key generation, multi-org topology) are in [`docs/development/devnet.md`](docs/development/devnet.md) — note that runbook still has sections marked **Preview only** from before Phase A landed; refresh tracked separately.
 
 ## What is this repo
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <p align="center">
   <a href="https://ligate.io">
-    <img src="docs/assets/mark.svg" alt="Ligate" width="80">
+    <img src="docs/assets/lockup.svg" alt="Ligate Labs" width="220">
   </a>
 </p>
 
 <h1 align="center">Ligate Chain</h1>
 
 <p align="center">
-  <strong>The on-chain attestation protocol for AI.</strong><br>
-  A sovereign rollup on Celestia.
+  <strong>The permissionless on-chain attestation protocol.</strong><br>
+  A sovereign rollup on Celestia. AI provenance is the wedge use case, not the only one.
 </p>
 
 <p align="center">
@@ -72,7 +72,7 @@ The canonical specification is in [`docs/protocol/attestation-v0.md`](docs/proto
 
 ## What Ligate Chain is, and isn't
 
-Ligate Chain is a **specialized app-chain**, not a general-purpose smart-contract platform. The closer comparisons are Celestia, Hyperliquid, dYdX v4, or Cosmos app-chains: each chain has a narrow remit and is shaped around it. Our remit is on-chain attestation infrastructure for AI claims.
+Ligate Chain is a **specialized app-chain**, not a general-purpose smart-contract platform. The closer comparisons are Celestia, Hyperliquid, dYdX v4, or Cosmos app-chains: each chain has a narrow remit and is shaped around it. Our remit is on-chain attestation infrastructure — any cryptographically signed off-chain record, verifiable later by anyone, with the curated module set (tokens, NFTs, payments, identity, agents) layered around it. AI provenance is the highest-conviction wedge use case (via Themisra) but the protocol is domain-agnostic: anyone registers a schema and an attestor set, anyone submits attestations under it.
 
 **It is:**
 
@@ -87,7 +87,7 @@ Ligate Chain is a **specialized app-chain**, not a general-purpose smart-contrac
 - An L2 in the Optimism / Arbitrum sense. We do not settle to Ethereum.
 - A general DeFi platform. The chain is shaped for attestation primitives plus a few sister modules. Lending, AMMs, perps, and similar live on chains designed for them.
 
-If you want to build a generalised dApp, this is the wrong chain. If you want verifiable on-chain receipts for AI activity at scale, this is the chain we are building for that.
+**What you can build on Ligate Chain today and through the v1 roadmap:** apps that register schemas and submit attestations (any domain — AI provenance, supply-chain, document notary, oracle data, governance receipts, KYC checkpoints, sensor logs, you name it); apps that issue fungible tokens or NFTs once `tokens` ([#47](https://github.com/ligate-io/ligate-chain/issues/47)) and `nft` ([#48](https://github.com/ligate-io/ligate-chain/issues/48)) modules ship; apps that compose with payments, identity, agent registry, and disputes modules as those land. **What you can't build today:** anything requiring arbitrary smart-contract execution (no EVM in v0–v3; tracked as a v4 option in [#52](https://github.com/ligate-io/ligate-chain/issues/52)). For chain-shaped Web3 features through curated modules + a permissionless attestation primitive, this is the chain. For arbitrary Solidity/Rust contracts, an EVM L2 or Solana is the right place today.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
-# Ligate Chain
+<p align="center">
+  <a href="https://ligate.io">
+    <img src="docs/assets/lockup.svg" alt="Ligate Labs" width="200">
+  </a>
+</p>
 
-Ligate Chain: the on-chain attestation protocol. A Sovereign SDK rollup on Celestia.
+<h1 align="center">Ligate Chain</h1>
+
+<p align="center">
+  <strong>The on-chain attestation protocol for AI.</strong><br>
+  A sovereign rollup on Celestia.
+</p>
+
+<p align="center">
+  <a href="https://github.com/ligate-io/ligate-chain/actions/workflows/ci.yml"><img src="https://github.com/ligate-io/ligate-chain/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="#license"><img src="https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg" alt="License: Apache-2.0 OR MIT"></a>
+  <a href="https://docs.ligate.io"><img src="https://img.shields.io/badge/docs-docs.ligate.io-A7D28C.svg" alt="Docs"></a>
+  <a href="#development-status"><img src="https://img.shields.io/badge/status-pre--devnet-E8833A.svg" alt="Pre-devnet"></a>
+</p>
+
+---
+
+## Quick start
+
+```bash
+# Clone
+git clone https://github.com/ligate-io/ligate-chain
+cd ligate-chain
+
+# Build the workspace (Rust 1.93 auto-installs via rust-toolchain.toml).
+# On Ubuntu / Debian first install: sudo apt install -y libclang-dev clang
+# On macOS first install: xcode-select --install
+cargo build --workspace
+
+# Run the full test suite
+cargo test --workspace --lib --tests
+```
+
+A public devnet is targeted for **Q2 2026**. Until then the protocol works end-to-end against a local Celestia mocha-testnet — see [`devnet/`](devnet) for the genesis configs and [`docs/development/devnet.md`](docs/development/devnet.md) for the operator runbook.
 
 ## What is this repo
 

--- a/docs/assets/lockup.svg
+++ b/docs/assets/lockup.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="185" height="48" viewBox="0 0 185 48" fill="none" role="img" aria-label="Ligate Labs">
+  <title>Ligate Labs</title>
+  <mask id="lm">
+    <rect width="48" height="48" fill="white"/>
+    <rect x="2.5" y="13.5" width="28" height="21" rx="10.5" fill="black"/>
+  </mask>
+  <g mask="url(#lm)">
+    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#F4F2EC" stroke-width="3" fill="none"/>
+  </g>
+  <rect x="4" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
+  <text x="62" y="24" dominant-baseline="central" style="font-family:'Space Grotesk','Inter','Helvetica Neue',Arial,sans-serif;font-size:22px;font-weight:500;letter-spacing:-0.02em;" fill="#F4F2EC">Ligate<tspan dx="4" style="font-weight:400;" fill="#8A8A96">Labs</tspan></text>
+</svg>

--- a/docs/assets/lockup.svg
+++ b/docs/assets/lockup.svg
@@ -5,8 +5,8 @@
     <rect x="2.5" y="13.5" width="28" height="21" rx="10.5" fill="black"/>
   </mask>
   <g mask="url(#lm)">
-    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#F4F2EC" stroke-width="3" fill="none"/>
+    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
   </g>
   <rect x="4" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
-  <text x="62" y="24" dominant-baseline="central" style="font-family:'Space Grotesk','Inter','Helvetica Neue',Arial,sans-serif;font-size:22px;font-weight:500;letter-spacing:-0.02em;" fill="#F4F2EC">Ligate<tspan dx="4" style="font-weight:400;" fill="#8A8A96">Labs</tspan></text>
+  <text x="62" y="24" dominant-baseline="central" style="font-family:'Space Grotesk','Inter','Helvetica Neue',Arial,sans-serif;font-size:22px;font-weight:500;letter-spacing:-0.02em;" fill="#A7D28C">Ligate<tspan dx="4" style="font-weight:400;" fill="#A7D28C" opacity="0.65">Labs</tspan></text>
 </svg>

--- a/docs/assets/mark.svg
+++ b/docs/assets/mark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none" role="img" aria-label="Ligate Labs mark">
+  <title>Ligate Labs mark</title>
+  <mask id="lm">
+    <rect width="48" height="48" fill="white"/>
+    <rect x="2.5" y="13.5" width="28" height="21" rx="10.5" fill="black"/>
+  </mask>
+  <g mask="url(#lm)">
+    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#F4F2EC" stroke-width="3" fill="none"/>
+  </g>
+  <rect x="4" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
+</svg>

--- a/docs/assets/mark.svg
+++ b/docs/assets/mark.svg
@@ -5,7 +5,7 @@
     <rect x="2.5" y="13.5" width="28" height="21" rx="10.5" fill="black"/>
   </mask>
   <g mask="url(#lm)">
-    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#F4F2EC" stroke-width="3" fill="none"/>
+    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
   </g>
   <rect x="4" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
 </svg>


### PR DESCRIPTION
## Summary

Now that the chain repo is public, the README is the front door for anyone landing on it. The existing copy was strong (the \"what it is / isn't\" framing, workspace layout, protocol-at-a-glance, dev status) but had no visual identity at the top, no status badges, no \"clone-and-build in 5 minutes\" path, and the brand line undersold the AI wedge.

This PR adds the visual chrome that mature chain repos lead with (Solana, Celestia, Aptos, Sui all use the same pattern), and a short Quick start section that actually works against today's codebase.

## What lands

- **Brand lockup** centered at the top, linked to ligate.io. Source SVG is a copy of `apps/landing/public/brand/lockup-sage.svg` from the marketing repo, dropped into [`docs/assets/lockup.svg`](docs/assets/lockup.svg). Plus [`docs/assets/mark.svg`](docs/assets/mark.svg) (the symbol-only mark) for any future use that needs a smaller graphic. Both are sage-on-transparent SVGs, render cleanly on GitHub's dark default.
- **Centered \"Ligate Chain\" title** below the lockup. The lockup carries the company brand (\"Ligate Labs\"), the H1 names the specific repo. Same disambiguation pattern Aptos uses (Aptos Labs lockup + `aptos-core` title).
- **Tagline tweak**: \"**The on-chain attestation protocol for AI.** A sovereign rollup on Celestia.\" The previous version (\"Ligate Chain: the on-chain attestation protocol. A Sovereign SDK rollup on Celestia.\") was technically accurate but missed the AI positioning that's the actual wedge — and that the marketing site, whitepaper, and research thesis all lead with.
- **Badges row**: CI status (live), license (Apache-2.0 OR MIT), docs link (docs.ligate.io), pre-devnet status. Sage / amber color choices match the brand palette.
- **Quick start section**: 5-line bash block from clone to running the test suite. Honest about what works today (test suite passes against local Celestia mocha-testnet) and explicit about what doesn't (public devnet target Q2 2026). Points at [`docs/development/devnet.md`](docs/development/devnet.md) for the actual operator runbook.

The rest of the README is unchanged.

## Why this shape

Standard chain-repo opener pattern across the ecosystem:

| Chain | Lockup | Tagline | Badges | Quick start |
|---|---|---|---|---|
| Solana / Agave | yes | yes | yes | yes |
| Celestia | yes | yes | yes | yes |
| Aptos | yes | yes | yes | yes |
| Sui | yes | yes | yes | yes |
| CometBFT | yes | yes | yes | yes |

The pattern works because the audience splits into two cohorts: casual visitors who scan the visual identity + tagline + status badges (\"is this real, is it active, what's the state\") and serious readers who go through the actual content. Both are served by the same open.

## Out of scope

- Any change to the License section (the dual Apache-2.0 / MIT declaration). That's covered separately in #77.
- The CI badge will stop reporting once the active ruleset starts requiring `CI pass` instead of the six individual checks (per #76). At that point we'll swap the badge URL to point at the `CI pass` job. Easy follow-up — left as a note rather than a coupled change here.
- A `light/dark` adaptive logo via `<picture>` + `prefers-color-scheme`. The sage SVG looks good on both GitHub themes; not worth the markup complexity yet.
- A NOTICE file. Not required by Apache-2.0 unless we redistribute Apache-licensed code with its own NOTICE — Sovereign SDK and Risc0 don't ship one we have to propagate.

## Test plan

- [ ] Render README on GitHub and confirm:
  - Lockup SVG loads (no broken image)
  - All four badges resolve
  - The `#license` and `#development-status` anchors jump correctly within the README
  - Quick start bash block formats cleanly
- [ ] Run the Quick start commands on a clean clone and verify the test suite still passes (it should — no code change in this PR).