### PR TITLE
Add cargo-deny for license, duplicate, source policy (closes #120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,21 @@ jobs:
       - uses: actions/checkout@v6
       - run: ./scripts/check-da-isolation.sh
 
+  # `cargo-deny` enforces our license / duplicate / source policy
+  # (see `deny.toml`). Gated on `code == true` because the policy
+  # only kicks in when the dep graph changes, and the dep graph only
+  # changes when a Rust file or Cargo manifest is touched, which is
+  # exactly what the `code` filter captures.
+  deny:
+    name: cargo deny
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny check
+
   # `cargo audit` runs on every PR including docs-only changes.
   # New RUSTSEC advisories can appear at any time independent of the
   # diff, and we want every PR to be a checkpoint for security
@@ -212,7 +227,7 @@ jobs:
   ci-pass:
     name: CI pass
     if: always()
-    needs: [changes, fmt, clippy, check, test, doc, da-isolation, audit]
+    needs: [changes, fmt, clippy, check, test, doc, da-isolation, deny, audit]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required checks
@@ -225,6 +240,7 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           DOC_RESULT: ${{ needs.doc.result }}
           DA_ISOLATION_RESULT: ${{ needs.da-isolation.result }}
+          DENY_RESULT: ${{ needs.deny.result }}
         run: |
           set -euo pipefail
           fail=0
@@ -238,7 +254,7 @@ jobs:
           # Docs-only change: code-checking jobs are correctly skipped.
           # Otherwise: every code-checking job must succeed.
           if [[ "$CODE_CHANGED" == "true" ]]; then
-            for var in FMT_RESULT CLIPPY_RESULT CHECK_RESULT TEST_RESULT DOC_RESULT DA_ISOLATION_RESULT; do
+            for var in FMT_RESULT CLIPPY_RESULT CHECK_RESULT TEST_RESULT DOC_RESULT DA_ISOLATION_RESULT DENY_RESULT; do
               result="${!var}"
               if [[ "$result" != "success" ]]; then
                 echo "::error::${var,,}: $result"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,8 +190,15 @@ The required gate is **`CI pass`**. It's a summary job that watches the underlyi
 | `cargo test` | Workspace lib + integration + doctests | yes |
 | `cargo doc` | rustdoc with `-D warnings` | yes |
 | `cargo audit` | RUSTSEC advisories | **no** — runs on every PR |
+| `cargo deny` | License / duplicate / source policy | yes |
 
 Why `cargo audit` ignores the path filter: new advisories appear independent of your diff. We want every PR to be a checkpoint for security signal.
+
+`cargo deny` enforces three policies on top of `cargo audit`:
+
+- **Licenses**: every transitive dep must resolve to a license in the allow list. New deps with copyleft or non-OSI licenses fail CI.
+- **Sources**: git deps may only come from the explicit allow list (currently the Sovereign SDK + its `rockbound` storage repo). Stops a stray `git = "..."` URL from sneaking in.
+- **Bans**: denies `native-tls`, `openssl`, and `openssl-sys`. We're Rustls-only; a transitive that flips us back to system OpenSSL would surprise the deploy story.
 
 Local equivalent (run before pushing):
 
@@ -202,9 +209,12 @@ cargo check --workspace --all-targets
 cargo test --workspace
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
 cargo audit
+cargo deny check  # brew install cargo-deny  (or `cargo install cargo-deny --locked`)
 ```
 
 Ignored advisories live in [`audit.toml`](audit.toml) — every entry is a transitive dep pinned by the Sovereign SDK. They clear automatically on SDK upgrades.
+
+Policy rules and per-crate exceptions live in [`deny.toml`](deny.toml). The Sovereign SDK ships under a custom commercial license (the SPCL); its crates are clarified to that license-ref. LGPL transitives (`malachite*`, `downloader`, `r-efi`) are pulled by risc0. Rationale for each exception is inline in the file.
 
 ## Filing issues
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,361 @@
+# cargo-deny config.
+#
+# Enforces license, duplicate-version, and source-policy rules on top
+# of cargo-audit's RUSTSEC checks. Tracking issue: #120.
+#
+# Revisit every time we upgrade the Sovereign SDK rev (most exceptions
+# below are transitive through the SDK's pinned deps).
+
+[licenses]
+version = 2
+# Permissive OSS licenses we're comfortable shipping. Anything not in
+# this list (or in `exceptions` / `clarify` below) fails CI.
+allow = [
+  "0BSD",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MIT-0",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Unlicense",
+  "Zlib",
+  # Sovereign SDK ships under a custom commercial license (10% revenue
+  # share for production rollups, OFAC compliance, notification
+  # obligation). Full text at:
+  # https://github.com/Sovereign-Labs/sovereign-sdk/blob/main/LICENSE.md
+  "LicenseRef-Sovereign-Permissionless-Commercial-License",
+]
+
+# Sovereign SDK crates don't declare a license in their Cargo.toml
+# (the SPCL is at repo root, not per-crate). Clarify each one we depend
+# on so cargo-deny can match it against the allow list above.
+#
+# The list mirrors our Cargo.lock; trim or extend as the SDK surface
+# we use grows.
+
+[[licenses.clarify]]
+name = "sov-accounts"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-address"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-api-spec"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-attester-incentives"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-bank"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-blob-sender"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-blob-storage"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-build"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-capabilities"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-celestia-adapter"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-chain-state"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-cli"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-db"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-db-types"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-full-node-configs"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-kernels"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-ledger-apis"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-metrics"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-mock-da"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-mock-zkvm"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-modules-api"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-modules-macros"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-modules-rollup-blueprint"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-modules-stf-blueprint"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-node-client"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-operator-incentives"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-paymaster"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-prover-incentives"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-rest-utils"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-risc0-adapter"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-rollup-apis"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-rollup-full-node-interface"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-rollup-interface"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-sequencer"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-sequencer-registry"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-state"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-stf-runner"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-test-utils"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-uniqueness"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-value-setter"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "sov-zkvm-utils"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "nearly-linear"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+# LGPL transitives. Every entry below is pulled by risc0 (the prover
+# stack) and gets statically linked into our prover binary.
+#
+# LGPL static-linking compliance hinges on users being able to swap
+# the LGPL'd portion. We satisfy that by publishing the chain source
+# (Apache-2.0 OR MIT) so anyone can rebuild against a different
+# revision of these crates. None of the LGPL'd code is forked into our
+# tree; we use them strictly as upstream libraries.
+
+[[licenses.exceptions]]
+# Build-script dep of risc0-circuit-recursion (downloads circuit
+# artifacts at build time). Not in any runtime path.
+allow = ["LGPL-3.0-or-later"]
+name = "downloader"
+version = "0.2.8"
+
+[[licenses.exceptions]]
+allow = ["LGPL-3.0-only"]
+name = "malachite"
+version = "0.4.22"
+
+[[licenses.exceptions]]
+allow = ["LGPL-3.0-only"]
+name = "malachite-base"
+version = "0.4.22"
+
+[[licenses.exceptions]]
+allow = ["LGPL-3.0-only"]
+name = "malachite-float"
+version = "0.4.22"
+
+[[licenses.exceptions]]
+allow = ["LGPL-3.0-only"]
+name = "malachite-nz"
+version = "0.4.22"
+
+[[licenses.exceptions]]
+allow = ["LGPL-3.0-only"]
+name = "malachite-q"
+version = "0.4.22"
+
+[[licenses.exceptions]]
+# UEFI types pulled by Rust std's platform-detection layer for some
+# target triples. Not reachable from any code path we ship.
+allow = ["LGPL-2.1-or-later"]
+name = "r-efi"
+version = "5.3.0"
+
+[[licenses.exceptions]]
+allow = ["LGPL-2.1-or-later"]
+name = "r-efi"
+version = "6.0.0"
+
+# Advisories: vulnerability ignores mirror `audit.toml` (rationale
+# documented there). cargo-deny additionally fires on `unmaintained`
+# advisories, which cargo-audit treats as warnings; those are
+# captured in the second block below.
+[advisories]
+version = 2
+ignore = [
+  # --- Vulnerability ignores (synced with audit.toml) ---
+  "RUSTSEC-2023-0071", # rsa Marvin attack via sqlx-mysql (no MySQL in our path)
+  "RUSTSEC-2025-0055", # tracing-subscriber ANSI escape via deep risc0 chain
+  "RUSTSEC-2025-0134", # rustls-pemfile unmaintained, jsonrpsee transitive
+  "RUSTSEC-2025-0141", # bincode 1.x unmaintained via sov-db
+  "RUSTSEC-2026-0066", # astral-tokio-tar dir-traversal via sov-test-utils dev-dep
+  "RUSTSEC-2026-0112", # astral-tokio-tar PAX header desync, same dep path
+  "RUSTSEC-2026-0113", # astral-tokio-tar chmod via symlinks, same dep path
+
+  # --- Unmaintained-crate advisories ---
+  # These are quality signals, not vulnerabilities. Every one is
+  # transitive through the SDK or risc0; we don't choose them
+  # directly. Revisit when SDK rev bumps.
+  "RUSTSEC-2023-0089", # atomic-polyfill, archived, transitive via risc0/embassy
+  "RUSTSEC-2024-0388", # derivative, archived, transitive via SDK proc-macros
+  "RUSTSEC-2024-0436", # paste, archived (still works), transitive deep
+  "RUSTSEC-2025-0057", # fxhash, archived, transitive via SDK dep graph
+]
+
+[bans]
+# Duplicate versions are pervasive in the SDK + risc0 transitive
+# graph. Warning on them produces noise without actionable diffs at
+# our level (we don't control the upstream pins). Track separately if
+# we ever see a *new* duplicate from one of our direct deps.
+multiple-versions = "allow"
+
+# Belt-and-braces against accidental TLS regressions. We use Rustls
+# everywhere; native-tls / openssl creeping in via a transitive change
+# would silently switch us to system OpenSSL and surprise the deploy
+# story.
+deny = [
+  { name = "native-tls" },
+  { name = "openssl" },
+  { name = "openssl-sys" },
+]
+
+[sources]
+# Crates.io is the only registry we expect.
+unknown-registry = "deny"
+# Git deps are allowed only from the explicit allow-list below; any
+# new git source has to go through deny.toml. Keeps the SDK pin from
+# silently growing siblings.
+unknown-git = "deny"
+required-git-spec = "rev"
+allow-git = [
+  "https://github.com/Sovereign-Labs/sovereign-sdk.git",
+  # SDK's RocksDB wrapper, pulled by sov-db / sov-blob-sender. Lives
+  # in a separate repo from the main SDK; both are pinned by rev.
+  "https://github.com/sovereign-labs/rockbound",
+]


### PR DESCRIPTION
## Summary

Adds `cargo-deny` to CI as defense-in-depth on top of `cargo audit`. Catches license drift, duplicate version bloat, and stray git sources before they merge.

## What ships

- `deny.toml`: license allow list, 41 SPCL clarifications for SDK crates, LGPL exceptions for risc0 transitives (`malachite*`, `downloader`, `r-efi`), advisory ignores mirroring `audit.toml` plus 4 unmaintained-crate ignores, bans on `native-tls`/`openssl`/`openssl-sys`, strict sources policy (`unknown-git = "deny"` with explicit allow list).
- New `cargo deny` CI job, gated on `code == true`, wired into the `CI pass` summary.
- `CONTRIBUTING.md`: table row, three-bullet policy summary, local command, deny.toml pointer.

## Notable design calls

- Strict source allow list catches a stray `git = "..."` URL at PR time, not at audit time.
- `multiple-versions = "allow"` matches the SDK's posture; the duplicate set is dominated by transitives we don't control.
- Rolled in 4 RUSTSEC unmaintained-crate ignores that cargo-deny treats as errors where cargo-audit treats them as warnings (`atomic-polyfill`, `derivative`, `paste`, `fxhash`).
- Dropped 3 stale rustls-webpki advisories from `deny.toml`'s ignore list (rustls-webpki is now 0.103.13, past the affected versions). `audit.toml` left untouched on purpose to keep PR scope tight; can clean up in a follow-up if desired.

## Test plan

- [x] `cargo deny check` passes locally with zero warnings (`advisories ok, bans ok, licenses ok, sources ok`).
- [ ] CI green on this PR.
- [ ] `CI pass` correctly reports `deny` as required.