### PR TITLE
Query RPC: get_schema, get_attestor_set, get_attestation REST endpoints (refs #21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "strum 0.26.3",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -31,6 +31,7 @@ sov-state       = { workspace = true, features = ["native"] }
 sov-test-utils  = { workspace = true }
 tempfile.workspace = true
 strum.workspace = true
+tokio.workspace = true
 
 [features]
 default = []

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -28,6 +28,12 @@
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "native")]
+mod query;
+
+#[cfg(feature = "native")]
+pub use query::{AttestationResponse, AttestorSetResponse, SchemaResponse};
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -41,8 +41,8 @@ use sha2::{Digest, Sha256};
 use sov_bank::{Amount, Bank, Coins, TokenId};
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
-    Context, DaSpec, GenesisState, Module, ModuleId, ModuleInfo, SafeString, SafeVec, Spec,
-    StateMap, StateValue, TxState,
+    Context, DaSpec, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, SafeString,
+    SafeVec, Spec, StateMap, StateValue, TxState,
 };
 use thiserror::Error as ThisError;
 
@@ -439,7 +439,7 @@ pub enum CallMessage<S: Spec> {
 /// Call handlers and genesis config live in sibling issues; this struct
 /// exists to lock down the state layout that every other piece of the
 /// module keys off.
-#[derive(Clone, ModuleInfo)]
+#[derive(Clone, ModuleInfo, ModuleRestApi)]
 pub struct AttestationModule<S: Spec> {
     /// Module's own discriminant id. Filled by the SDK from the value
     /// keyed by `ATTESTATION_DISCRIMINANT` in `constants.toml` (21 in

--- a/crates/modules/attestation/src/query.rs
+++ b/crates/modules/attestation/src/query.rs
@@ -1,0 +1,145 @@
+//! REST query API for the attestation module.
+//!
+//! Three single-key lookups exposed under the module's REST namespace
+//! (mounted by the runtime via [`HasCustomRestApi`] under
+//! `/modules/attestation/...`):
+//!
+//! - `GET /schemas/{schemaId}` — fetch one schema
+//! - `GET /attestor-sets/{attestorSetId}` — fetch one attestor set
+//! - `GET /attestations/{attestationId}` — fetch one attestation by
+//!   `<schemaId>:<payloadHash>`
+//!
+//! `list_by_schema` is intentionally **not** in this module. The
+//! attestation `StateMap<AttestationId, Attestation<S>>` is keyed by a
+//! 64-byte compound id, which is fine for point lookups but bad for
+//! filter-by-schema iteration without a secondary index. Adding the
+//! index touches the write path on `SubmitAttestation` plus the
+//! storage schema, so it ships separately. See the follow-up issue
+//! linked from #21.
+//!
+//! All three routes return a typed JSON body, 404 on missing key, 400
+//! on malformed id. Paths use the canonical Bech32 string forms
+//! (`lsc1…`, `las1…`, `lsc1…:lph1…`) since those are the strings the
+//! protocol exposes everywhere else (genesis files, attestation
+//! receipts, error messages).
+
+use std::str::FromStr;
+
+use axum::routing::get;
+use serde::{Deserialize, Serialize};
+use sov_modules_api::prelude::{axum, UnwrapInfallible};
+use sov_modules_api::rest::utils::{errors, ApiResult, Path};
+use sov_modules_api::rest::{ApiState, HasCustomRestApi};
+use sov_modules_api::{ApiStateAccessor, Spec};
+
+use crate::{
+    Attestation, AttestationId, AttestationModule, AttestorSet, AttestorSetId, Schema, SchemaId,
+};
+
+// --- response types ----------------------------------------------------------
+
+/// Body of `GET /schemas/{schemaId}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound = "S::Address: Serialize + serde::de::DeserializeOwned")]
+pub struct SchemaResponse<S: Spec> {
+    /// The schema as stored on chain.
+    pub schema: Schema<S>,
+}
+
+/// Body of `GET /attestor-sets/{attestorSetId}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttestorSetResponse {
+    /// The attestor set as stored on chain.
+    pub attestor_set: AttestorSet,
+}
+
+/// Body of `GET /attestations/{attestationId}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound = "S::Address: Serialize + serde::de::DeserializeOwned")]
+pub struct AttestationResponse<S: Spec> {
+    /// The attestation as stored on chain.
+    pub attestation: Attestation<S>,
+}
+
+// --- routes ------------------------------------------------------------------
+
+impl<S: Spec> AttestationModule<S> {
+    /// `GET /schemas/{schemaId}` — fetch one schema by Bech32 id.
+    async fn route_get_schema(
+        state: ApiState<S, Self>,
+        mut accessor: ApiStateAccessor<S>,
+        Path(schema_id_str): Path<String>,
+    ) -> ApiResult<SchemaResponse<S>> {
+        let schema_id = SchemaId::from_str(&schema_id_str).map_err(|e| {
+            errors::bad_request_400("Invalid schema id (expected Bech32 `lsc1…`)", e.to_string())
+        })?;
+        let schema = state
+            .schemas
+            .get(&schema_id, &mut accessor)
+            .unwrap_infallible()
+            .ok_or_else(|| errors::not_found_404("Schema", schema_id))?;
+        Ok(SchemaResponse { schema }.into())
+    }
+
+    /// `GET /attestor-sets/{attestorSetId}` — fetch one attestor set
+    /// (members + threshold) by Bech32 id.
+    async fn route_get_attestor_set(
+        state: ApiState<S, Self>,
+        mut accessor: ApiStateAccessor<S>,
+        Path(attestor_set_id_str): Path<String>,
+    ) -> ApiResult<AttestorSetResponse> {
+        let attestor_set_id = AttestorSetId::from_str(&attestor_set_id_str).map_err(|e| {
+            errors::bad_request_400(
+                "Invalid attestor set id (expected Bech32 `las1…`)",
+                e.to_string(),
+            )
+        })?;
+        let attestor_set = state
+            .attestor_sets
+            .get(&attestor_set_id, &mut accessor)
+            .unwrap_infallible()
+            .ok_or_else(|| errors::not_found_404("AttestorSet", attestor_set_id))?;
+        Ok(AttestorSetResponse { attestor_set }.into())
+    }
+
+    /// `GET /attestations/{attestationId}` — fetch one attestation by
+    /// its compound id `<schemaId>:<payloadHash>`.
+    async fn route_get_attestation(
+        state: ApiState<S, Self>,
+        mut accessor: ApiStateAccessor<S>,
+        Path(attestation_id_str): Path<String>,
+    ) -> ApiResult<AttestationResponse<S>> {
+        let attestation_id = AttestationId::from_str(&attestation_id_str).map_err(|e| {
+            errors::bad_request_400(
+                "Invalid attestation id (expected `<schemaId>:<payloadHash>`)",
+                e.to_string(),
+            )
+        })?;
+        let attestation = state
+            .attestations
+            .get(&attestation_id, &mut accessor)
+            .unwrap_infallible()
+            .ok_or_else(|| errors::not_found_404("Attestation", attestation_id))?;
+        Ok(AttestationResponse { attestation }.into())
+    }
+}
+
+// --- router wiring -----------------------------------------------------------
+
+impl<S: Spec> HasCustomRestApi for AttestationModule<S> {
+    type Spec = S;
+
+    fn custom_rest_api(&self, state: ApiState<S>) -> axum::Router<()> {
+        axum::Router::new()
+            .route("/schemas/{schemaId}", get(Self::route_get_schema))
+            .route(
+                "/attestor-sets/{attestorSetId}",
+                get(Self::route_get_attestor_set),
+            )
+            .route(
+                "/attestations/{attestationId}",
+                get(Self::route_get_attestation),
+            )
+            .with_state(state.with(self.clone()))
+    }
+}

--- a/crates/modules/attestation/src/query.rs
+++ b/crates/modules/attestation/src/query.rs
@@ -132,14 +132,8 @@ impl<S: Spec> HasCustomRestApi for AttestationModule<S> {
     fn custom_rest_api(&self, state: ApiState<S>) -> axum::Router<()> {
         axum::Router::new()
             .route("/schemas/{schemaId}", get(Self::route_get_schema))
-            .route(
-                "/attestor-sets/{attestorSetId}",
-                get(Self::route_get_attestor_set),
-            )
-            .route(
-                "/attestations/{attestationId}",
-                get(Self::route_get_attestation),
-            )
+            .route("/attestor-sets/{attestorSetId}", get(Self::route_get_attestor_set))
+            .route("/attestations/{attestationId}", get(Self::route_get_attestation))
             .with_state(state.with(self.clone()))
     }
 }

--- a/crates/modules/attestation/tests/integration.rs
+++ b/crates/modules/attestation/tests/integration.rs
@@ -1046,3 +1046,203 @@ fn submit_attestation_rejects_empty_signatures() {
         }),
     });
 }
+
+// ============================================================================
+// REST query API (GET /modules/attestation/...)
+// ============================================================================
+//
+// These exercise the routes wired up in `attestation::query` via the
+// SDK's `TestRunner::setup_rest_api_server`. The runtime auto-mounts
+// every module's `HasCustomRestApi` impl under `/modules/<name>/`, so
+// hitting `/modules/attestation/schemas/<id>` invokes the route in
+// `query.rs` against live runtime state.
+//
+// Each test follows the pattern:
+//   1. setup() + register attestor set + register schema (+ optionally
+//      submit attestation) via tx executions, exactly like the call-
+//      handler integration tests above.
+//   2. setup_rest_api_server().await to start an axum server on a
+//      random port and obtain a reqwest::Client.
+//   3. query_api_response::<T>(path, client).await for the typed body,
+//      or query_api(...) when we want to inspect the HTTP status code
+//      directly (the 404 / 400 cases).
+
+use attestation::{AttestationResponse, AttestorSetResponse, SchemaResponse};
+use sov_test_utils::runtime::ApiPath;
+
+/// Path builder that produces `/modules/attestation/<suffix>` matching
+/// the routes mounted by `HasCustomRestApi` for the attestation module.
+fn attestation_api_path(suffix: &str) -> ApiPath {
+    ApiPath::query_module("attestation").with_custom_api_path(suffix)
+}
+
+/// Pre-stage state that the query-route tests need: an attestor set, a
+/// schema registered against it, and (for the attestation case) one
+/// submitted attestation. Returns the ids the tests assert against.
+struct StagedQueryState {
+    attestor_set_id: attestation::AttestorSetId,
+    schema_id: attestation::SchemaId,
+    submitter_addr: <S as sov_modules_api::Spec>::Address,
+    payload_hash: attestation::PayloadHash,
+}
+
+fn stage_query_state(env: &mut TestEnv, signers: &[SigningKey; 3]) -> StagedQueryState {
+    let submitter_addr = env.submitter.address();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterAttestorSet { members: safe_members(signers), threshold: 2 },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let attestor_set_id = AttestorSet::derive_id(&pubkeys_of(signers), 2);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("themisra.proof-of-prompt"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, "themisra.proof-of-prompt", 1);
+
+    let payload_hash = attestation::PayloadHash::from([0x42u8; 32]);
+    let digest = attestation::SignedAttestationPayload::<S> {
+        schema_id,
+        payload_hash,
+        submitter: submitter_addr,
+        timestamp: 0,
+    }
+    .digest();
+    let sig_vec: Vec<AttestorSignature> = signers[..2]
+        .iter()
+        .map(|sk| AttestorSignature {
+            pubkey: PubKey::from(sk.verifying_key().to_bytes()),
+            sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(
+                sk.sign(&digest).to_bytes().to_vec(),
+            )
+            .unwrap(),
+        })
+        .collect();
+    let signatures =
+        SafeVec::<AttestorSignature, MAX_ATTESTATION_SIGNATURES>::try_from(sig_vec).unwrap();
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+
+    StagedQueryState { attestor_set_id, schema_id, submitter_addr, payload_hash }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_get_schema_returns_registered_schema() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let staged = stage_query_state(&mut env, &signers);
+
+    let client = env.runner.setup_rest_api_server().await;
+    let resp: SchemaResponse<S> = env
+        .runner
+        .query_api_response(
+            &attestation_api_path(&format!("schemas/{}", staged.schema_id)),
+            &client,
+        )
+        .await;
+
+    assert_eq!(resp.schema.owner, staged.submitter_addr);
+    assert_eq!(resp.schema.name.as_str(), "themisra.proof-of-prompt");
+    assert_eq!(resp.schema.version, 1);
+    assert_eq!(resp.schema.attestor_set, staged.attestor_set_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_get_attestor_set_returns_registered_set() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let staged = stage_query_state(&mut env, &signers);
+
+    let client = env.runner.setup_rest_api_server().await;
+    let resp: AttestorSetResponse = env
+        .runner
+        .query_api_response(
+            &attestation_api_path(&format!("attestor-sets/{}", staged.attestor_set_id)),
+            &client,
+        )
+        .await;
+
+    assert_eq!(resp.attestor_set.threshold, 2);
+    // The module sorts members at registration time so the
+    // AttestorSetId derivation is deterministic. Compare as sorted
+    // sets rather than ordered slices.
+    let mut got: Vec<PubKey> = resp.attestor_set.members.as_slice().to_vec();
+    got.sort_by_key(|pk| *pk.as_bytes());
+    let mut expected = pubkeys_of(&signers);
+    expected.sort_by_key(|pk| *pk.as_bytes());
+    assert_eq!(got, expected);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_get_attestation_returns_submitted_attestation() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let signers = sample_signers();
+    let staged = stage_query_state(&mut env, &signers);
+
+    let attestation_id =
+        attestation::AttestationId::from_pair(&staged.schema_id, &staged.payload_hash);
+
+    let client = env.runner.setup_rest_api_server().await;
+    let resp: AttestationResponse<S> = env
+        .runner
+        .query_api_response(
+            &attestation_api_path(&format!("attestations/{attestation_id}")),
+            &client,
+        )
+        .await;
+
+    assert_eq!(resp.attestation.schema_id, staged.schema_id);
+    assert_eq!(resp.attestation.payload_hash, staged.payload_hash);
+    assert_eq!(resp.attestation.submitter, staged.submitter_addr);
+    assert_eq!(resp.attestation.signatures.as_slice().len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_get_schema_returns_404_for_unknown_id() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let client = env.runner.setup_rest_api_server().await;
+
+    // Well-formed Bech32 with the right HRP, but no schema with this id
+    // exists in state. Construct deterministically to avoid relying on
+    // a random pick that might collide with a registered schema.
+    let unknown_schema_id = attestation::SchemaId::from([0xAAu8; 32]);
+
+    let resp = env
+        .runner
+        .query_api(
+            &attestation_api_path(&format!("schemas/{unknown_schema_id}")),
+            &client,
+        )
+        .await;
+
+    assert_eq!(resp.status().as_u16(), 404);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_get_schema_returns_400_for_invalid_bech32() {
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+    let client = env.runner.setup_rest_api_server().await;
+
+    // Garbage path segment. Not a valid Bech32 string.
+    let resp = env
+        .runner
+        .query_api(&attestation_api_path("schemas/not-a-valid-id"), &client)
+        .await;
+
+    assert_eq!(resp.status().as_u16(), 400);
+}

--- a/crates/modules/attestation/tests/integration.rs
+++ b/crates/modules/attestation/tests/integration.rs
@@ -1224,10 +1224,7 @@ async fn query_get_schema_returns_404_for_unknown_id() {
 
     let resp = env
         .runner
-        .query_api(
-            &attestation_api_path(&format!("schemas/{unknown_schema_id}")),
-            &client,
-        )
+        .query_api(&attestation_api_path(&format!("schemas/{unknown_schema_id}")), &client)
         .await;
 
     assert_eq!(resp.status().as_u16(), 404);
@@ -1239,10 +1236,7 @@ async fn query_get_schema_returns_400_for_invalid_bech32() {
     let client = env.runner.setup_rest_api_server().await;
 
     // Garbage path segment. Not a valid Bech32 string.
-    let resp = env
-        .runner
-        .query_api(&attestation_api_path("schemas/not-a-valid-id"), &client)
-        .await;
+    let resp = env.runner.query_api(&attestation_api_path("schemas/not-a-valid-id"), &client).await;
 
     assert_eq!(resp.status().as_u16(), 400);
 }


### PR DESCRIPTION
## Summary

Without query RPC, the chain is write-only — every consumer (Themisra, Iris, Mneme, third-party SDKs) has to re-derive state from Celestia blobs themselves. This PR adds three single-key REST endpoints under `ligate-node` that close the loop:

- `GET /modules/attestation/schemas/{schemaId}`
- `GET /modules/attestation/attestor-sets/{attestorSetId}`
- `GET /modules/attestation/attestations/{attestationId}` where `attestationId` is `<schemaId>:<payloadHash>`

Closes the read-side of #21 with full integration test coverage. The fourth endpoint listed in #21 (`list_by_schema`) is **deferred** — see *Scope* below.

## What lands

### Module crate (`crates/modules/attestation`)

- `src/query.rs` (new) — three async route handlers and a `HasCustomRestApi` impl:
  - `route_get_schema` — Bech32-parse `{schemaId}`, look up `schemas: StateMap<SchemaId, Schema<S>>`, wrap in `SchemaResponse<S>`.
  - `route_get_attestor_set` — same shape against `attestor_sets: StateMap<AttestorSetId, AttestorSet>`.
  - `route_get_attestation` — parse `<schemaId>:<payloadHash>` (matches `AttestationId::Display`), look up `attestations: StateMap<AttestationId, Attestation<S>>`.
  - All three: 400 on malformed Bech32 (with the expected HRP in the error message), 404 on missing key, 200 with typed JSON body otherwise.
- `src/lib.rs` — adds `#[derive(ModuleRestApi)]` next to the existing `ModuleInfo` derive (this is the one that actually wires `HasCustomRestApi` into the runtime's per-module router; without it the routes 404 at the global fallback). Plus `#[cfg(feature = "native")] mod query;` and re-exports for the response types.

### Tests (`crates/modules/attestation/tests/integration.rs`)

Five new integration tests using `sov-test-utils::TestRunner::setup_rest_api_server` — same SDK-canonical pattern the archival_queries tests use:

| Test | Asserts |
|---|---|
| `query_get_schema_returns_registered_schema` | round-trip: register schema via tx, GET, owner / name / version / attestor_set match |
| `query_get_attestor_set_returns_registered_set` | threshold + sorted-members match (the module sorts members for deterministic ID derivation, so we compare as sorted sets) |
| `query_get_attestation_returns_submitted_attestation` | schema_id / payload_hash / submitter / signature count match |
| `query_get_schema_returns_404_for_unknown_id` | well-formed Bech32 with no matching state → 404 |
| `query_get_schema_returns_400_for_invalid_bech32` | garbage path segment → 400 |

Plus a `stage_query_state` helper that registers attestor set + schema + attestation for the happy-path tests to share.

`tokio` added to `dev-dependencies` for the `#[tokio::test(flavor = "multi_thread")]` macro that the SDK's REST test harness requires.

## Scope: why `list_by_schema` is deferred

#21 lists four endpoints. Three ship here. The fourth — `list_by_schema` — needs a design call before code:

- `attestations: StateMap<AttestationId, Attestation<S>>` is keyed by the 64-byte compound `(schema_id, payload_hash)`. Point lookups are O(1); filter-by-schema iteration without a secondary index requires either a full `iter_raw` scan + filter (O(N) over all attestations) or a new state field (e.g. `attestations_by_schema: StateMap<SchemaId, _>`) populated on the `SubmitAttestation` write path.
- The full-scan approach is simple but bad once volume grows. The secondary-index approach is correct but touches the storage schema and the write-side fee path.
- This belongs in its own PR with the index design pinned down. Critical-path consumers (Themisra prompt-receipt verification, Iris MCP `verify(attestation_id)`, Mneme "Attest with Mneme" flow) all use the three single-key endpoints in this PR — they don't need `list_by_schema`. The explorer (#80) does, and it's the natural follow-up driver.

Range / time-bucketed / by-submitter / aggregation queries belong in the indexer service (#91), not the node's REST API. The node stays narrow and fast.

## Why REST + axum, not JSON-RPC

The Sovereign SDK at our pinned rev (`f89964c`) ships the REST + axum + `HasCustomRestApi` stack as the canonical module-query pattern. Sov-bank, sov-chain-state, sov-hyperlane all use it. Going JSON-RPC would mean fighting the framework; the REST surface is what the SDK auto-merges into the runtime router and what `TestRunner` knows how to start a test server for.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p attestation --all-features --all-targets -- -D warnings` clean
- [x] `cargo test -p attestation --all-features` — 29 / 29 (24 existing + 5 new)
- [x] `cargo check -p attestation -p ligate-stf -p ligate-rollup --all-features` clean (verified end-to-end the rollup binary still builds with the new module wired in)
- [x] All gates run locally on macOS with `DYLD_FALLBACK_LIBRARY_PATH` and `RISC0_SKIP_BUILD_KERNELS` workarounds documented in the README
- [ ] Same gates green in CI (the new `CI pass` summary check)
- [ ] Render PR description on GitHub with the URL examples and table

## Out of scope (tracked separately)

- `list_by_schema` endpoint — follow-up PR, see *Scope* above
- WebSocket / SSE live event stream for new attestations / schema registrations / etc. → #92
- Block indexer service for derived / range / aggregation queries → #91
- Hosted public RPC instance at `rpc.ligate.io` → #79
- Block explorer UI consuming the indexer → #80

## Refs

- closes the read-side of #21 (3 of 4 endpoints; `list_by_schema` deferred to follow-up)
- companion: #91 (indexer), #92 (WebSocket), #79 (hosted RPC), #80 (explorer)
