### PR TITLE
CI: exclude .github/dependabot.yml from code path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
               - '!.gitignore'
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/CODEOWNERS'
+              - '!.github/dependabot.yml'
 
   fmt:
     name: cargo fmt


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to the path-filter exclusion list so Dependabot config edits no longer trigger the full `cargo fmt/clippy/check/test/doc` suite. Closes #114.

## What lands

One line in `.github/workflows/ci.yml` `changes` job filter:

```yaml
- '!.github/dependabot.yml'
```

## Why

Per #114: `.github/dependabot.yml` edits (e.g. PR #94 config bundle, PR #102 ignore rules add) ran the full code CI on changes that touched zero Rust. With this filter entry, future Dependabot config edits land on the docs-only fast path. Real dep bumps (`Cargo.lock`, `Cargo.toml` workspace edits) still trigger code CI as expected.

## Out of scope

- Excluding `Cargo.lock` Dependabot updates. A real dep bump can shift transitive resolution in ways that warrant re-running tests; lower-leverage to exclude.
- Excluding `devnet/genesis/*.json`. A genesis edit is operationally a hard fork; running the full suite is the correct behaviour.

## Test plan

- [x] Diff is one line, in the existing exclusion list, in the right place
- [x] No em dashes added
- [ ] `CI pass` green on the pull request (this PR itself touches a workflow file, so the path filter detects code; full CI runs on it. Future Dependabot config edits will skip.)

## Related issues

closes #114
