### PR TITLE
Move max_builder_bps from const to state for governance-tunability

### DIFF
--- a/crates/client-rs/src/lib.rs
+++ b/crates/client-rs/src/lib.rs
@@ -86,8 +86,8 @@ use thiserror::Error as ThisError;
 pub use attestation::{
     Attestation, AttestationConfig, AttestationId, AttestorSet, AttestorSetId, AttestorSignature,
     CallMessage, Hash32, PayloadHash, PubKey, Schema, SchemaId, SignedAttestationPayload,
-    MAX_ATTESTATION_SIGNATURES, MAX_ATTESTOR_SET_MEMBERS, MAX_ATTESTOR_SIGNATURE_BYTES,
-    MAX_BUILDER_BPS,
+    DEFAULT_MAX_BUILDER_BPS, MAX_ATTESTATION_SIGNATURES, MAX_ATTESTOR_SET_MEMBERS,
+    MAX_ATTESTOR_SIGNATURE_BYTES,
 };
 
 // ----- Errors -----------------------------------------------------------------
@@ -157,8 +157,9 @@ pub fn register_attestor_set<S: Spec>(
 /// Build a [`CallMessage::RegisterSchema`].
 ///
 /// `fee_routing_addr` must be `Some` iff `fee_routing_bps > 0`, and
-/// `fee_routing_bps` must be `<= attestation::MAX_BUILDER_BPS` (5000
-/// in v0). The state transition enforces these invariants; this
+/// `fee_routing_bps` must be `<= attestation::DEFAULT_MAX_BUILDER_BPS`
+/// (5000 in v0; the runtime cap lives in module state and is
+/// governance-tunable). The state transition enforces these invariants; this
 /// builder is a thin typed wrapper around the enum variant. Returns
 /// [`ClientError::SchemaNameOverCap`] if `name` exceeds the
 /// `SafeString` default cap.

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -400,7 +400,7 @@ pub enum CallMessage<S: Spec> {
     /// Costs `SCHEMA_REGISTRATION_FEE` $LGT (governance, default 100 $LGT).
     /// Owner is the transaction submitter. `attestor_set` must reference
     /// an already-registered [`AttestorSet`]. `fee_routing_bps` must be
-    /// ≤ `MAX_BUILDER_BPS` (5000 in v0). `fee_routing_addr` must be
+    /// ≤ `DEFAULT_MAX_BUILDER_BPS` (5000 in v0). `fee_routing_addr` must be
     /// `Some` iff `fee_routing_bps > 0`.
     RegisterSchema {
         /// See [`Schema::name`]. Bounded by [`SafeString`]'s default
@@ -526,13 +526,35 @@ pub struct AttestationModule<S: Spec> {
     /// as [`AttestationModule::total_treasury_collected`].
     #[state]
     pub builder_fees_collected: StateMap<S::Address, Amount>,
+
+    /// Maximum `fee_routing_bps` accepted at schema registration.
+    ///
+    /// Set at genesis from [`AttestationConfig::max_builder_bps`], default
+    /// [`DEFAULT_MAX_BUILDER_BPS`] (5000 = 50%). Stored in state so the
+    /// future governance module ([#41](https://github.com/ligate-io/ligate-chain/issues/41))
+    /// can update it via a tx without a hard fork.
+    ///
+    /// Handlers (`handle_register_schema`, `seed_from_config`) read from
+    /// state and fall back to [`DEFAULT_MAX_BUILDER_BPS`] if the value is
+    /// not yet set. The fallback is defensive against state corruption or
+    /// mid-upgrade reads, never a normal operating path.
+    #[state]
+    pub max_builder_bps: StateValue<u16>,
 }
 
 // ----- Protocol constants -----------------------------------------------------
 
-/// Maximum `fee_routing_bps` accepted at schema registration (5000 = 50%).
-/// Governance-adjustable in v1+; hardcoded for v0.
-pub const MAX_BUILDER_BPS: u16 = 5000;
+/// Default maximum `fee_routing_bps` accepted at schema registration
+/// (5000 = 50%). Genesis configs that omit
+/// [`AttestationConfig::max_builder_bps`] fall back to this value.
+///
+/// The runtime cap lives in
+/// [`AttestationModule::max_builder_bps`] state and is governance-tunable
+/// via the future governance module
+/// ([#41](https://github.com/ligate-io/ligate-chain/issues/41)). This
+/// const is kept as the fallback for defensive reads (state-corruption,
+/// mid-upgrade) and the genesis-config default.
+pub const DEFAULT_MAX_BUILDER_BPS: u16 = 5000;
 
 /// Default attestation fee in $LGT, in the chain's smallest unit.
 /// Placeholder constant. Real fee sizing is a governance parameter set
@@ -574,7 +596,7 @@ pub struct InitialAttestorSet {
 /// Validated with the same rules as [`CallMessage::RegisterSchema`]: the
 /// referenced attestor set must be known (either declared in
 /// [`AttestationConfig::initial_attestor_sets`] or registered earlier in
-/// the genesis flow), `fee_routing_bps <= MAX_BUILDER_BPS`, and the
+/// the genesis flow), `fee_routing_bps <= DEFAULT_MAX_BUILDER_BPS`, and the
 /// address / bps orphan check. `owner` is supplied explicitly at genesis
 /// because there is no transaction sender at that point.
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
@@ -588,7 +610,7 @@ pub struct InitialSchema<S: Spec> {
     pub version: u32,
     /// [`AttestorSetId`] the schema binds to.
     pub attestor_set: AttestorSetId,
-    /// Fee routing basis points (`0..=MAX_BUILDER_BPS`).
+    /// Fee routing basis points (`0..=DEFAULT_MAX_BUILDER_BPS`).
     pub fee_routing_bps: u16,
     /// Fee routing address; required iff `fee_routing_bps > 0`.
     pub fee_routing_addr: Option<S::Address>,
@@ -628,6 +650,17 @@ pub struct AttestationConfig<S: Spec> {
     /// in `initial_attestor_sets` above, or by a previous `InitialSchema`
     /// bootstrap pass, though the latter is not supported today).
     pub initial_schemas: Vec<InitialSchema<S>>,
+    /// Maximum `fee_routing_bps` accepted at schema registration.
+    /// Default [`DEFAULT_MAX_BUILDER_BPS`] (5000 = 50%) preserves v0
+    /// behaviour. Stored in state at genesis so the governance module
+    /// ([#41](https://github.com/ligate-io/ligate-chain/issues/41)) can
+    /// raise or lower it later without a hard fork.
+    #[serde(default = "default_max_builder_bps")]
+    pub max_builder_bps: u16,
+}
+
+fn default_max_builder_bps() -> u16 {
+    DEFAULT_MAX_BUILDER_BPS
 }
 
 // ============================================================================
@@ -672,7 +705,7 @@ pub enum AttestationError {
     #[error("schema references an unregistered attestor set")]
     UnknownAttestorSet,
 
-    /// `fee_routing_bps` exceeded the protocol cap [`MAX_BUILDER_BPS`].
+    /// `fee_routing_bps` exceeded the protocol cap [`DEFAULT_MAX_BUILDER_BPS`].
     #[error("fee routing bps ({bps}) exceeds protocol cap ({cap})")]
     FeeRoutingExceedsCap {
         /// Supplied basis points.
@@ -851,6 +884,7 @@ impl<S: Spec> AttestationModule<S> {
         self.attestation_fee.set(&config.attestation_fee, state)?;
         self.schema_registration_fee.set(&config.schema_registration_fee, state)?;
         self.attestor_set_fee.set(&config.attestor_set_fee, state)?;
+        self.max_builder_bps.set(&config.max_builder_bps, state)?;
 
         for initial in &config.initial_attestor_sets {
             if initial.members.is_empty() {
@@ -882,10 +916,10 @@ impl<S: Spec> AttestationModule<S> {
         }
 
         for schema in &config.initial_schemas {
-            if schema.fee_routing_bps > MAX_BUILDER_BPS {
+            if schema.fee_routing_bps > config.max_builder_bps {
                 return Err(AttestationError::FeeRoutingExceedsCap {
                     bps: schema.fee_routing_bps,
-                    cap: MAX_BUILDER_BPS,
+                    cap: config.max_builder_bps,
                 }
                 .into());
             }
@@ -972,12 +1006,12 @@ impl<S: Spec> AttestationModule<S> {
         context: &Context<S>,
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<()> {
-        if fee_routing_bps > MAX_BUILDER_BPS {
-            return Err(AttestationError::FeeRoutingExceedsCap {
-                bps: fee_routing_bps,
-                cap: MAX_BUILDER_BPS,
-            }
-            .into());
+        // Read the cap from state, falling back to the const default if
+        // unset. Defensive against state-corruption / mid-upgrade reads;
+        // post-genesis the value is always present.
+        let cap = self.max_builder_bps.get(state)?.unwrap_or(DEFAULT_MAX_BUILDER_BPS);
+        if fee_routing_bps > cap {
+            return Err(AttestationError::FeeRoutingExceedsCap { bps: fee_routing_bps, cap }.into());
         }
         if (fee_routing_bps > 0) != fee_routing_addr.is_some() {
             return Err(AttestationError::OrphanFeeRouting.into());
@@ -1170,7 +1204,7 @@ impl<S: Spec> AttestationModule<S> {
 }
 
 /// Split an attestation fee into `(builder_share, treasury_share)` per
-/// `fee_routing_bps` (basis points, capped at [`MAX_BUILDER_BPS`]).
+/// `fee_routing_bps` (basis points, capped at [`DEFAULT_MAX_BUILDER_BPS`]).
 ///
 /// `Amount` is a `u128` newtype. The intermediate split is computed as
 /// `total / 10_000 * bps + (total % 10_000) * bps / 10_000` to keep the

--- a/crates/modules/attestation/tests/integration.rs
+++ b/crates/modules/attestation/tests/integration.rs
@@ -84,12 +84,43 @@ fn setup_with_initial(
         attestor_set_fee,
         initial_attestor_sets,
         initial_schemas: vec![],
+        max_builder_bps: attestation::DEFAULT_MAX_BUILDER_BPS,
     };
 
     let genesis = GenesisConfig::from_minimal_config(genesis_config.into(), attestation_config);
 
     let runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
 
+    TestEnv { runner, submitter, treasury, lgt_token_id }
+}
+
+/// Like [`setup_with_initial`] but lets the test override the
+/// genesis-time `max_builder_bps` cap. Used by the cap-related tests
+/// that exercise a non-default state value. Fees are zero so the cap
+/// is the only behaviour under test.
+fn setup_with_cap(initial_attestor_sets: Vec<InitialAttestorSet>, max_builder_bps: u16) -> TestEnv {
+    let genesis_config =
+        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(2);
+
+    let submitter = genesis_config.additional_accounts()[0].clone();
+    let treasury_user = genesis_config.additional_accounts()[1].clone();
+    let treasury = treasury_user.address();
+
+    let lgt_token_id = config_gas_token_id();
+
+    let attestation_config = AttestationConfig::<S> {
+        treasury,
+        lgt_token_id,
+        attestation_fee: Amount::ZERO,
+        schema_registration_fee: Amount::ZERO,
+        attestor_set_fee: Amount::ZERO,
+        initial_attestor_sets,
+        initial_schemas: vec![],
+        max_builder_bps,
+    };
+
+    let genesis = GenesisConfig::from_minimal_config(genesis_config.into(), attestation_config);
+    let runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
     TestEnv { runner, submitter, treasury, lgt_token_id }
 }
 
@@ -240,7 +271,88 @@ fn register_schema_rejects_over_cap_fee_routing() {
                 name: safe_name("over-cap"),
                 version: 1,
                 attestor_set: attestor_set_id,
-                fee_routing_bps: 6000, // > MAX_BUILDER_BPS (5000)
+                fee_routing_bps: 6000, // > DEFAULT_MAX_BUILDER_BPS (5000)
+                fee_routing_addr: Some(env.submitter.address()),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+        }),
+    });
+}
+
+#[test]
+fn register_schema_accepts_bps_at_default_cap() {
+    // The default genesis config sets `max_builder_bps` to
+    // `DEFAULT_MAX_BUILDER_BPS` (5000). A schema with bps exactly
+    // equal to the cap is allowed (the comparison is strict-greater).
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_initial(Amount::ZERO, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("at-default-cap"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: attestation::DEFAULT_MAX_BUILDER_BPS,
+                fee_routing_addr: Some(env.submitter.address()),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Successful(_)));
+        }),
+    });
+}
+
+#[test]
+fn register_schema_honours_custom_cap_at_genesis() {
+    // Genesis sets max_builder_bps to 3000. A schema with bps 2999
+    // succeeds: the handler reads the cap from state, not from the
+    // const default (5000).
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_cap(initial, 3000);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("under-custom-cap"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 2999,
+                fee_routing_addr: Some(env.submitter.address()),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(matches!(result.tx_receipt, TxEffect::Successful(_)));
+        }),
+    });
+}
+
+#[test]
+fn register_schema_rejects_above_custom_cap() {
+    // Genesis sets max_builder_bps to 3000. A schema with bps 3001
+    // fails: the handler must read from state, not the const default
+    // (which would let 3001 through since 3001 < 5000).
+    let signers = sample_signers();
+    let pubs = pubkeys_of(&signers);
+    let initial = vec![InitialAttestorSet { members: pubs.clone(), threshold: 2 }];
+    let mut env = setup_with_cap(initial, 3000);
+    let attestor_set_id = AttestorSet::derive_id(&pubs, 2);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("over-custom-cap"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 3001,
                 fee_routing_addr: Some(env.submitter.address()),
             },
         ),

--- a/crates/modules/attestation/tests/unit.rs
+++ b/crates/modules/attestation/tests/unit.rs
@@ -9,7 +9,7 @@
 //!   matter for sets; threshold / version / owner / name all
 //!   participate).
 //! - `SignedAttestationPayload::digest` determinism.
-//! - `MAX_BUILDER_BPS` cap.
+//! - `DEFAULT_MAX_BUILDER_BPS` cap.
 //! - `split_attestation_fee` math at zero, mid, cap, and overflow-
 //!   adjacent inputs.
 //!
@@ -215,6 +215,7 @@ fn attestation_config_json_round_trip() {
             fee_routing_bps: 1000,
             fee_routing_addr: Some(sample_addr(5)),
         }],
+        max_builder_bps: attestation::DEFAULT_MAX_BUILDER_BPS,
     };
     let json = serde_json::to_string(&cfg).expect("encode");
     let decoded: AttestationConfig<S> = serde_json::from_str(&json).expect("decode");
@@ -356,10 +357,13 @@ fn signed_payload_digest_changes_with_submitter() {
 // ----- Protocol constants ----------------------------------------------------
 
 #[test]
-fn max_builder_bps_is_half() {
-    // Documenting the invariant explicitly so a future refactor
-    // doesn't silently raise the cap without thought.
-    assert_eq!(attestation::MAX_BUILDER_BPS, 5000);
+fn default_max_builder_bps_is_half() {
+    // Documenting the default invariant explicitly so a future refactor
+    // doesn't silently raise the const default without thought. The
+    // runtime cap lives in module state (governance-tunable per #40);
+    // this asserts the bootstrap default for genesis configs that
+    // omit `AttestationConfig::max_builder_bps`.
+    assert_eq!(attestation::DEFAULT_MAX_BUILDER_BPS, 5000);
 }
 
 // Compile-time assertion: ed25519 (64 bytes) and BLS (48 bytes)

--- a/crates/rollup/tests/blueprint_smoke.rs
+++ b/crates/rollup/tests/blueprint_smoke.rs
@@ -71,6 +71,7 @@ fn runtime_genesis_config_round_trips_for_production_spec() {
         attestor_set_fee: Amount(0),
         initial_attestor_sets: vec![],
         initial_schemas: vec![],
+        max_builder_bps: attestation::DEFAULT_MAX_BUILDER_BPS,
     };
 
     let genesis = GenesisConfig::<S> {

--- a/crates/rollup/tests/e2e_smoke.rs
+++ b/crates/rollup/tests/e2e_smoke.rs
@@ -123,6 +123,7 @@ fn setup_with_seeded_state() -> StagedGenesis {
             fee_routing_bps: 0,
             fee_routing_addr: None,
         }],
+        max_builder_bps: attestation::DEFAULT_MAX_BUILDER_BPS,
     };
 
     let minimal: MinimalOptimisticGenesisConfig<S> = high_level.into();

--- a/crates/stf/src/tests.rs
+++ b/crates/stf/src/tests.rs
@@ -100,6 +100,7 @@ mod genesis_loader {
             attestor_set_fee: Amount(0),
             initial_attestor_sets: vec![],
             initial_schemas: vec![],
+            max_builder_bps: attestation::DEFAULT_MAX_BUILDER_BPS,
         };
 
         GenesisConfig::<S> {

--- a/devnet/genesis/attestation.json
+++ b/devnet/genesis/attestation.json
@@ -5,5 +5,6 @@
   "schema_registration_fee": "100000000",
   "attestor_set_fee": "50000000",
   "initial_attestor_sets": [],
-  "initial_schemas": []
+  "initial_schemas": [],
+  "max_builder_bps": 5000
 }


### PR DESCRIPTION
## Summary

Moves the `max_builder_bps` cap from a Rust const to module state so the future governance module ([#41](https://github.com/ligate-io/ligate-chain/issues/41)) can adjust it via a tx without a hard fork. Existing v0 behaviour is preserved: any genesis config that omits the new field defaults to 5000 (50%) via `#[serde(default)]`. Closes #40.

## What lands

### Module + config

- `pub const MAX_BUILDER_BPS: u16 = 5000` renamed to `pub const DEFAULT_MAX_BUILDER_BPS: u16 = 5000`. Kept as the genesis default + defensive fallback for handler reads.
- `AttestationModule` gains `pub max_builder_bps: StateValue<u16>`.
- `AttestationConfig` gains `max_builder_bps: u16` with `#[serde(default = "default_max_builder_bps")]`. Existing genesis JSONs that omit it deserialize cleanly.
- `seed_from_config` writes the value to state at genesis and uses it for `initial_schemas` validation.
- `handle_register_schema` reads from state with fallback to `DEFAULT_MAX_BUILDER_BPS` when unset (defensive against state-corruption / mid-upgrade reads; post-genesis the value is always present).

### Genesis JSON

- `devnet/genesis/attestation.json` adds `"max_builder_bps": 5000` for operator visibility.

### Tests

3 new tests in `crates/modules/attestation/tests/integration.rs`:

1. `register_schema_accepts_bps_at_default_cap`, `bps == 5000` succeeds (boundary on default cap; comparison is strict greater-than).
2. `register_schema_honours_custom_cap_at_genesis`, genesis sets cap to 3000, `bps = 2999` succeeds.
3. `register_schema_rejects_above_custom_cap`, genesis sets cap to 3000, `bps = 3001` rejects (proves the handler reads from state, not the const default).

A new `setup_with_cap` helper supports tests that need a non-default cap.

Existing test renamed: `max_builder_bps_is_half` to `default_max_builder_bps_is_half`. Now asserts the const default rather than a runtime value.

### Construct sites

5 `AttestationConfig` construct sites updated to include the new field: `unit.rs`, `integration.rs` (in `setup_with_initial`), `e2e_smoke.rs`, `blueprint_smoke.rs`, `stf/src/tests.rs`.

### Re-exports

- `crates/client-rs/src/lib.rs` re-exports `DEFAULT_MAX_BUILDER_BPS` instead of `MAX_BUILDER_BPS`. Documentation updated to mention the runtime cap lives in module state.

## Why this shape

Defensive read pattern in handlers (`get(state)?.unwrap_or(DEFAULT_MAX_BUILDER_BPS)`) means a misconfigured genesis or mid-upgrade read still applies the v0 cap. Post-genesis the state value is always present, so the fallback never fires in practice; it exists to make the code robust without making the genesis path fragile.

`#[serde(default)]` on the config field means existing genesis JSONs without the field continue to load. New JSONs can include the value explicitly to make the cap visible to operators.

## Out of scope

- The actual governance flow that updates the value at runtime. That is the governance-module work tracked in [#41](https://github.com/ligate-io/ligate-chain/issues/41).
- Other constants that could move to state (`DEFAULT_ATTESTATION_FEE_LGT_NANOS`, etc.). All other relevant constants are already `StateValue`s; only `MAX_BUILDER_BPS` was still a `pub const`.
- Wire-format snapshot tests update for `AttestationConfig`. The Borsh snapshot suite covers `Schema`, `AttestorSet`, `Attestation`, `SignedAttestationPayload`, and `CallMessage` variants. `AttestationConfig` is a genesis-only type loaded from JSON, not part of the public protocol wire surface, and is not in the snapshot suite.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p attestation --test integration register_schema` (8/8 pass: 5 existing + 3 new)
- [x] `cargo test --workspace --lib --tests` (104 tests, 0 failures)
- [x] `cargo test --workspace --doc`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] Zero em dashes added in the diff
- [ ] `CI pass` green on the pull request

## Related issues

closes #40
