### PR TITLE
Add CI guard for DA-agnostic crate isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --workspace --no-deps --document-private-items
 
+  # Cheap belt-and-braces check that the DA-agnostic crates haven't
+  # accidentally picked up a hard dependency on Celestia. The SDK's
+  # type discipline already keeps `crates/stf/`, `crates/modules/`,
+  # `crates/stf-declaration/`, and `crates/client-rs/` generic over
+  # the DA spec, but a stray `use sov_celestia_adapter::*` would still
+  # compile silently. This grep guard catches drift at PR time.
+  #
+  # Tracking issue: #117 (DA-agnostic by construction).
+  da-isolation:
+    name: DA isolation
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: ./scripts/check-da-isolation.sh
+
   # `cargo audit` runs on every PR including docs-only changes.
   # New RUSTSEC advisories can appear at any time independent of the
   # diff, and we want every PR to be a checkpoint for security
@@ -194,7 +211,7 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [changes, fmt, clippy, check, test, doc, audit]
+    needs: [changes, fmt, clippy, check, test, doc, da-isolation, audit]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required checks
@@ -206,6 +223,7 @@ jobs:
           CHECK_RESULT: ${{ needs.check.result }}
           TEST_RESULT: ${{ needs.test.result }}
           DOC_RESULT: ${{ needs.doc.result }}
+          DA_ISOLATION_RESULT: ${{ needs.da-isolation.result }}
         run: |
           set -euo pipefail
           fail=0
@@ -219,7 +237,7 @@ jobs:
           # Docs-only change: code-checking jobs are correctly skipped.
           # Otherwise: every code-checking job must succeed.
           if [[ "$CODE_CHANGED" == "true" ]]; then
-            for var in FMT_RESULT CLIPPY_RESULT CHECK_RESULT TEST_RESULT DOC_RESULT; do
+            for var in FMT_RESULT CLIPPY_RESULT CHECK_RESULT TEST_RESULT DOC_RESULT DA_ISOLATION_RESULT; do
               result="${!var}"
               if [[ "$result" != "success" ]]; then
                 echo "::error::${var,,}: $result"

--- a/scripts/check-da-isolation.sh
+++ b/scripts/check-da-isolation.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fail if Celestia-specific identifiers leak into DA-agnostic crates.
+#
+# The Ligate Chain rollup is designed to be swappable across DA
+# layers (Mock + Celestia today; Ethereum blobs / EigenDA / homegrown
+# DA later). The STF, modules, and client crates are generic over
+# `S: Spec` — which carries the `Da: DaSpec` parameter transitively
+# — so they should never reference a concrete DA backend by name.
+#
+# Only the rollup blueprint crate and Risc0 guest crates are allowed
+# to know about specific DA backends, because that's where the DA
+# choice gets wired into a binary.
+#
+# This guard catches drift cheaply: a `use sov_celestia_adapter::*;`
+# in a module crate would compile fine today (the module is generic
+# over `S`), but it represents a coupling we don't want and would
+# turn into a real swap blocker over time.
+#
+# Tracking issue: ligate-io/ligate-chain#117
+
+set -euo pipefail
+
+# Crates that MUST stay DA-agnostic. Anything outside this list is
+# either DA-bound on purpose (the rollup blueprint, the Risc0 guest)
+# or not DA-relevant (docs, scripts, tests of the rollup itself).
+guarded_paths=(
+  "crates/modules"
+  "crates/stf"
+  "crates/stf-declaration"
+  "crates/client-rs"
+)
+
+# Patterns that indicate Celestia-specific coupling. Case-insensitive
+# so we catch both `Celestia` types and `celestia` identifiers / paths.
+# The word "namespace" alone is not matched — schema-namespace prose
+# in the attestation module is unrelated to Celestia's `Namespace`.
+patterns=(
+  "celestia"
+  "sov_celestia_adapter"
+)
+
+leaks=0
+for path in "${guarded_paths[@]}"; do
+  if [[ ! -d "$path" ]]; then
+    echo "::warning::guarded path does not exist: $path (script may need update)"
+    continue
+  fi
+  for pattern in "${patterns[@]}"; do
+    if matches=$(grep -r -i -n --include="*.rs" --include="*.toml" "$pattern" "$path" 2>/dev/null); then
+      echo "::error::DA isolation violation in $path (pattern: '$pattern'):"
+      printf '%s\n' "$matches" | sed 's/^/  /'
+      leaks=1
+    fi
+  done
+done
+
+if [[ $leaks -ne 0 ]]; then
+  echo ""
+  echo "::error::Celestia coupling detected in a DA-agnostic crate."
+  echo "::error::These crates must stay generic over the DA layer so we can swap"
+  echo "::error::Celestia for Ethereum blobs / EigenDA / a homegrown DA later."
+  echo "::error::"
+  echo "::error::Move the coupling into crates/rollup/, or update this guard if"
+  echo "::error::the architecture has deliberately changed (see ligate-chain#117)."
+  exit 1
+fi
+
+echo "DA isolation OK: no Celestia coupling in DA-agnostic crates."


### PR DESCRIPTION
## Summary

Adds a cheap CI guardrail that fails if Celestia-specific identifiers leak into the DA-agnostic crates (`crates/modules/`, `crates/stf/`, `crates/stf-declaration/`, `crates/client-rs/`).

The Sovereign SDK's type discipline already keeps these crates generic over `S: Spec` (which carries `Da: DaSpec` transitively), but a stray `use sov_celestia_adapter::*;` would still compile silently. This grep-based check catches drift at PR time so the swap path stays open.

Tracks acceptance criterion 3 of #117 (DA-agnostic by construction).

## What's in this PR

- `scripts/check-da-isolation.sh` — bash check that greps the four guarded crate paths for `celestia` / `sov_celestia_adapter` (case-insensitive, `.rs` and `.toml` files). Prints GitHub workflow `::error::` annotations on hit and exits 1.
- `.github/workflows/ci.yml` — new `da-isolation` job, gated on `code == true` like the other code jobs. Threaded into the `ci-pass` summary's `needs:` list and result check.

## Audit baseline (2026-04-30)

The current tree passes the guard cleanly. Celestia coupling is contained to:

- `crates/rollup/src/{celestia_rollup,mock_rollup,lib,main}.rs` — blueprint impls + CLI dispatch (correct location)
- `crates/rollup/provers/risc0/guest-celestia/` — DA-specific Risc0 guest
- `crates/rollup/tests/devnet_config.rs`, `crates/rollup/provers/risc0/build.rs` — wiring

Zero leaks in any guarded crate.

## Verification

Local dry-run on a clean tree:

```
$ ./scripts/check-da-isolation.sh
DA isolation OK: no Celestia coupling in DA-agnostic crates.
```

Local dry-run with a planted leak (`use sov_celestia_adapter::CelestiaService;` in `crates/modules/attestation/src/`):

```
::error::DA isolation violation in crates/modules (pattern: 'celestia'):
  crates/modules/attestation/src/_tmp_test/test.rs:1:use sov_celestia_adapter::CelestiaService;
::error::DA isolation violation in crates/modules (pattern: 'sov_celestia_adapter'):
  crates/modules/attestation/src/_tmp_test/test.rs:1:use sov_celestia_adapter::CelestiaService;
::error::Celestia coupling detected in a DA-agnostic crate.
[exit 1]
```

## Why

Two reasons. Vendor risk: if Celestia's roadmap or economics shift between now and mainnet, we want the swap to a different DA backend (Ethereum blobs, EigenDA, Avail, Near DA) to be a 2-week project, not a 6-month rewrite. Sovereignty: a Ligate-native DA stays on the long-term table; keeping the seam clean today preserves that path without committing to it.

The cost of the guard is ~2 seconds of CI per PR. The cost of letting Celestia coupling drift into a module crate and finding out at swap time is much higher.

## What this does NOT do

- Does not commit to building a homegrown DA. That's a separate decision tracked in #117.
- Does not switch off Celestia. Mock + Celestia stay the supported backends through devnet.
- Does not document the swap path or write the "adding a DA adapter" playbook. Both are still acceptance criteria of #117 to land separately.
