### PR TITLE
Add Borsh wire-format snapshot tests for public protocol types (closes #45)

### DIFF
--- a/crates/modules/attestation/tests/borsh_snapshot.rs
+++ b/crates/modules/attestation/tests/borsh_snapshot.rs
@@ -1,0 +1,360 @@
+//! Borsh wire-format snapshot tests for the public protocol types.
+//!
+//! Every type that crosses a chain boundary (call messages submitted in
+//! transactions, state values stored on-chain, signed payloads consumed
+//! by attestors) is hashed here against a checked-in expected
+//! encoding. A PR that accidentally shifts a field, reorders a struct,
+//! or changes a serialization derive flips the assertion red — and the
+//! diff in this file makes the wire-format change explicit so reviewers
+//! catch it deliberately.
+//!
+//! ## When this fires
+//!
+//! Common causes: adding a field to a struct, reordering fields,
+//! changing a field's type, swapping a `Vec<T>` cap, adding a new
+//! `CallMessage` variant in any position other than the last (Borsh
+//! enums are tag-prefixed so appending a variant is safe; reordering
+//! is a hard fork).
+//!
+//! ## When this fails
+//!
+//! Two paths:
+//!
+//! 1. **Unintended change.** Revert the diff. The assertion was doing
+//!    its job.
+//! 2. **Intended change.** Update the expected hex literal with the
+//!    new value AND add a comment in the surrounding test explaining
+//!    the wire-format impact. If the change breaks any existing
+//!    on-chain state (state values, attestation signatures), add a
+//!    migration plan to the PR description.
+//!
+//! ## Test data convention
+//!
+//! Each value uses distinctive byte patterns so the encoded bytes
+//! tell a story when read by hand:
+//!
+//! - `0x11..` → SchemaId
+//! - `0x22..` → AttestorSetId
+//! - `0x33..` → PayloadHash
+//! - `0xAA..`, `0xBB..`, `0xCC..` → PubKeys (three of them)
+//! - `0xDD..`, `0xEE..` → AttestorSignature `sig` content
+//! - `0x77..` → submitter address
+//! - `0x88..` → fee_routing_addr
+//!
+//! Strings: `"ligate.test"` for schema name; short, ASCII, no
+//! locale-sensitive surprises.
+
+use attestation::{
+    Attestation, AttestationId, AttestorSet, AttestorSetId, AttestorSignature, CallMessage,
+    PayloadHash, PubKey, Schema, SchemaId, SignedAttestationPayload, MAX_ATTESTATION_SIGNATURES,
+    MAX_ATTESTOR_SET_MEMBERS, MAX_ATTESTOR_SIGNATURE_BYTES,
+};
+use borsh::BorshSerialize;
+use sov_modules_api::{Address, SafeString, SafeVec};
+
+type S = sov_test_utils::TestSpec;
+
+// --- helpers ---------------------------------------------------------------
+
+/// Convert a byte slice to a lowercase hex string with no separators.
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Borsh-serialize `value`, hex-encode, assert against `expected_hex`.
+/// On mismatch, print a clear actionable error pointing the reader at
+/// the file-level docs.
+fn assert_snapshot<T: BorshSerialize>(name: &str, value: &T, expected_hex: &str) {
+    let bytes = borsh::to_vec(value).expect("Borsh serialization of owned data is infallible");
+    let actual_hex = to_hex(&bytes);
+    assert_eq!(
+        actual_hex, expected_hex,
+        "\nBorsh snapshot for `{name}` changed.\n\
+         \n\
+         If this change is intentional (you bumped a protocol type, added a\n\
+         field, reordered a variant), update the expected hex literal with\n\
+         the new value AND document the wire-format impact in the PR. If a\n\
+         migration is required for any existing on-chain state, capture\n\
+         that in the PR description before merging.\n\
+         \n\
+         Otherwise, revert the change.\n\
+         \n\
+         expected: {expected_hex}\n\
+         actual:   {actual_hex}\n",
+    );
+}
+
+// --- 32-byte ID types ------------------------------------------------------
+//
+// All four are macro-generated newtypes around `[u8; 32]`. The Borsh
+// encoding is just the 32 bytes verbatim. Snapshotting them anyway so
+// the test fires if anyone changes the underlying primitive (e.g. moves
+// to a length-prefixed encoding).
+
+#[test]
+fn snapshot_schema_id() {
+    assert_snapshot(
+        "SchemaId",
+        &SchemaId::from([0x11u8; 32]),
+        "1111111111111111111111111111111111111111111111111111111111111111",
+    );
+}
+
+#[test]
+fn snapshot_attestor_set_id() {
+    assert_snapshot(
+        "AttestorSetId",
+        &AttestorSetId::from([0x22u8; 32]),
+        "2222222222222222222222222222222222222222222222222222222222222222",
+    );
+}
+
+#[test]
+fn snapshot_payload_hash() {
+    assert_snapshot(
+        "PayloadHash",
+        &PayloadHash::from([0x33u8; 32]),
+        "3333333333333333333333333333333333333333333333333333333333333333",
+    );
+}
+
+#[test]
+fn snapshot_pubkey() {
+    assert_snapshot(
+        "PubKey",
+        &PubKey::from([0xAAu8; 32]),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+}
+
+// --- AttestationId compound id ---------------------------------------------
+
+#[test]
+fn snapshot_attestation_id() {
+    let id =
+        AttestationId::from_pair(&SchemaId::from([0x11u8; 32]), &PayloadHash::from([0x33u8; 32]));
+    assert_snapshot(
+        "AttestationId",
+        &id,
+        "1111111111111111111111111111111111111111111111111111111111111111\
+         3333333333333333333333333333333333333333333333333333333333333333",
+    );
+}
+
+// --- AttestorSet ----------------------------------------------------------
+
+#[test]
+fn snapshot_attestor_set() {
+    let set = AttestorSet {
+        members: vec![
+            PubKey::from([0xAAu8; 32]),
+            PubKey::from([0xBBu8; 32]),
+            PubKey::from([0xCCu8; 32]),
+        ],
+        threshold: 2,
+    };
+    assert_snapshot(
+        "AttestorSet",
+        &set,
+        // Borsh: u32 len (3 = 0x03000000 LE) + 3 × 32-byte members + u8 threshold (0x02)
+        "03000000\
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+         bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\
+         cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\
+         02",
+    );
+}
+
+// --- AttestorSignature ----------------------------------------------------
+
+#[test]
+fn snapshot_attestor_signature() {
+    let sig = AttestorSignature {
+        pubkey: PubKey::from([0xAAu8; 32]),
+        sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(vec![0xDDu8; 64])
+            .expect("64 bytes fits MAX_ATTESTOR_SIGNATURE_BYTES (96)"),
+    };
+    assert_snapshot(
+        "AttestorSignature",
+        &sig,
+        // Borsh: 32-byte pubkey + u32 sig len (64 = 0x40000000 LE) + 64 bytes of 0xDD
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+         40000000\
+         dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\
+         dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    );
+}
+
+// --- Schema<S> ------------------------------------------------------------
+
+#[test]
+fn snapshot_schema() {
+    let schema: Schema<S> = Schema {
+        owner: Address::from([0x77u8; 28]),
+        name: String::from("ligate.test"),
+        version: 1,
+        attestor_set: AttestorSetId::from([0x22u8; 32]),
+        fee_routing_bps: 0,
+        fee_routing_addr: None,
+    };
+    assert_snapshot(
+        "Schema<TestSpec>",
+        &schema,
+        // owner (28 bytes) + name (u32 len = 11 + "ligate.test" UTF-8) +
+        // version (u32 LE) + attestor_set (32 bytes) + fee_routing_bps (u16 LE) +
+        // Option<Address>::None (1 byte tag)
+        "77777777777777777777777777777777777777777777777777777777\
+         0b0000006c69676174652e74657374\
+         01000000\
+         2222222222222222222222222222222222222222222222222222222222222222\
+         0000\
+         00",
+    );
+}
+
+// --- Attestation<S> -------------------------------------------------------
+
+#[test]
+fn snapshot_attestation() {
+    let att: Attestation<S> = Attestation {
+        schema_id: SchemaId::from([0x11u8; 32]),
+        payload_hash: PayloadHash::from([0x33u8; 32]),
+        submitter: Address::from([0x77u8; 28]),
+        timestamp: 0,
+        signatures: vec![AttestorSignature {
+            pubkey: PubKey::from([0xAAu8; 32]),
+            sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(vec![0xDDu8; 64]).unwrap(),
+        }],
+    };
+    assert_snapshot(
+        "Attestation<TestSpec>",
+        &att,
+        // schema_id (32) + payload_hash (32) + submitter (28) + timestamp (u64 LE = 0) +
+        // signatures (u32 len = 1) + 1 × AttestorSignature (32 + u32 len 64 + 64 bytes)
+        "1111111111111111111111111111111111111111111111111111111111111111\
+         3333333333333333333333333333333333333333333333333333333333333333\
+         77777777777777777777777777777777777777777777777777777777\
+         0000000000000000\
+         01000000\
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+         40000000\
+         dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\
+         dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    );
+}
+
+// --- SignedAttestationPayload<S> ------------------------------------------
+//
+// This is the payload attestors sign over. The encoding is load-bearing
+// for cross-attestor signature compatibility — a change here invalidates
+// every signature an off-chain attestor has ever produced.
+
+#[test]
+fn snapshot_signed_attestation_payload() {
+    let payload: SignedAttestationPayload<S> = SignedAttestationPayload {
+        schema_id: SchemaId::from([0x11u8; 32]),
+        payload_hash: PayloadHash::from([0x33u8; 32]),
+        submitter: Address::from([0x77u8; 28]),
+        timestamp: 0,
+    };
+    assert_snapshot(
+        "SignedAttestationPayload<TestSpec>",
+        &payload,
+        // schema_id (32) + payload_hash (32) + submitter (28) + timestamp (u64 LE = 0)
+        "1111111111111111111111111111111111111111111111111111111111111111\
+         3333333333333333333333333333333333333333333333333333333333333333\
+         77777777777777777777777777777777777777777777777777777777\
+         0000000000000000",
+    );
+}
+
+// --- CallMessage<S> variants ---------------------------------------------
+//
+// The call enum is the chain's user-facing transaction surface. Variant
+// **order** is part of the wire format (Borsh prefixes each variant
+// with a u8 tag = its declaration index). Adding a variant in the
+// middle is a hard fork; appending is safe.
+
+#[test]
+fn snapshot_call_message_register_attestor_set() {
+    let msg: CallMessage<S> = CallMessage::RegisterAttestorSet {
+        members: SafeVec::<PubKey, MAX_ATTESTOR_SET_MEMBERS>::try_from(vec![
+            PubKey::from([0xAAu8; 32]),
+            PubKey::from([0xBBu8; 32]),
+            PubKey::from([0xCCu8; 32]),
+        ])
+        .unwrap(),
+        threshold: 2,
+    };
+    assert_snapshot(
+        "CallMessage::RegisterAttestorSet",
+        &msg,
+        // variant tag (0x00) + u32 len (3) + 3 × 32-byte pubkeys + u8 threshold (0x02)
+        "00\
+         03000000\
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+         bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\
+         cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\
+         02",
+    );
+}
+
+#[test]
+fn snapshot_call_message_register_schema() {
+    let msg: CallMessage<S> = CallMessage::RegisterSchema {
+        name: SafeString::try_from(String::from("ligate.test")).unwrap(),
+        version: 1,
+        attestor_set: AttestorSetId::from([0x22u8; 32]),
+        fee_routing_bps: 5000,
+        fee_routing_addr: Some(Address::from([0x88u8; 28])),
+    };
+    assert_snapshot(
+        "CallMessage::RegisterSchema",
+        &msg,
+        // variant tag (0x01) + name (u32 len 11 + "ligate.test") +
+        // version (u32 LE = 1) + attestor_set (32) +
+        // fee_routing_bps (u16 LE = 5000 = 0x88 0x13) +
+        // Option<Address>::Some(...) (tag 0x01 + 28 bytes)
+        "01\
+         0b0000006c69676174652e74657374\
+         01000000\
+         2222222222222222222222222222222222222222222222222222222222222222\
+         8813\
+         01\
+         88888888888888888888888888888888888888888888888888888888",
+    );
+}
+
+#[test]
+fn snapshot_call_message_submit_attestation() {
+    let msg: CallMessage<S> = CallMessage::SubmitAttestation {
+        schema_id: SchemaId::from([0x11u8; 32]),
+        payload_hash: PayloadHash::from([0x33u8; 32]),
+        signatures: SafeVec::<AttestorSignature, MAX_ATTESTATION_SIGNATURES>::try_from(vec![
+            AttestorSignature {
+                pubkey: PubKey::from([0xAAu8; 32]),
+                sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(vec![0xDDu8; 64])
+                    .unwrap(),
+            },
+        ])
+        .unwrap(),
+    };
+    assert_snapshot(
+        "CallMessage::SubmitAttestation",
+        &msg,
+        // variant tag (0x02) + schema_id (32) + payload_hash (32) +
+        // signatures (u32 len 1) + 1 × AttestorSignature (32 + u32 len 64 + 64 bytes)
+        "02\
+         1111111111111111111111111111111111111111111111111111111111111111\
+         3333333333333333333333333333333333333333333333333333333333333333\
+         01000000\
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+         40000000\
+         dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\
+         dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    );
+}


### PR DESCRIPTION
## Summary

Add a Borsh wire-format snapshot test for every public protocol type in the `attestation` crate. Each test builds a deterministic instance, encodes it via Borsh, and asserts the resulting hex against a hardcoded literal. A PR that accidentally shifts a field, reorders a struct, swaps a `Vec<T>` cap, or rearranges a `CallMessage` variant flips the assertion red — the diff in the test file then forces reviewers to evaluate the wire-format change deliberately rather than letting it slip silently into a release.

## Why this matters

Without snapshots, the chain has no automatic gate against silent wire-format breaks. A renamed field, a reordered struct, a bumped `MAX_*` constant — any of those changes the Borsh encoding of an on-chain value and:

- invalidates every signature an off-chain attestor has ever produced (signatures are over the canonical Borsh of `SignedAttestationPayload`),
- breaks the deserialization path for any state already written under the old layout,
- desynchronises the chain hash derivation that the runtime uses for tx domain separation.

Snapshots are the cheapest defence: a single line of hex in a test file that has to be updated, with reviewer attention, every time the wire format moves.

## What lands

A new test file: `crates/modules/attestation/tests/borsh_snapshot.rs`. 360 lines, one `#[test]` per protocol type, plus a header docstring explaining the test's purpose, when it fires, and the two valid responses to a failure (intentional bump → update + document; unintentional → revert).

### Coverage

13 snapshots across 13 types / variants:

| Type | Snapshot |
|---|---|
| `SchemaId`, `AttestorSetId`, `PayloadHash`, `PubKey` (32-byte ID newtypes) | identity-mapped 32-byte encoding |
| `AttestationId` (compound) | `(schema_id, payload_hash)` 64-byte concatenation |
| `AttestorSet` | `Vec<PubKey>` length prefix + members + threshold |
| `AttestorSignature` | pubkey + length-prefixed sig bytes |
| `Schema<TestSpec>` | full struct: owner / name / version / attestor_set / fee_routing_bps / fee_routing_addr |
| `Attestation<TestSpec>` | schema_id / payload_hash / submitter / timestamp / signatures |
| `SignedAttestationPayload<TestSpec>` | the canonical attestor-signed digest payload |
| `CallMessage::RegisterAttestorSet` | enum tag 0x00 + members + threshold |
| `CallMessage::RegisterSchema` | enum tag 0x01 + name + version + attestor_set + fee_routing_bps + fee_routing_addr |
| `CallMessage::SubmitAttestation` | enum tag 0x02 + schema_id + payload_hash + signatures |

`SignedAttestationPayload` is the most load-bearing — its encoding is what attestors sign over. A change there invalidates every signature in flight.

### Test data convention

Distinctive byte patterns so each encoded snapshot tells a story when read by hand:

| Pattern | Type |
|---|---|
| `0x11..` | `SchemaId` |
| `0x22..` | `AttestorSetId` |
| `0x33..` | `PayloadHash` |
| `0xAA..`, `0xBB..`, `0xCC..` | `PubKey` (three of them) |
| `0xDD..` | `AttestorSignature` `sig` content |
| `0x77..` | submitter address |
| `0x88..` | `fee_routing_addr` |

Strings: `"ligate.test"` for schema name — short, ASCII, no locale-sensitive surprises.

### Generic types

Anything `<S: Spec>` is instantiated with `sov_test_utils::TestSpec` (the same spec the existing integration tests use). If we ever switch the canonical test spec, the snapshots regenerate; that's a deliberate, reviewable change.

## When this fires

Common causes of failure:

- Adding a field to `Schema`, `Attestation`, `AttestorSet`, `SignedAttestationPayload`
- Reordering struct fields
- Changing a field's type (e.g. `String` → `SafeString`, `u32` → `u64`)
- Bumping a `MAX_*` constant on a `SafeVec` (changes the Borsh size envelope)
- Adding a new `CallMessage` variant in any position **other than the last** (Borsh enums are tag-prefixed, appending a variant is a soft format change; reordering is a hard fork)

Common false alarms (none expected today, but documented in the file):

- Switching the `S: Spec` parameter — only fires if the test's `type S` line changes, and that's a deliberate cross-test concern

## When this fails

Two paths, documented in the file's docstring:

1. **Unintended change.** Revert the diff. The assertion was doing its job.
2. **Intended change.** Update the expected hex literal AND add a comment in the test explaining the wire-format impact. If the change breaks any existing on-chain state (state values, attestation signatures), the PR description must include a migration plan.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p attestation --all-features --all-targets -- -D warnings` clean
- [x] `cargo test -p attestation --all-features` — **72 tests pass** (13 new snapshot + 28 integration + 2 smoke + 29 unit). Verified breakdown via `--test borsh_snapshot`.
- [x] `cargo check -p attestation` clean
- [ ] Same gates green on CI

## What this is not

- Not a snapshot-based fuzzer or property-test framework. Each snapshot pins one fixed value; we're not exhaustively exploring the input space.
- Not coverage of SDK-derived runtime types (`RuntimeCall<S>`, `RuntimeEvent<S>`). Those are macro-generated by the Sovereign SDK, not owned by us; if their layout shifts, the SDK rev bump that introduces the change is the right place to discuss it. Worth revisiting if we hit a real false-negative.
- Not coverage of `client-rs` types — `client-rs` re-exports `attestation` types, so the protocol surface is already covered. New types added in `client-rs` (none today) would warrant their own snapshots.
- Not enforced via doctest, integration test, or fuzzing — pure `#[test]` against `assert_eq!` on hex strings. Boring on purpose.

## Refs

- closes #45
- builds on the public-API hardening from #103 (`#[non_exhaustive]` on the same types)
