### PR TITLE
Mark public protocol enums #[non_exhaustive] (closes #43)

### DIFF
--- a/crates/client-rs/src/lib.rs
+++ b/crates/client-rs/src/lib.rs
@@ -94,6 +94,7 @@ pub use attestation::{
 
 /// Errors surfaced by the Ligate client SDK.
 #[derive(Debug, ThisError)]
+#[non_exhaustive]
 pub enum ClientError {
     /// Caller supplied a `Vec<PubKey>` longer than
     /// [`MAX_ATTESTOR_SET_MEMBERS`].

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -371,10 +371,16 @@ impl<S: Spec> SignedAttestationPayload<S> {
 /// `rename = "CallMessage"` keeps the schema name stable across
 /// generic instantiations, sidestepping the type-parameter-name
 /// resolution issue the auto-derive otherwise hits on `<S>`.
+// `#[non_exhaustive]` so downstream consumers must include a `_ =>`
+// arm when matching CallMessage. New protocol variants land in v1+
+// (e.g. `RegisterTokenSchema`, `RegisterIdentity`); the attribute
+// keeps non-Ligate code from compile-breaking on those additions.
+// Matches the `std::io::ErrorKind` pattern for protocol enums.
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema, UniversalWallet)]
 #[serialize(Borsh, Serde)]
 #[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "CallMessage")]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum CallMessage<S: Spec> {
     /// Register a new [`AttestorSet`].
     ///
@@ -634,6 +640,7 @@ pub struct AttestationConfig<S: Spec> {
 /// returned from a Module handler, so callers of the RPC can pattern-match
 /// on the wire shape while the chain runtime stays generic.
 #[derive(Debug, ThisError)]
+#[non_exhaustive]
 pub enum AttestationError {
     /// `threshold` was greater than the number of supplied members.
     #[error("attestor set threshold ({threshold}) exceeds member count ({count})")]
@@ -759,6 +766,7 @@ pub enum AttestationError {
     Deserialize,
     schemars::JsonSchema,
 )]
+#[non_exhaustive]
 pub enum AttestationEvent {
     /// Placeholder variant. Never emitted in v0; reserved so the enum
     /// is non-empty (Borsh derives require at least one variant on

--- a/crates/stf/src/genesis_config.rs
+++ b/crates/stf/src/genesis_config.rs
@@ -108,6 +108,7 @@ impl GenesisPaths {
 /// `Io` and `ParseJson` keep the offending path in the error so
 /// operators can pinpoint the bad file without scanning logs.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum GenesisError {
     /// Failed to read a per-module JSON file from disk.
     #[error("failed to read {path}: {source}")]


### PR DESCRIPTION
## Summary

Mark every public enum in the chain crates `#[non_exhaustive]`. Now that `ligate-chain` is public, downstream consumers should not be free to write exhaustive `match` arms over our protocol enums — adding variants in v1+ (new `CallMessage` variants when the `tokens` and `nft` modules ship, new `AttestationError` cases, new `ClientError` cases) needs to be a non-breaking minor release for crates depending on us. `#[non_exhaustive]` is the standard Rust mechanism that achieves this.

## What lands

Five enums marked, one line each:

| Enum | Crate | Why |
|---|---|---|
| `CallMessage<S>` | `attestation` | Protocol call surface. New variants land in v1+ (`tokens` #47, `nft` #48, `payments`, `agents`, `identity`, `disputes`). Match the `std::io::ErrorKind` pattern for protocol enums. |
| `AttestationError` | `attestation` | Error enum. New cases as the module grows. Standard practice. |
| `AttestationEvent` | `attestation` | Event enum. Real events land alongside #21 (now closed) and onward. |
| `GenesisError` | `ligate-stf` | Error enum. New cases as genesis loader grows. Standard practice. |
| `ClientError` | `ligate-client` | Error enum. New cases as the SDK surface grows. Standard practice. |

## What it does for downstream consumers

Inside this repo, exhaustive matches on these enums still compile (the attribute only affects *downstream* crates outside the defining one). External consumers must include a `_ => ...` arm in any `match` over them, or get a compile error pointing at the missing wildcard. That's the contract: future-Ligate-Chain may add variants in non-breaking releases, your code stays compiling.

## Why not on every enum

Skipped these intentionally:

- `SupportedDaLayer` in `crates/rollup/src/main.rs` is a CLI-internal `clap::ValueEnum`. It IS open-ended (we'll add new DA layers — Avail, EigenDA — later) but `clap`'s parsing handles unknowns at runtime and there's no public-API match concern. Adding the attribute is fine; left out for now to keep the PR focused on the protocol surface.
- Various `#[derive]`-generated enums (`RuntimeCall<S>`, `RuntimeEvent<S>`, etc.) come from SDK macros — we don't own them, the SDK does.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p attestation -p ligate-stf -p ligate-client --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test -p attestation -p ligate-stf -p ligate-client --all-features` — all 31 tests pass (29 attestation integration + 2 smoke), no doctests broken
- [ ] Same gates green on CI

## Refs

- closes #43
