### PR TITLE
Ignore RUSTSEC-2026-0112 and -0113 (astral-tokio-tar, transitive test-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,8 @@ jobs:
             --ignore RUSTSEC-2026-0099 \
             --ignore RUSTSEC-2025-0141 \
             --ignore RUSTSEC-2025-0134 \
+            --ignore RUSTSEC-2026-0112 \
+            --ignore RUSTSEC-2026-0113 \
             --ignore RUSTSEC-2026-0066 \
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2025-0055

--- a/audit.toml
+++ b/audit.toml
@@ -39,6 +39,21 @@ ignore = [
     # transitively bumps astral-tokio-tar to >= 0.6.0.
     "RUSTSEC-2026-0066",
 
+    # astral-tokio-tar 0.5.6, PAX header desynchronization. Same dep
+    # path as -0066 above (testcontainers -> astral-tokio-tar in the
+    # sov-test-utils dev-deps). Same threat-model justification: we
+    # never extract attacker-controlled tar archives. Solution per
+    # RUSTSEC: upgrade to >= 0.6.1; clears when SDK testcontainers
+    # bumps. Filed 2026-04-28.
+    "RUSTSEC-2026-0112",
+
+    # astral-tokio-tar 0.5.6, `unpack_in` can chmod arbitrary directories
+    # by following symlinks. Same dep path as -0066 / -0112. Same
+    # threat-model justification: not reachable from production code.
+    # Solution: upgrade to >= 0.6.1; clears when SDK testcontainers
+    # bumps. Filed 2026-04-28.
+    "RUSTSEC-2026-0113",
+
     # rsa 0.9.x Marvin attack (CVSS 5.9). Pulled by sqlx-mysql, which is
     # a transitive build-time dep of sov-db's optional sqlx integration.
     # No production code path uses MySQL or RSA decryption; the Marvin


### PR DESCRIPTION
## Summary

Two new RUSTSEC advisories landed today on `astral-tokio-tar`, immediately failing `cargo audit` on every open PR. Adds them to the ignore list with the same threat-model justification as the existing `RUSTSEC-2026-0066` entry on the same crate.

| Advisory | Title | Severity |
|---|---|---|
| `RUSTSEC-2026-0112` | PAX header desynchronization | low |
| `RUSTSEC-2026-0113` | `unpack_in` chmod arbitrary directories via symlinks | low |

## Why ignore

`astral-tokio-tar` is pulled transitively by `testcontainers`, which is a **test-only dep** of `sov-test-utils`. We never extract attacker-controlled tar archives in production code. The existing `RUSTSEC-2026-0066` ignore (same package, same dep path, related issue) carries the same rationale and has been stable for weeks.

Solution per RUSTSEC: upgrade to `astral-tokio-tar >= 0.6.1`. We can't — the version is pinned by upstream `testcontainers` which the SDK pulls. The ignore clears automatically when the SDK bumps testcontainers.

## What lands

- `audit.toml`: add two new entries with rationale comments cross-referencing `RUSTSEC-2026-0066`. Filed-on date in the comment for tracking.
- `.github/workflows/ci.yml`: add two `--ignore` flags to the `cargo audit` job. Order kept consistent with the file.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses
- [x] No Rust changes, the path filter will skip the heavy gates
- [ ] CI passes on this PR (the only "real" check is `cargo audit` itself, which now no longer reports those two)
- [ ] After merge, rebase #103 (`#[non_exhaustive]` sweep) and confirm CI goes green; same for the chain-id-strings PR coming after

## Refs

- closes nothing directly
- unblocks #103 and the chain-id docs work coming next
