### PR TITLE
Dependabot: ignore SDK-locked schemars major and strum minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,14 @@
 #
 # Auto-merge is deliberately not configured. Maintainers review every
 # Dependabot PR until we have a track record of clean upgrades.
+#
+# Ignore rules cover crates whose newer versions are blocked by the
+# Sovereign SDK rev we git-pin to. The SDK macros emit code against
+# specific transitive-dep API shapes; bumping past what the SDK
+# supports breaks compilation across half the workspace. Pattern when
+# a Dependabot PR fails for this reason: close the PR, add the
+# dep-name to the ignore list below, revisit when we bump the SDK
+# pin in `Cargo.toml` to a rev that supports the newer API.
 
 version: 2
 updates:
@@ -44,6 +52,22 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # schemars 1.x is a major-version bump with breaking API changes
+      # (gen module renamed, schema_name() signature changed, schema
+      # module became private). Sovereign SDK derive macros at our
+      # pinned rev still consume the 0.8 API. Revisit when the SDK
+      # rev we track adopts schemars 1.x. See closed #100.
+      - dependency-name: "schemars"
+        update-types: ["version-update:semver-major"]
+      # strum 0.26 -> 0.27 reorganised VariantArray / VariantNames.
+      # The SDK's #[derive(DispatchCall)] and friends emit code
+      # against the 0.26 trait shapes. Pre-1.0 minor IS breaking
+      # in semver terms here. Revisit on SDK rev bump. See closed #101.
+      - dependency-name: "strum"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     labels:
       - "foundation"
       - "p2"


### PR DESCRIPTION
## Summary

Dependabot opened #100 (schemars 0.8.22 → 1.2.1) and #101 (strum 0.26.3 → 0.27.2) on Monday. Both fail CI because they're blocked by the Sovereign SDK rev we git-pin to in `Cargo.toml`. Closed both. This PR extends `.github/dependabot.yml` with ignore rules so they stop reopening every week.

## What lands

- **`.github/dependabot.yml`**: adds an `ignore:` block under the cargo ecosystem with two entries:
  - `schemars`: ignore semver-major (the breaking 0.8 → 1.x shift)
  - `strum`: ignore semver-minor and semver-major (pre-1.0 minor 0.26 → 0.27 is breaking in this case; the trait reorganisation broke `VariantArray` / `VariantNames` derive output across the SDK macros)
- A header comment documents the pattern: when a Dependabot PR fails due to upstream SDK lock, close it and add the dep-name here. Revisit when we bump the SDK rev in `Cargo.toml` to one that supports the newer API.

## Why

Schemars 1.x and strum 0.27 are both real, valid releases of those crates. We can't adopt them unilaterally because the Sovereign SDK at our pinned rev (`f89964c66bcfb6a31712e43278378b54c33d3779`) emits derive-macro output that consumes the older API:

- Schemars: `gen` module renamed (now reserved keyword), `schema_name()` signature changed `String` → `Cow<'static, str>`, `schema` module became private. SDK macros output `impl JsonSchema` against the 0.8 shape across `RuntimeCallDiscriminants`, `AttestationEvent`, `SchemaIdBech32`, etc.
- Strum: `VariantArray` and `VariantNames` traits reorganised in 0.27. The SDK's `#[derive(DispatchCall)]` and friends emit `RuntimeCallDiscriminants: strum::VariantArray` bounds that don't satisfy on the new trait location.

Verified the SDK's `dev` branch (9 commits ahead of our pin) hasn't moved to either yet, so even bumping our SDK rev in Cargo.toml wouldn't unblock this. The right move is wait for upstream and document the wait.

## Test plan

- [x] `python3 -c "import yaml; ..."` — file parses
- [x] No Rust changes — `paths-filter` will skip `cargo fmt/clippy/check/test/doc` correctly; `cargo audit` still runs (it always does); `CI pass` accepts the skipped state
- [ ] Verify next Monday's Dependabot run does NOT re-open PRs for `schemars` major or `strum` minor/major

## Out of scope

- Bumping the Sovereign SDK rev in `Cargo.toml`. Separate effort, separate PR — there are 9 commits between our pin and SDK `dev` head; worth a periodic review but not driven by these specific Dependabot bumps.
- Auto-merge for low-risk Dependabot patches. Still deliberately not configured; revisit after we have a clean-upgrade track record.

## Refs

- closes nothing directly (the broken Dependabot PRs are already closed: #100, #101)
- documents the upstream-lock pattern for future Dependabot triage
