### PR TITLE
Audit and tighten public Error variant test coverage (closes #124)

### DIFF
--- a/crates/client-rs/src/lib.rs
+++ b/crates/client-rs/src/lib.rs
@@ -331,6 +331,47 @@ mod tests {
     }
 
     #[test]
+    fn submit_attestation_rejects_over_cap_signatures() {
+        // MAX_ATTESTATION_SIGNATURES + 1 signatures. Pin the
+        // `AttestationSignaturesOverCap` variant explicitly so a
+        // future refactor that replaces the cap check with a
+        // different error type fails this test loudly.
+        let schema_id = sample_schema_id(1);
+        let payload_hash = sample_payload_hash(2);
+        let too_many: Vec<AttestorSignature> = (0..=MAX_ATTESTATION_SIGNATURES as u8)
+            .map(|i| AttestorSignature {
+                pubkey: sample_pubkey(i),
+                sig: SafeVec::try_from(vec![0u8; 64]).unwrap(),
+            })
+            .collect();
+        let result = submit_attestation::<S>(schema_id, payload_hash, too_many);
+        match result {
+            Err(ClientError::AttestationSignaturesOverCap { actual, max }) => {
+                assert_eq!(actual, MAX_ATTESTATION_SIGNATURES + 1);
+                assert_eq!(max, MAX_ATTESTATION_SIGNATURES);
+            }
+            other => panic!("expected AttestationSignaturesOverCap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn register_schema_rejects_over_cap_name() {
+        // SafeString's default cap is 256 bytes; the SDK enforces
+        // it via TryFrom<String>. Anything longer than that surfaces
+        // as `SchemaNameOverCap`. We use 1024 chars to be well past
+        // any plausible bump.
+        let too_long = "a".repeat(1024);
+        let attestor_set_id = AttestorSetId::from([1u8; 32]);
+        let result = register_schema::<S>(too_long.clone(), 1, attestor_set_id, 0, None);
+        match result {
+            Err(ClientError::SchemaNameOverCap(name)) => {
+                assert_eq!(name, too_long);
+            }
+            other => panic!("expected SchemaNameOverCap, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn register_schema_builds_correct_variant() {
         let attestor_set_id = AttestorSetId::from([7u8; 32]);
         let fee_addr = sample_address(9);

--- a/crates/modules/attestation/tests/integration.rs
+++ b/crates/modules/attestation/tests/integration.rs
@@ -146,6 +146,30 @@ fn safe_name(s: &str) -> SafeString {
     SafeString::try_from(s.to_string()).expect("name fits SafeString default cap")
 }
 
+/// Asserts the tx reverted AND the rendered reason contains `phrase`.
+///
+/// Pinning the phrase guards against a refactor that changes which
+/// `AttestationError` variant fires on a given input. Without this,
+/// `matches!(_, TxEffect::Reverted(_))` accepts any reversion as
+/// success, including bug-induced ones (e.g. an unrelated panic
+/// elsewhere in the handler that surfaces as a different error).
+///
+/// Pair every negative-path test with one of these calls. See the
+/// coverage matrix in `docs/development/error-coverage.md`.
+#[track_caller]
+fn assert_reverted_with(receipt: &TxEffect<S>, phrase: &str) {
+    match receipt {
+        TxEffect::Reverted(payload) => {
+            let msg = payload.reason.to_string();
+            assert!(
+                msg.contains(phrase),
+                "expected phrase '{phrase}' in reverted reason, got: {msg}",
+            );
+        }
+        other => panic!("expected Reverted, got {other:?}"),
+    }
+}
+
 #[test]
 fn register_attestor_set_happy_path() {
     let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::new(7));
@@ -210,7 +234,7 @@ fn register_attestor_set_rejects_threshold_above_members() {
             CallMessage::RegisterAttestorSet { members, threshold: 2 },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "exceeds member count");
         }),
     });
 }
@@ -227,7 +251,7 @@ fn register_attestor_set_rejects_zero_threshold() {
             CallMessage::RegisterAttestorSet { members, threshold: 0 },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "must be at least 1");
         }),
     });
 }
@@ -250,7 +274,7 @@ fn register_schema_requires_existing_attestor_set() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "unregistered attestor set");
         }),
     });
 }
@@ -276,7 +300,7 @@ fn register_schema_rejects_over_cap_fee_routing() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "exceeds protocol cap");
         }),
     });
 }
@@ -357,7 +381,7 @@ fn register_schema_rejects_above_custom_cap() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "exceeds protocol cap");
         }),
     });
 }
@@ -466,7 +490,7 @@ fn register_schema_rejects_orphan_routing_bps_without_addr() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "fee routing misconfigured");
         }),
     });
 }
@@ -492,7 +516,7 @@ fn register_schema_rejects_orphan_routing_addr_without_bps() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "fee routing misconfigured");
         }),
     });
 }
@@ -514,7 +538,7 @@ fn submit_attestation_requires_existing_schema() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "schema not found");
         }),
     });
 }
@@ -608,7 +632,7 @@ fn full_register_register_submit_flow() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "attestation already exists");
         }),
     });
 }
@@ -683,7 +707,7 @@ fn submit_below_threshold_rejects() {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "quorum not met");
         }),
     });
 }
@@ -706,7 +730,7 @@ fn submit_with_unknown_pubkey_rejects() {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "not in the schema's attestor set");
         }),
     });
 }
@@ -732,7 +756,7 @@ fn submit_with_invalid_signature_rejects() {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "did not verify");
         }),
     });
 }
@@ -753,7 +777,7 @@ fn submit_with_duplicate_pubkey_rejects() {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "duplicate attestor pubkey");
         }),
     });
 }
@@ -779,7 +803,61 @@ fn submit_with_bad_sig_length_rejects() {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
         ),
         assert: Box::new(|result, _state| {
-            assert!(matches!(result.tx_receipt, TxEffect::Reverted(_)));
+            assert_reverted_with(&result.tx_receipt, "expected 64 for ed25519");
+        }),
+    });
+}
+
+#[test]
+fn submit_with_off_curve_pubkey_rejects() {
+    // Pin the `InvalidAttestorPubkey` variant. The handler runs
+    // `VerifyingKey::from_bytes` on the signature's pubkey field;
+    // bytes that don't decompress to a curve point surface as
+    // `InvalidAttestorPubkey`. Most 32-byte values DO decompress
+    // (ed25519-dalek's `from_bytes` is permissive about canonical
+    // encoding); we use `[0x02; 32]`, which empirically fails with
+    // "Cannot decompress Edwards point" because the y value has no
+    // valid x square root mod p.
+    //
+    // The attestor-set registration handler doesn't curve-validate
+    // members (only structural invariants), so we can seed the set
+    // with this off-curve pubkey at genesis and let the submit
+    // path discover the failure during signature verification.
+    let off_curve_pk = PubKey::from([0x02u8; 32]);
+    let initial = vec![InitialAttestorSet { members: vec![off_curve_pk], threshold: 1 }];
+    let mut env = setup_with_initial(Amount::ZERO, Amount::ZERO, Amount::ZERO, initial);
+    let attestor_set_id = AttestorSet::derive_id(&[off_curve_pk], 1);
+    let submitter_addr = env.submitter.address();
+
+    // Register a schema bound to the off-curve attestor set.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::RegisterSchema {
+                name: safe_name("off-curve"),
+                version: 1,
+                attestor_set: attestor_set_id,
+                fee_routing_bps: 0,
+                fee_routing_addr: None,
+            },
+        ),
+        assert: Box::new(|result, _state| assert!(result.tx_receipt.is_successful())),
+    });
+    let schema_id = Schema::<S>::derive_id(&submitter_addr, "off-curve", 1);
+
+    // Submit an attestation whose only signature has the off-curve
+    // pubkey. Sig content is irrelevant; the pubkey check fires
+    // before signature verification.
+    let payload_hash = attestation::PayloadHash::from([0x07u8; 32]);
+    let bogus_sig =
+        AttestorSignature { pubkey: off_curve_pk, sig: SafeVec::try_from(vec![0u8; 64]).unwrap() };
+    let signatures = SafeVec::try_from(vec![bogus_sig]).unwrap();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
+        ),
+        assert: Box::new(|result, _state| {
+            assert_reverted_with(&result.tx_receipt, "not a valid ed25519 point");
         }),
     });
 }
@@ -839,10 +917,7 @@ fn submit_digest_is_bound_to_submitter() {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures },
         ),
         assert: Box::new(|result, _state| {
-            assert!(
-                matches!(result.tx_receipt, TxEffect::Reverted(_)),
-                "wrong-submitter digest must not verify"
-            );
+            assert_reverted_with(&result.tx_receipt, "did not verify");
         }),
     });
 }
@@ -1033,11 +1108,7 @@ fn register_attestor_set_rejects_duplicate() {
             CallMessage::RegisterAttestorSet { members: safe_members(&signers), threshold: 2 },
         ),
         assert: Box::new(|result, _state| {
-            assert!(
-                matches!(result.tx_receipt, TxEffect::Reverted(_)),
-                "duplicate attestor set must revert: {:?}",
-                result.tx_receipt
-            );
+            assert_reverted_with(&result.tx_receipt, "attestor set already registered");
         }),
     });
 }
@@ -1080,11 +1151,7 @@ fn register_schema_rejects_duplicate() {
             },
         ),
         assert: Box::new(|result, _state| {
-            assert!(
-                matches!(result.tx_receipt, TxEffect::Reverted(_)),
-                "duplicate schema must revert: {:?}",
-                result.tx_receipt
-            );
+            assert_reverted_with(&result.tx_receipt, "schema already registered");
         }),
     });
 }
@@ -1105,11 +1172,7 @@ fn register_attestor_set_rejects_empty_members() {
             CallMessage::RegisterAttestorSet { members: empty, threshold: 1 },
         ),
         assert: Box::new(|result, _state| {
-            assert!(
-                matches!(result.tx_receipt, TxEffect::Reverted(_)),
-                "empty members must revert: {:?}",
-                result.tx_receipt
-            );
+            assert_reverted_with(&result.tx_receipt, "must have at least one member");
         }),
     });
 }
@@ -1150,11 +1213,7 @@ fn submit_attestation_rejects_empty_signatures() {
             CallMessage::SubmitAttestation { schema_id, payload_hash, signatures: empty_sigs },
         ),
         assert: Box::new(|result, _state| {
-            assert!(
-                matches!(result.tx_receipt, TxEffect::Reverted(_)),
-                "empty signatures must revert: {:?}",
-                result.tx_receipt
-            );
+            assert_reverted_with(&result.tx_receipt, "quorum not met");
         }),
     });
 }

--- a/docs/development/error-coverage.md
+++ b/docs/development/error-coverage.md
@@ -1,0 +1,109 @@
+# Error-variant coverage audit
+
+Catalogue of every public `Error` variant in the protocol crates plus the test that asserts it fires. Audit-prep hygiene from [#124](https://github.com/ligate-io/ligate-chain/issues/124).
+
+The acceptance criterion: every `pub` Error variant has at least one test asserting it fires on the expected bad input. Tests that previously matched on `TxEffect::Reverted(_)` without pinning the variant now use the `assert_reverted_with(receipt, phrase)` helper to grep the rendered error message for a unique substring from the variant's `#[error("...")]` attribute, so a refactor that changes which variant fires breaks the test loudly.
+
+## `attestation::AttestationError` (18 variants)
+
+All in `crates/modules/attestation/src/lib.rs`. Tests in `crates/modules/attestation/tests/integration.rs` unless noted.
+
+| Variant | Phrase pinned | Test |
+|---|---|---|
+| `ThresholdExceedsMembers` | `exceeds member count` | `register_attestor_set_rejects_threshold_above_members` |
+| `ZeroThreshold` | `must be at least 1` | `register_attestor_set_rejects_zero_threshold` |
+| `EmptyAttestorSet` | `must have at least one member` | `register_attestor_set_rejects_empty_members` |
+| `DuplicateAttestorSet` | `attestor set already registered` | `register_attestor_set_rejects_duplicate` |
+| `DuplicateSchema` | `schema already registered` | `register_schema_rejects_duplicate` |
+| `UnknownAttestorSet` | `unregistered attestor set` | `register_schema_requires_existing_attestor_set` |
+| `FeeRoutingExceedsCap` | `exceeds protocol cap` | `register_schema_rejects_over_cap_fee_routing` + `register_schema_rejects_above_custom_cap` |
+| `OrphanFeeRouting` | `fee routing misconfigured` | `register_schema_rejects_orphan_routing_bps_without_addr` + `register_schema_rejects_orphan_routing_addr_without_bps` |
+| `UnknownSchema` | `schema not found` | `submit_attestation_requires_existing_schema` |
+| `DuplicateAttestation` | `attestation already exists` | `full_register_register_submit_flow` (write-once branch) |
+| `DuplicateSignaturePubkey` | `duplicate attestor pubkey` | `submit_with_duplicate_pubkey_rejects` |
+| `UnknownAttestorPubkey` | `not in the schema's attestor set` | `submit_with_unknown_pubkey_rejects` |
+| `InvalidAttestorPubkey` | `not a valid ed25519 point` | `submit_with_off_curve_pubkey_rejects` |
+| `BadSignatureLength` | `expected 64 for ed25519` | `submit_with_bad_sig_length_rejects` |
+| `InvalidSignature` | `did not verify` | `submit_with_invalid_signature_rejects` + `submit_digest_is_bound_to_submitter` |
+| `BelowThreshold` | `quorum not met` | `submit_below_threshold_rejects` + `submit_attestation_rejects_empty_signatures` |
+| `MissingAttestorSet` | n/a (unreachable in v0) | see "Unreachable variants" below |
+| `ChainNotConfigured` | n/a (unreachable in tests) | see "Unreachable variants" below |
+
+## `ligate_stf::genesis_config::GenesisError` (4 variants)
+
+All in `crates/stf/src/genesis_config.rs`. Tests in `crates/stf/src/tests.rs::genesis_loader`.
+
+| Variant | Test |
+|---|---|
+| `Io` | `create_genesis_config_surfaces_io_error_with_path` |
+| `ParseJson` | `create_genesis_config_surfaces_parse_error_with_path` |
+| `MissingGasToken` | `validate_rejects_missing_gas_token` |
+| `LgtTokenIdMismatch` | `validate_rejects_lgt_token_id_mismatch` |
+
+## `ligate_client::ClientError` (4 variants)
+
+All in `crates/client-rs/src/lib.rs`. Tests in the same file's `mod tests` block.
+
+| Variant | Test |
+|---|---|
+| `AttestorSetMembersOverCap` | `register_attestor_set_rejects_over_cap` |
+| `AttestationSignaturesOverCap` | `submit_attestation_rejects_over_cap_signatures` |
+| `SchemaNameOverCap` | `register_schema_rejects_over_cap_name` |
+| `SignatureBytesOverCap` | n/a (currently unreachable) |
+
+## Unreachable variants
+
+Three variants have no test by design. Each is documented here so a future audit doesn't re-flag them.
+
+### `AttestationError::MissingAttestorSet`
+
+Fires when a `Schema` references an `AttestorSetId` that no longer exists in `StateMap<AttestorSetId, AttestorSet>`. v0 has no delete operation on attestor sets; once registered, an attestor set cannot disappear from state. The variant exists as defensive depth for a future v1+ feature that adds attestor-set retirement (governance-driven or auto-expiring sets); when that lands, pair the new feature with a test that fires this variant.
+
+### `AttestationError::ChainNotConfigured`
+
+Fires when the attestation module is invoked before `seed_from_config` has run (i.e., `lgt_token_id` or `treasury` is `None` in state). Every test path goes through `TestRunner` which always seeds via genesis, so this code path isn't reachable from `TransactionTestCase`. Two ways to fire it would be:
+
+1. A direct module-level unit test that constructs an `AttestationModule` without genesis seeding and calls a handler. Plumbing-heavy because it requires building a `Context` + `TxState` by hand.
+2. An end-to-end test that boots a runtime without an `AttestationConfig` (which currently fails at `validate_config` time, not at handler time).
+
+Neither test pulls its weight today. The variant guards against a chain composition that omits the attestation genesis loader, and the existing `validate_config` cross-module check catches that case before any tx executes. Documenting as defensive depth, no test.
+
+### `ClientError::SignatureBytesOverCap`
+
+Fires when a caller-supplied signature byte string exceeds `MAX_ATTESTOR_SIGNATURE_BYTES` (96). The current public builders (`register_attestor_set`, `register_schema`, `submit_attestation`, `sign_attestation`) all produce `SafeVec<u8, MAX_ATTESTOR_SIGNATURE_BYTES>` from sources that are bounded by construction (`SigningKey::sign` always returns 64 bytes for ed25519). No public path produces an oversized sig bytes input.
+
+The variant is reserved for a future builder that takes raw caller-supplied sig bytes (e.g. a `submit_with_raw_signatures` for cross-signature-scheme testing or a `submit_unverified` for relay scenarios). When such a builder lands, pair it with a test that fires this variant. Until then, the variant is callable in theory but not from any code in this repo.
+
+## Helper: `assert_reverted_with`
+
+```rust
+#[track_caller]
+fn assert_reverted_with(receipt: &TxEffect<S>, phrase: &str) {
+    match receipt {
+        TxEffect::Reverted(payload) => {
+            let msg = payload.reason.to_string();
+            assert!(
+                msg.contains(phrase),
+                "expected phrase '{phrase}' in reverted reason, got: {msg}",
+            );
+        }
+        other => panic!("expected Reverted, got {other:?}"),
+    }
+}
+```
+
+Lives in `crates/modules/attestation/tests/integration.rs`. Use it in every new negative-path test instead of `assert!(matches!(_, TxEffect::Reverted(_)))`. The phrase argument should be a substring of the variant's `#[error("...")]` attribute that's unique enough not to match any other variant.
+
+When a new `pub Error` variant ships, do all three of:
+
+1. Add the `#[error("...")]` attribute with a phrase nobody else uses.
+2. Write the test that fires it.
+3. Add a row to the table above.
+
+This document is the single source of truth for which variants are tested and which are intentionally unreachable. Refresh on every PR that touches a public Error enum.
+
+## Out of scope
+
+- **Coverage measurement** (`cargo llvm-cov`). "Every variant has a test" is the proxy we use; line coverage is a separate decision.
+- **Property-based testing of decoders.** That's `proptest` ([#122](https://github.com/ligate-io/ligate-chain/issues/122)) territory.
+- **Fuzzing of decoders.** Already shipped via [#119](https://github.com/ligate-io/ligate-chain/issues/119); see `crates/modules/attestation/fuzz/`.


### PR DESCRIPTION
## Summary

Audits every public `Error` variant in the protocol crates and tightens test coverage. Pairs naturally with #156 (fuzz) and #148 (threat model) as the audit-prep trio. Counts 26 variants across three enums; 23 now have a test that pins the specific variant, 3 are documented as unreachable with rationale.

## What ships

- **Helper** in `crates/modules/attestation/tests/integration.rs`: `assert_reverted_with(receipt, phrase)` matches the rendered error message for a unique substring from the variant's `#[error]` attribute. Replaces 14 existing `assert!(matches!(_, TxEffect::Reverted(_)))` patterns that accepted any reversion as success.
- **3 new tests:**
  - `submit_with_off_curve_pubkey_rejects` (integration) for `InvalidAttestorPubkey`. Uses `[0x02; 32]` as the pubkey input; empirically fails ed25519-dalek's `VerifyingKey::from_bytes` decompression because the y has no valid x square root mod p.
  - `submit_attestation_rejects_over_cap_signatures` (client-rs) for `AttestationSignaturesOverCap`.
  - `register_schema_rejects_over_cap_name` (client-rs) for `SchemaNameOverCap`.
- **Audit doc** `docs/development/error-coverage.md` (109 lines): coverage matrix for all 26 variants with the test that exercises each, plus documented rationale for the 3 unreachable variants.

## Coverage scoreboard

| Enum | Variants | Tested | Unreachable (documented) |
|---|---|---|---|
| `AttestationError` | 18 | 16 | 2 (`MissingAttestorSet`, `ChainNotConfigured`) |
| `GenesisError` | 4 | 4 | 0 |
| `ClientError` | 4 | 3 | 1 (`SignatureBytesOverCap`) |

## Notable findings

1. **`SignatureBytesOverCap` is dead code.** No public builder produces an oversized sig bytes input (every public path either uses `SigningKey::sign` which always returns 64 bytes, or constructs `SafeVec<u8, 96>` from sources bounded by construction). Documented as "reserved for future builders" rather than removed; removing a `pub` enum variant is a breaking change.
2. **`MissingAttestorSet` is unreachable in v0** because there's no delete operation on attestor sets. Defensive depth for a future v1+ attestor-set retirement feature.
3. **`ChainNotConfigured` is unreachable through `TestRunner`** because every test path runs through genesis seeding. The `validate_config` cross-module check fires earlier than this variant ever could in practice; documenting both layers.

## Notable design calls

- **Phrase-pinning over typed-error-pinning.** `RevertedTxContents.reason` is a stringly-typed `ModuleError` wrapping any error; recovering the typed `AttestationError` from the receipt would require an SDK-side change. Substring-matching the rendered message is the lighter-weight path that gives us 80% of the safety with 20% of the plumbing.
- **`docs/development/error-coverage.md` as a live doc, not a snapshot.** New `pub Error` variants need an `#[error]` phrase + a test + a row added to the matrix. The doc's "When a new pub Error variant ships" section spells it out so it survives without me.

## Test plan

- [x] `cargo test -p attestation --test integration` passes (32 tests).
- [x] `cargo test -p ligate-client --lib` passes (14 tests).
- [x] `cargo clippy -p attestation -p ligate-client --tests` passes.
- [x] `cargo fmt --check` passes.
- [ ] CI green on all 10 jobs.