### PR TITLE
Make Labs wordmark fully sage in README lockup (drop 0.65 opacity)

### DIFF
--- a/docs/assets/lockup.svg
+++ b/docs/assets/lockup.svg
@@ -8,5 +8,5 @@
     <rect x="19" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
   </g>
   <rect x="4" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
-  <text x="62" y="24" dominant-baseline="central" style="font-family:'Space Grotesk','Inter','Helvetica Neue',Arial,sans-serif;font-size:22px;font-weight:500;letter-spacing:-0.02em;" fill="#A7D28C">Ligate<tspan dx="4" style="font-weight:400;" fill="#A7D28C" opacity="0.65">Labs</tspan></text>
+  <text x="62" y="24" dominant-baseline="central" style="font-family:'Space Grotesk','Inter','Helvetica Neue',Arial,sans-serif;font-size:22px;font-weight:500;letter-spacing:-0.02em;" fill="#A7D28C">Ligate<tspan dx="4" style="font-weight:400;" fill="#A7D28C">Labs</tspan></text>
 </svg>


### PR DESCRIPTION
## Summary

The Ligate Labs lockup at the top of the README rendered \`Labs\` in sage at 65% opacity, giving \`Ligate\` and \`Labs\` slightly different visual weights. Brand call: both should be the same solid \`#A7D28C\` sage.

## What changed

Single character change in \`docs/assets/lockup.svg\`: removed \`opacity="0.65"\` from the \`Labs\` \`<tspan>\`. Result: \`Labs\` now renders at full sage saturation, matching \`Ligate\`.

## Test plan

- [ ] Render \`README.md\` on GitHub and confirm the lockup at the top shows \`Ligate\` and \`Labs\` in the same sage color
- [ ] Confirm CI green (path-filter routes this to the docs-only fast path; only \`Detect changes\`, \`audit\`, and \`CI pass\` should run)

## Refs

- visual polish on top of the lockup that landed in #78