### PR TITLE
Spec: chain REST API is point lookups only; list/range queries live in the indexer (closes #21)

### DIFF
--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -139,15 +139,37 @@ enum CallMessage {
 
 ## Query RPC (read path)
 
+The chain's REST API is **point lookups only by design**. Three endpoints, all single-key:
+
 ```
-get_schema(schema_id)                       -> Option<Schema>
-get_attestor_set(set_id)                    -> Option<AttestorSet>
-get_attestation(schema_id, payload_hash)    -> Option<Attestation>
-list_attestations_by_schema(schema_id, pagination)  -> Vec<AttestationKey>
-list_schemas_by_owner(owner, pagination)    -> Vec<SchemaId>
+GET /modules/attestation/schemas/{schema_id}                       -> Schema | 404
+GET /modules/attestation/attestor-sets/{attestor_set_id}           -> AttestorSet | 404
+GET /modules/attestation/attestations/{schema_id}:{payload_hash}   -> Attestation | 404
 ```
 
-No transactions. No state changes. Cheap to serve from indexed node.
+Wired in [PR #93](https://github.com/ligate-io/ligate-chain/pull/93) (closes the read-side of [#21](https://github.com/ligate-io/ligate-chain/issues/21)). 400 on malformed Bech32, 404 on missing key, 200 with typed JSON body otherwise.
+
+### What's deliberately not here
+
+List, range, time-bucketed, by-submitter, aggregation, top-N, search, full-text — none of those are on the chain. Three reasons:
+
+1. **The chain's data is keyed for verification, not for search.** Every node would have to scan the full attestations map to satisfy a `list_by_schema` query, which is microseconds at v0 devnet volume and minutes at production volume. Pushing search work into the consensus path makes every node pay for every random user's query.
+2. **Adding a secondary index is a hard fork.** A `StateMap<SchemaId, _>` populated on the write path would change the on-chain state shape — see [`docs/protocol/upgrades.md`](upgrades.md) for what counts as a hard fork. We don't want speculative hard forks for query patterns that have a better home elsewhere.
+3. **There's a better home.** Range / list / aggregation queries belong in a separate **indexer service** ([#91](https://github.com/ligate-io/ligate-chain/issues/91)) that reads the chain's REST + WebSocket surface and writes into a real database (Postgres). Standard pattern across every mature chain — Cosmos has Numia / SubQuery / Mintscan, Ethereum has The Graph / Goldsky / Alchemy, Solana has Helius / Triton, Aptos / Sui ship official indexers alongside their validators. The chain stays narrow and fast; the indexer absorbs query-pattern complexity.
+
+If a future query pattern can be answered with a single direct lookup against existing state (e.g. `get_schema_owner_count` derived as a counter on the schema entry), it's fair game for the chain. If it requires scanning, sorting, joining, or windowing, it belongs in the indexer — full stop.
+
+### What lives in the indexer instead
+
+Tracked in [#91](https://github.com/ligate-io/ligate-chain/issues/91), shipping pre-public-devnet alongside the explorer ([#80](https://github.com/ligate-io/ligate-chain/issues/80)):
+
+- `list_attestations_by_schema(schema_id, from?, to?, page, limit)` — the canonical example
+- `list_schemas_by_owner(owner_address, page, limit)`
+- `list_attestations_by_submitter(address, page, limit)`
+- Time-range queries, top-N stats, full-text search
+- WebSocket subscriptions for live events ([#92](https://github.com/ligate-io/ligate-chain/issues/92))
+
+These read the chain's point-lookup REST + the future event firehose; they do not require any chain-side change. The boundary holds.
 
 ---
 


### PR DESCRIPTION
## Summary

Close out #21 by amending the protocol spec to make the chain's REST surface boundary explicit: **the chain's REST API is point lookups only by design; list / range / time-bucketed / aggregation queries live in the indexer service (#91), not on the node**.

This formalises the architectural call we made when deferring `list_by_schema` from PR #93. Now that the indexer is on the backlog and the upgrades doc (#109) defines what a hard fork is, leaving #21 open with an implicit "we'll add list_by_schema someday" was misleading. The right move is closing #21 and recording the boundary so future contributors know not to reach for it.

## What lands

`docs/protocol/attestation-v0.md` `## Query RPC (read path)` section, fully rewritten:

### Before

```
get_schema(schema_id)                       -> Option<Schema>
get_attestor_set(set_id)                    -> Option<AttestorSet>
get_attestation(schema_id, payload_hash)    -> Option<Attestation>
list_attestations_by_schema(schema_id, pagination)  -> Vec<AttestationKey>
list_schemas_by_owner(owner, pagination)    -> Vec<SchemaId>
```

A speculative interface that mixed three real endpoints (the ones #93 shipped) with two list endpoints that never existed and now never will.

### After

The three real endpoints, with their actual paths, response shapes, and HTTP semantics. Plus two new subsections:

- **"What's deliberately not here"** — the three reasons: data is keyed for verification not search; secondary indexes are hard forks (referencing the new `upgrades.md`); the indexer is the better home (referencing #91 + the precedent set by every mature chain — Cosmos / Ethereum / Solana / Aptos / Sui all do this split).
- **"What lives in the indexer instead"** — concrete list of the queries (`list_attestations_by_schema`, `list_schemas_by_owner`, `list_attestations_by_submitter`, time-range, top-N, full-text, WebSocket subscriptions) that the indexer absorbs, with an explicit note that these read the chain's point-lookup REST + future event firehose and require no chain-side change.

The boundary rule, in one line: *if a query can be answered by a direct lookup against existing state, it's fair game for the chain; if it requires scanning, sorting, joining, or windowing, it belongs in the indexer*.

## Why now

Three forcing functions, all today:

1. **#93 shipped the three real endpoints** and deferred the fourth. The spec still listed all five.
2. **The upgrades doc (#109) just defined "hard fork"**: any state-shape change touching Borsh layout. A `list_by_schema` secondary index would be exactly that. Documenting the boundary while the upgrades language is fresh makes the rationale legible.
3. **The indexer issue (#91) is on the backlog at p1 v1**. The architectural commitment is real; the doc should reflect it.

## What this is **not**

- Not removing functionality. The three point-lookup endpoints stay; the deleted "list_attestations_by_schema" / "list_schemas_by_owner" lines were never implemented, just speculative spec.
- Not closing the indexer issue (#91). That stays open as the home for the deferred work.
- Not changing the runtime, modules, tests, or CI.

## Test plan

- [x] Internal links resolve (`upgrades.md`, the issue refs `#91`, `#80`, `#92`, `#93`)
- [x] No code touched — path filter routes this to docs-only fast path
- [ ] Render on GitHub and confirm the new section reads cleanly + the indented bullet list of indexer-side queries renders

## Refs

- closes #21 (the read-side ships in #93's three endpoints; the deferred `list_by_schema` is recorded as belonging in #91, not on the chain)
- builds on #93 (Query RPC), #109 (upgrades doc), #91 (indexer service issue)
