### PR TITLE
Public-repo hygiene: CONTRIBUTING, CODE_OF_CONDUCT, issue/PR templates, Dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Something is broken in the chain code, devnet config, or build system
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please fill in the fields below so we can reproduce and triage quickly.
+
+        **Do not file security vulnerabilities here.** See [`SECURITY.md`](https://github.com/ligate-io/ligate-chain/blob/main/SECURITY.md) for the private disclosure process.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Describe the bug. What did you observe?
+      placeholder: "When I run `cargo run --bin ligate-node`, the node panics with..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen
+      placeholder: "The node should boot and serve RPC on port 8080."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal sequence that reliably reproduces the bug.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Commit hash
+      description: Output of `git rev-parse HEAD`.
+      placeholder: "59f8f65..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux (Ubuntu / Debian)
+        - Linux (other)
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Other (please describe in 'What happened')
+    validations:
+      required: true
+
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust toolchain
+      description: Output of `rustc --version`. Should match `rust-toolchain.toml`.
+      placeholder: "rustc 1.93.0 (254b59607 2026-01-19)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Trim to the relevant sections. Use code blocks for readability.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Optional. Hardware quirks, custom configs, things you tried that did not work.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Disables the "Open a blank issue" link so every new issue uses one of
+# the templates above. Keeps the queue actionable.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/ligate-io/ligate-chain/discussions
+    about: General questions, design discussions, and "how do I…" go in Discussions, not Issues. File an issue only when the answer requires a code change.
+
+  - name: Security vulnerability
+    url: https://github.com/ligate-io/ligate-chain/security/advisories/new
+    about: Do not file public issues for vulnerabilities. Open a private security advisory instead. See SECURITY.md for the full disclosure policy.
+
+  - name: Email the maintainers
+    url: mailto:hello@ligate.io
+    about: For anything that doesn't fit Discussions, a public issue, or a security advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a new capability for the chain, modules, or SDK
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to propose a new feature, module, or extension to an existing surface. For protocol-shape changes (new `CallMessage` variants, state-layout shifts, wire-format breaks), please read [`docs/protocol/attestation-v0.md`](https://github.com/ligate-io/ligate-chain/blob/main/docs/protocol/attestation-v0.md) first.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user-visible problem does this feature address? Avoid jumping to a solution here.
+      placeholder: "Today there is no way for an indexer to subscribe to new attestations as they land. Polling the REST endpoint at 200ms intervals is wasteful and adds visible latency to UI surfaces."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed approach
+      description: What should we build? Sketch the surface (API, types, state shape) at enough detail for a reviewer to evaluate trade-offs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you weigh, and why did you reject them?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Suggested scope
+      description: Which release window does this fit into? See the `v0` / `v0.5` / `v1` / `v2` / `v3` / `v4` labels for guidance.
+      options:
+        - v0 (devnet readiness)
+        - v0.5 (Ligate MCP / Iris)
+        - v1 (post-devnet, identity + disputes + economic trust)
+        - v2 (cryptographic verification, payments, agents)
+        - v3 (decentralisation, ecosystem)
+        - v4 (general-purpose extension via EVM compatibility)
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Suggested priority
+      options:
+        - p0 (blocking critical path)
+        - p1 (important but not blocking)
+        - p2 (nice-to-have)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Optional. Links to specs, prior art in other chains, sketches.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,64 @@
+<!--
+Template for pull requests against ligate-io/ligate-chain.
+
+Keep one concern per PR. If you're solving more than one problem,
+split the work into separate PRs so reviewers can evaluate each
+independently. See CONTRIBUTING.md for the full conventions.
+-->
+
+## Summary
+
+<!-- One to three sentences. What does this PR do, and why does it matter? -->
+
+## What lands
+
+<!--
+Bulleted list of concrete changes. Reviewers should be able to map
+each bullet to a chunk of the diff.
+
+Example:
+- New `route_get_schema` handler in `crates/modules/attestation/src/query.rs`
+- `ModuleRestApi` derive on `AttestationModule<S>`
+- 5 integration tests in `tests/integration.rs` covering happy path + 404 + 400
+-->
+
+-
+
+## Why this shape
+
+<!--
+The "why", not the "what". The diff covers what changed; this section
+covers the rationale, alternatives considered, and any non-obvious
+trade-offs. Skip if the PR is a one-liner.
+-->
+
+## Out of scope
+
+<!--
+What you considered but deliberately did not include in this PR, with
+a pointer to where it gets handled. Stops reviewers from asking "why
+not also fix X?".
+-->
+
+## Test plan
+
+<!--
+Checkboxes for each thing you verified. Include both local CI gates
+and any manual / integration verification.
+-->
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
+- [ ] `cargo audit`
+- [ ] `CI pass` green on the pull request
+
+## Related issues
+
+<!--
+Use "closes #N" for issues this PR fully resolves and "refs #N" for
+ones it touches but does not close. Helps the project board auto-update.
+-->
+
+closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+# Dependabot config for ligate-chain.
+#
+# Two ecosystems we care about:
+#   - cargo: workspace dependencies in Cargo.toml + transitives
+#   - github-actions: pinned action versions in .github/workflows/
+#
+# Both run weekly on Monday morning Europe/Amsterdam to land in our
+# review queue at the start of the work week. The five-PR cap on cargo
+# avoids review-queue floods on weeks with many small bumps.
+#
+# Grouping rationale:
+#
+#   - sov-* crates are a single git-pinned Sovereign SDK rev. Bumping
+#     them piecemeal would create incompatible PRs that don't compile;
+#     group them so a Dependabot PR moves the whole rev together.
+#   - risc0-* crates are released in lockstep. Same logic.
+#
+# Major-version bumps stay separate (default behaviour) so we eyeball
+# each one rather than auto-grouping breaking changes.
+#
+# Auto-merge is deliberately not configured. Maintainers review every
+# Dependabot PR until we have a track record of clean upgrades.
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 5
+    groups:
+      sov-rollup-deps:
+        patterns:
+          - "sov-*"
+        update-types:
+          - "minor"
+          - "patch"
+      risc0:
+        patterns:
+          - "risc0-*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "foundation"
+      - "p2"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 3
+    labels:
+      - "foundation"
+      - "p2"
+    commit-message:
+      prefix: "deps(actions)"
+      include: "scope"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct. The full text is canonical at that URL and applies in full to every space associated with this repository: the GitHub repository itself, GitHub Discussions, issues, pull requests, code reviews, and any community channels run by Ligate Labs that reference this project.
+
+## Scope
+
+The code applies to anyone participating in the project. That includes maintainers, contributors, and anyone interacting in project-managed spaces or representing the project in public spaces.
+
+## Reporting
+
+If you encounter a violation, please report it to the maintainers at <hello@ligate.io> with the subject line prefixed `[CONDUCT]`. Reports route to the maintainer triage queue and are kept confidential. We will respond within two business days to acknowledge the report and outline next steps.
+
+If a maintainer is the subject of a report, contact a different maintainer or any organisation owner of `ligate-io` directly so that the report does not route through the involved party.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing the standards of the Contributor Covenant and will take appropriate and fair corrective action in response to behavior they deem inappropriate, threatening, offensive, or harmful. Enforcement actions may include warnings, temporary bans from project spaces, or permanent bans, in line with the Community Impact Guidelines published with the Covenant.
+
+## Attribution
+
+This Code of Conduct is adopted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), which itself is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,217 @@
+# Contributing to Ligate Chain
+
+Thanks for the interest. This document covers everything from cloning the repo to merging a PR.
+
+The short version: read [`README.md`](README.md) for what the chain is, [`docs/protocol/attestation-v0.md`](docs/protocol/attestation-v0.md) for how the protocol actually works, run `cargo test --workspace` to verify your environment, then open a focused PR with a clear test plan. The longer version follows.
+
+## Table of contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Local development setup](#local-development-setup)
+- [Project layout](#project-layout)
+- [Running tests locally](#running-tests-locally)
+- [Code style](#code-style)
+- [Commit conventions](#commit-conventions)
+- [Pull request conventions](#pull-request-conventions)
+- [Required reading for protocol PRs](#required-reading-for-protocol-prs)
+- [CI gates](#ci-gates)
+- [Filing issues](#filing-issues)
+- [Security disclosures](#security-disclosures)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant 2.1](CODE_OF_CONDUCT.md). By participating, you agree to abide by it. Reports go to `hello@ligate.io` with subject prefix `[CONDUCT]`.
+
+## Local development setup
+
+### Toolchain
+
+The Rust toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml) (currently `1.93.0`). Any modern `rustup` will install it automatically when you `cd` into the repo or run `cargo build` for the first time. Don't override the toolchain unless you're explicitly testing a different version.
+
+### System dependencies
+
+The chain pulls in `librocksdb-sys`, which needs `libclang` at build time:
+
+**Ubuntu / Debian**
+
+```bash
+sudo apt install -y libclang-dev clang
+```
+
+**macOS**
+
+The Command Line Tools ship with what's needed:
+
+```bash
+xcode-select --install
+```
+
+Then export the dyld and libclang paths so `librocksdb-sys`'s build script can find the dylib at link time. Add to `~/.zshrc` or `~/.bashrc`:
+
+```bash
+export DYLD_FALLBACK_LIBRARY_PATH=/Library/Developer/CommandLineTools/usr/lib
+export LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib
+```
+
+Or set them per-invocation:
+
+```bash
+DYLD_FALLBACK_LIBRARY_PATH=/Library/Developer/CommandLineTools/usr/lib \
+LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib \
+cargo test --workspace
+```
+
+### macOS-only Risc0 workaround
+
+The Risc0 prover crate (`crates/rollup/provers/risc0`) builds Metal kernels on macOS. If your Command Line Tools install is missing the Metal SDK (i.e. you don't have Xcode proper), set:
+
+```bash
+export RISC0_SKIP_BUILD_KERNELS=1
+```
+
+This is a per-machine workaround. **Do not** set it in CI — Linux runners build the CPU kernels cleanly, and skipping there produces unresolved-symbol errors at link time. CI also sets `SKIP_GUEST_BUILD=1` to skip the heavy ~10-minute zkVM guest compilation; that one's fine to mirror locally.
+
+### First build
+
+```bash
+git clone https://github.com/ligate-io/ligate-chain
+cd ligate-chain
+cargo build --workspace
+```
+
+Cold build: ~3-5 minutes on a recent dev machine. Warm rebuild: seconds.
+
+## Project layout
+
+The `README.md` `## Workspace layout` section is the canonical reference. Quick map:
+
+- `crates/modules/attestation` — the attestation protocol module (state, call handlers, REST queries)
+- `crates/stf`, `crates/stf-declaration` — runtime composition (the chain's modules wired into a state-transition function)
+- `crates/rollup` — the `ligate-node` binary
+- `crates/rollup/provers/risc0` — Risc0 inner zkVM prover, with a Celestia guest sub-workspace
+- `crates/client-rs` — Rust client SDK
+- `devnet/` — checked-in genesis JSONs + Mock/Celestia rollup TOMLs
+- `docs/protocol/` — protocol specifications
+- `docs/development/` — operator runbooks
+
+## Running tests locally
+
+```bash
+# Workspace-wide library + integration + doc tests
+cargo test --workspace
+
+# Just one crate (faster iteration)
+cargo test -p attestation --all-features
+
+# A single test by name
+cargo test -p attestation query_get_schema_returns_registered_schema
+
+# Skip the heavy zkVM guest build (matches CI)
+SKIP_GUEST_BUILD=1 cargo test --workspace
+```
+
+If you're touching a state map, an attestor signature path, or the genesis loader, run the full suite — there are 29+ integration tests that exercise the cross-module invariants (sequencer-registry locking, attester/prover bonds, fee routing through `sov-bank`).
+
+## Code style
+
+### rustfmt
+
+`rustfmt` config is in [`rustfmt.toml`](rustfmt.toml). CI runs:
+
+```bash
+cargo fmt --all -- --check
+```
+
+If your local rustfmt version differs from CI's pinned `1.93.0`, the check might disagree. Easy fix: re-run `rustup update`, or run `cargo +1.93.0 fmt --all` explicitly.
+
+### clippy
+
+CI treats every clippy warning as an error:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Don't `#[allow(...)]` to silence a clippy warning unless you've left a comment explaining *why* the lint is wrong for your case.
+
+### rustdoc
+
+Public items must have a doc comment. CI builds docs with `RUSTDOCFLAGS=-D warnings`:
+
+```bash
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
+```
+
+Comment density expectation for public protocol types (`Schema`, `AttestorSet`, `Attestation`, `CallMessage`, etc.): every field needs a doc comment, every variant needs a doc comment, every method needs a doc comment with a one-line summary. These are the surface third-party builders consume; treat them like API docs, not internal notes.
+
+For module-internal helpers, doc comments are encouraged but not enforced.
+
+## Commit conventions
+
+- **One-line subject.** Imperative mood, ideally under 72 characters. Examples from the repo: `Add LICENSE-APACHE and LICENSE-MIT files to match workspace declaration`, `Skip code-checking jobs on docs-only PRs via paths-filter + CI summary check`.
+- **Optional body.** Blank line then a paragraph explaining *why* the change is shaped this way, not what it does (the diff covers what).
+- **No `Co-Authored-By` trailer.** Repo-wide convention.
+- **No `Signed-off-by`.** We don't run a DCO.
+- **Reference issues** in the subject or body when relevant: `(refs #21)`, `(closes #76)`.
+- **One concern per commit.** If you're adding a feature *and* fixing an unrelated bug, that's two commits.
+
+## Pull request conventions
+
+- **One concern per PR.** Reviewers should be able to summarise your PR in one sentence. If they can't, split it.
+- **Test plan in the description.** Use the `.github/PULL_REQUEST_TEMPLATE.md` checkboxes — it forces you to think through what you've actually verified.
+- **CI must be green.** The required check is `CI pass` (a summary that aggregates `fmt`, `clippy`, `check`, `test`, `doc`, `audit`). Docs-only PRs skip the heavy gates via `paths-filter`; that's intentional.
+- **Reviews.** One approving review required (currently bypassed for the founder; this changes when a second engineer joins). For external contributors, expect a review turnaround of 1-3 business days.
+- **Rebasing vs. merging.** No hard preference — `merge`, `squash`, and `rebase` are all allowed. Squash is the default for tidy single-commit changes.
+
+## Required reading for protocol PRs
+
+If your PR touches `crates/modules/attestation`, the runtime composition in `crates/stf`, or any state shape that ends up in `devnet/genesis/*.json`, read these first:
+
+1. [`docs/protocol/attestation-v0.md`](docs/protocol/attestation-v0.md) — the protocol specification (entities, state layout, fees, invariants)
+2. [`docs/protocol/addresses-and-signing.md`](docs/protocol/addresses-and-signing.md) — why the chain signs ed25519 natively, what `lig1...` addresses are, and what changes when EVM auth lands (#72)
+
+Wire-format-affecting changes (Borsh layout shifts, `MAX_*` cap bumps, new `CallMessage` variants) need a migration story before they merge. Open a discussion or draft PR if you're unsure whether your change qualifies.
+
+## CI gates
+
+The required gate is **`CI pass`**. It's a summary job that watches the underlying jobs and accepts:
+
+| Job | Purpose | Skipped on docs-only PRs? |
+|---|---|---|
+| `cargo fmt` | Format check (`-- --check`) | yes |
+| `cargo clippy` | Lints (`-D warnings`) | yes |
+| `cargo check` | Compile check (`--workspace --all-targets`) | yes |
+| `cargo test` | Workspace lib + integration + doctests | yes |
+| `cargo doc` | rustdoc with `-D warnings` | yes |
+| `cargo audit` | RUSTSEC advisories | **no** — runs on every PR |
+
+Why `cargo audit` ignores the path filter: new advisories appear independent of your diff. We want every PR to be a checkpoint for security signal.
+
+Local equivalent (run before pushing):
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo check --workspace --all-targets
+cargo test --workspace
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
+cargo audit
+```
+
+Ignored advisories live in [`audit.toml`](audit.toml) — every entry is a transitive dep pinned by the Sovereign SDK. They clear automatically on SDK upgrades.
+
+## Filing issues
+
+Use the GitHub issue forms:
+
+- **Bug report** — something broke; include the commit hash, OS, and a minimal repro
+- **Feature request** — propose a new capability; include the user problem, alternatives considered, and a v0/v1/v2 scope guess
+- **Question** — usually redirected to GitHub Discussions; only file as an issue if the answer needs a code change
+
+Don't file a blank issue — the templates are there to keep the queue actionable.
+
+## Security disclosures
+
+**Do not file public issues for vulnerabilities.** See [`SECURITY.md`](SECURITY.md) for the disclosure policy. Short version: open a GitHub Private Security Advisory at <https://github.com/ligate-io/ligate-chain/security/advisories/new>, or email `hello@ligate.io` with subject prefix `[SECURITY]`.
+
+Acknowledgement within 2 business days. 90-day coordinated disclosure default.

--- a/README.md
+++ b/README.md
@@ -255,16 +255,17 @@ v0 scope is the attestation protocol only. Identity, disputes/slashing, payments
 
 ## Contributing
 
-Required reading before a non-trivial PR:
+The full contributor guide is in [`CONTRIBUTING.md`](CONTRIBUTING.md): local dev setup (including the macOS libclang gotcha and the per-machine Risc0 workaround), code style, commit conventions, PR process, and the CI gates your branch has to pass.
 
-1. [`docs/protocol/attestation-v0.md`](docs/protocol/attestation-v0.md) for the protocol itself.
-2. [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for the CI jobs your branch has to pass.
+Required reading before a non-trivial protocol PR:
 
-CI runs six jobs and all must pass: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo check`, `cargo test`, `cargo doc` (with `RUSTDOCFLAGS=-D warnings`), and `cargo audit`. Please run them locally before pushing; the full list is in the "Build and test" section above.
+1. [`docs/protocol/attestation-v0.md`](docs/protocol/attestation-v0.md) — the protocol specification.
+2. [`docs/protocol/addresses-and-signing.md`](docs/protocol/addresses-and-signing.md) — addressing and signature schemes.
+3. [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — the CI gates.
 
-Commit style: one-line subject (imperative mood, under ~72 chars), blank line, short body explaining the why. Keep changes focused; open separate PRs for independent concerns.
+This project adopts the [Contributor Covenant](CODE_OF_CONDUCT.md). Security disclosures go through [`SECURITY.md`](SECURITY.md), not public issues.
 
-Issues, questions, and bug reports: [github.com/ligate-io/ligate-chain/issues](https://github.com/ligate-io/ligate-chain/issues).
+Issues and bug reports: [github.com/ligate-io/ligate-chain/issues](https://github.com/ligate-io/ligate-chain/issues). General questions and design discussions: [GitHub Discussions](https://github.com/ligate-io/ligate-chain/discussions).
 
 ## License
 


### PR DESCRIPTION
## Summary

Public-repo hygiene bundle. With `ligate-chain` flipped to public, the four most-visible gaps for anyone landing on the repo cold were: no contributor guide, no Code of Conduct, no PR/issue templates, and no Dependabot. This PR closes all four. Pure additive, no chain code touched.

## What lands

### `CONTRIBUTING.md` (closes #86)

Full contributor guide. Sections:

- Code of Conduct pointer
- Local development setup (Rust toolchain pin, Ubuntu/Debian and macOS system deps with the `DYLD_FALLBACK_LIBRARY_PATH` + `LIBCLANG_PATH` exports written out, the macOS-only `RISC0_SKIP_BUILD_KERNELS` workaround for setups missing the Metal SDK, why CI doesn't set it)
- Project layout (pointer at the README's workspace map)
- Running tests locally (full + per-crate + per-test commands; the `SKIP_GUEST_BUILD=1` env var to mirror CI)
- Code style (rustfmt + clippy + rustdoc with comment-density expectations for public protocol types)
- Commit conventions (one-line subject, no Co-Authored-By trailer, no DCO sign-off, issue references)
- Pull request conventions (one-concern-per-PR, test plan checkboxes, the bypass note for the founder, expected review turnaround)
- Required reading for protocol PRs (the spec + the addresses-and-signing doc)
- CI gates table mapping each job to its purpose and which ones path-filter skips on docs-only PRs (and why `cargo audit` deliberately doesn't)
- Filing issues (pointer at the templates)
- Security disclosures (pointer at SECURITY.md)

Goal: a new contributor can go from clone to merged PR by reading only this one file.

### `CODE_OF_CONDUCT.md` (closes #87)

Adopts the Contributor Covenant 2.1 by reference (the canonical text lives at `contributor-covenant.org`; embedding it verbatim adds maintenance overhead with no benefit). Includes:

- Scope (the project, Discussions, issues, PRs, code reviews, any Ligate-Labs-run channels referencing the project)
- Reporting channel (`hello@ligate.io` with `[CONDUCT]` subject prefix; alternate path if a maintainer is the subject of a report; 2-business-day acknowledgement)
- Enforcement notes (maintainers act per the Covenant's Community Impact Guidelines)
- Attribution (CC BY 4.0 source, linked)

GitHub's Community Profile detection recognises this pattern.

### `.github/PULL_REQUEST_TEMPLATE.md` (part of #88)

Six sections that match what reviewers consistently want:

- Summary (1–3 sentences)
- What lands (bullets that map to diff chunks)
- Why this shape (rationale, alternatives)
- Out of scope (forestalls "but what about X?")
- Test plan (checkboxes for each verification, including the six local CI gates and the `CI pass` summary)
- Related issues (`closes #N` / `refs #N`)

HTML comments throughout explain the intent of each section without showing in the rendered preview.

### `.github/ISSUE_TEMPLATE/` (rest of #88)

- `bug_report.yml` — what happened, expected, repro, commit hash, OS dropdown (Linux/macOS variants), Rust toolchain, logs (rendered as shell), extras
- `feature_request.yml` — problem to solve, proposed approach, alternatives, scope dropdown (`v0`/`v0.5`/`v1`/`v2`/`v3`/`v4`), priority dropdown (`p0`/`p1`/`p2`)
- `config.yml` — `blank_issues_enabled: false`, plus three contact links: GitHub Discussions for questions, the private security advisory URL for vulnerabilities, and `mailto:hello@ligate.io` for everything else

GitHub forms format (YAML) so each field is structured and required where it matters.

### `.github/dependabot.yml` (closes #89)

Two ecosystems, weekly schedule (Monday 06:00 Europe/Amsterdam):

- `cargo`: 5-PR cap. Two grouped patterns: `sov-*` (the Sovereign SDK rev-pinned crates that must move together; bumping piecemeal produces incompatible compiles) and `risc0-*` (released in lockstep). Major bumps stay ungrouped.
- `github-actions`: 3-PR cap. Pinned action versions in `.github/workflows/`.

Labels: `foundation` + `p2` for both. Commit-message prefixes `deps` / `deps(actions)` so they're filterable in the log. Auto-merge deliberately not configured — maintainers eyeball every Dependabot PR until there's a track record of clean upgrades.

### `README.md` polish

`## Contributing` section trimmed: instead of duplicating dev-setup details, point at `CONTRIBUTING.md`. Adds explicit pointers at `CODE_OF_CONDUCT.md`, `SECURITY.md`, and the GitHub Discussions URL. Two extra lines, removes ~five.

## Why this shape

- **Bundled into one PR.** Four issues, but the code is all small public-repo boilerplate that lands together cleanly. Splitting into four PRs would 4x the review overhead for what's mostly verbatim conventions.
- **Code of Conduct by reference, not embedded.** Modern projects commonly link to the Contributor Covenant 2.1 rather than vendoring the full text. GitHub's Community Profile detection still recognises the pattern, and we avoid stale-text drift if the Covenant updates.
- **Issue forms (YAML), not Markdown templates.** YAML forms enforce required fields and provide dropdowns that keep the queue actionable. Markdown templates are a free-text box reviewers have to chase for missing context.
- **Dependabot weekly, not daily.** Daily floods the review queue with low-signal patches. Weekly batches arrive at the start of the work week, get reviewed together, and land or get rolled back as a set.
- **No DCO / sign-off requirement.** We're already dual-licensed Apache-2.0 / MIT with the standard Rust contribution trailer in the README's License section. Adding DCO would be belt-and-braces with no real protection upgrade.

## Test plan

- [x] `cargo fmt --all -- --check`: clean (no Rust files touched)
- [x] YAML files parse (`python3 -c "import yaml; ..."` for `dependabot.yml` + 3 issue templates)
- [x] All four files referenced by `README.md` and `CONTRIBUTING.md` exist at the linked paths
- [ ] Render `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` on GitHub and confirm internal links resolve
- [ ] Open a draft "test" issue from GitHub UI and confirm:
  - `Open a blank issue` is gone
  - Three contact links appear (Discussions, Security advisory, hello@ligate.io)
  - Bug and Feature templates surface their forms
- [ ] Open a draft PR and confirm the template renders with all six sections + the six CI-gate checkboxes
- [ ] Wait for the first Dependabot PR (next Monday morning local time) and confirm it groups correctly
- [ ] GitHub Community Profile (`/community`) shows all four hygiene boxes complete (CONTRIBUTING, CODE_OF_CONDUCT, SECURITY which is already there from #90, and either issue templates or PR template)

## Out of scope

- Auto-merge for low-risk Dependabot patches — explicitly deferred until we have a clean-upgrade track record
- A separate `security@ligate.io` PGP-keyed inbox — flagged in `SECURITY.md` as roadmap, lands closer to mainnet
- A `CHANGELOG.md` — not yet, will introduce when v0.1 gets tagged
- Repository-level discussions categories setup (the URL in `config.yml` works as-is; categories are admin-tab work)
- Any new chain code or tests

## Closes

- closes #86 (CONTRIBUTING.md)
- closes #87 (CODE_OF_CONDUCT.md)
- closes #88 (PR + issue templates)
- closes #89 (Dependabot config)
