### PR TITLE
Add Prometheus /metrics endpoint with attestation counters (refs #110)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "attestation",
  "borsh",
  "ed25519-dalek",
+ "prometheus",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -4132,11 +4133,14 @@ dependencies = [
  "anyhow",
  "async-trait",
  "attestation",
+ "axum",
  "borsh",
  "clap",
  "ed25519-dalek",
  "ligate-prover-risc0",
  "ligate-stf",
+ "prometheus",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -4216,6 +4220,12 @@ dependencies = [
  "sov-uniqueness",
  "strum 0.26.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5409,6 +5419,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.11.1",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.11.1",
+ "hex",
+]
+
+[[package]]
 name = "progenitor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5483,8 +5515,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "thiserror 2.0.18",
 ]
 
@@ -6602,6 +6636,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -6609,7 +6656,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -8792,7 +8839,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -10524,7 +10571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,11 @@ async-trait = "0.1"
 clap        = { version = "4", features = ["derive"] }
 tokio       = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
 rustls      = { version = "0.23", default-features = false, features = ["ring"] }
+# Prometheus + axum for the `/metrics` endpoint (#110). Both already
+# present in the dep tree via SDK transitives; we explicitly pin via
+# the workspace so direct uses don't silently shift on SDK rev bumps.
+prometheus  = { version = "0.14", default-features = false }
+axum        = { version = "0.8", default-features = false, features = ["tokio", "http1"] }
 # Risc0 toolchain versions track the SDK workspace.
 risc0-zkvm          = { version = "3.0", default-features = false }
 risc0-zkvm-platform = "2.2"

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -22,6 +22,12 @@ thiserror.workspace = true
 sov-modules-api = { workspace = true }
 sov-bank        = { workspace = true }
 
+# Prometheus counters for the module's call paths. Optional behind
+# the `metrics` feature so the in-zkVM build (which doesn't need
+# observability) doesn't pull libcompiler_builtins dupes. Tracking
+# issue: #110 (Phase 1 scope).
+prometheus = { workspace = true, optional = true }
+
 [dev-dependencies]
 attestation     = { path = ".", features = ["native"] }
 serde_json.workspace = true
@@ -35,7 +41,11 @@ tokio.workspace = true
 
 [features]
 default = []
+# `native` includes Prometheus counters: only the host build
+# observes them, the zkVM guest stays clean. The counters expose
+# nothing in the zkVM proof; they live entirely on the prover host.
 native = [
     "sov-modules-api/native",
     "sov-bank/native",
+    "dep:prometheus",
 ]

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -34,6 +34,9 @@ mod query;
 #[cfg(feature = "native")]
 pub use query::{AttestationResponse, AttestorSetResponse, SchemaResponse};
 
+#[cfg(feature = "native")]
+pub mod metrics;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -991,6 +994,9 @@ impl<S: Spec> AttestationModule<S> {
 
         self.attestor_sets.set(&id, &AttestorSet { members: sorted_members, threshold }, state)?;
 
+        #[cfg(feature = "native")]
+        metrics::record_attestor_set_registered();
+
         Ok(())
     }
 
@@ -1041,6 +1047,9 @@ impl<S: Spec> AttestationModule<S> {
             &Schema { owner, name, version, attestor_set, fee_routing_bps, fee_routing_addr },
             state,
         )?;
+
+        #[cfg(feature = "native")]
+        metrics::record_schema_registered();
 
         Ok(())
     }
@@ -1116,6 +1125,9 @@ impl<S: Spec> AttestationModule<S> {
             &Attestation { schema_id, payload_hash, submitter, timestamp, signatures },
             state,
         )?;
+
+        #[cfg(feature = "native")]
+        metrics::record_attestation_submitted();
 
         Ok(())
     }

--- a/crates/modules/attestation/src/metrics.rs
+++ b/crates/modules/attestation/src/metrics.rs
@@ -1,0 +1,98 @@
+//! Prometheus counters for the attestation module's call paths.
+//!
+//! Phase 1 of #110: minimal counter set covering the three handler
+//! entry points. Wired in `handle_register_attestor_set`,
+//! `handle_register_schema`, and `handle_submit_attestation`. The
+//! `/metrics` endpoint that scrapes these lives in
+//! `crates/rollup/src/metrics.rs`; this module is just the
+//! definitions plus the lazy registry binding.
+//!
+//! # Why per-counter `OnceLock`
+//!
+//! `prometheus`'s `register_counter!` macro uses the global default
+//! registry. We could call it once in module init and stash the
+//! returned `Counter` in a `OnceLock`, but the SDK doesn't give us
+//! a single "module loaded" hook to do that on. A lazy
+//! `OnceLock<Counter>` per metric handles the cold-start case
+//! cleanly: the first handler call registers, every later call
+//! reads the cached `Counter`.
+//!
+//! Gated behind the `native` feature at the module include site
+//! in `lib.rs` so the in-zkVM guest build doesn't pull `prometheus`
+//! for no reason. The host build always enables `native`, so
+//! `record_*` is always live there.
+
+use std::sync::OnceLock;
+
+use prometheus::{register_int_counter, IntCounter};
+
+/// Counter incremented once per `RegisterAttestorSet` handler
+/// invocation that returns `Ok(())`. A failed registration (e.g.
+/// `ZeroThreshold`, `DuplicateAttestorSet`) does NOT increment.
+/// Failure breakdown by reason lands in Phase 2 via a labelled
+/// counter vector; see #110 follow-up.
+fn attestor_sets_registered() -> &'static IntCounter {
+    static M: OnceLock<IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter!(
+            "ligate_attestor_sets_registered_total",
+            "Number of attestor sets successfully registered on-chain since the node started."
+        )
+        .expect("counter registers once")
+    })
+}
+
+/// Counter incremented once per successful `RegisterSchema`. Same
+/// shape and semantics as the attestor-set counter.
+fn schemas_registered() -> &'static IntCounter {
+    static M: OnceLock<IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter!(
+            "ligate_schemas_registered_total",
+            "Number of schemas successfully registered on-chain since the node started."
+        )
+        .expect("counter registers once")
+    })
+}
+
+/// Counter incremented once per successful `SubmitAttestation`.
+fn attestations_submitted() -> &'static IntCounter {
+    static M: OnceLock<IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter!(
+            "ligate_attestations_submitted_total",
+            "Number of attestations successfully submitted on-chain since the node started."
+        )
+        .expect("counter registers once")
+    })
+}
+
+// ----- Public API ------------------------------------------------------------
+
+/// Bump the attestor-set-registered counter. Called after a
+/// successful `RegisterAttestorSet` handler.
+pub fn record_attestor_set_registered() {
+    attestor_sets_registered().inc();
+}
+
+/// Bump the schema-registered counter. Called after a successful
+/// `RegisterSchema` handler.
+pub fn record_schema_registered() {
+    schemas_registered().inc();
+}
+
+/// Bump the attestation-submitted counter. Called after a successful
+/// `SubmitAttestation` handler.
+pub fn record_attestation_submitted() {
+    attestations_submitted().inc();
+}
+
+/// Touch every metric so they show up in the registry at startup
+/// even before any handler fires. Without this, a brand-new node
+/// returns an empty `/metrics` response until the first tx lands,
+/// which trips alerting rules that expect a known metric set.
+pub fn init() {
+    let _ = attestor_sets_registered();
+    let _ = schemas_registered();
+    let _ = attestations_submitted();
+}

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -49,8 +49,20 @@ sov-stf-runner                 = { workspace = true }
 # trait impls) is available to the blueprint.
 ligate-stf = { path = "../stf", features = ["native"] }
 
+# Direct path dep so main.rs can call `attestation::metrics::init()`
+# at startup. The `native` feature pulls in the Prometheus counter
+# definitions; the rest of the binary already gets the type via the
+# ligate-stf chain.
+attestation = { path = "../modules/attestation", features = ["native"] }
+
+# Prometheus + axum for the `/metrics` endpoint (issue #110, Phase 1).
+# axum runs in its own tokio task next to the SDK's REST server so we
+# don't have to touch the blueprint's router setup.
+prometheus = { workspace = true, features = ["process"] }
+axum       = { workspace = true }
+
 [dev-dependencies]
-attestation     = { path = "../modules/attestation" }
+reqwest         = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 ed25519-dalek   = { workspace = true }
 serde_json      = { workspace = true }
 sov-test-utils  = { workspace = true }

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -29,6 +29,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod celestia_rollup;
+pub mod metrics;
 mod mock_rollup;
 
 pub use celestia_rollup::{CelestiaLigateRollup, CelestiaRollupSpec};

--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -12,12 +12,13 @@
 //!   serves no purpose with mock zkVM, and we want startup to be
 //!   fast for devnet smoke testing.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::exit;
 
 use anyhow::Context as _;
 use clap::Parser;
-use ligate_rollup::{CelestiaLigateRollup, MockLigateRollup};
+use ligate_rollup::{metrics, CelestiaLigateRollup, MockLigateRollup};
 use ligate_stf::genesis_config::GenesisPaths;
 use sov_address::MultiAddressEvm;
 use sov_celestia_adapter::CelestiaService;
@@ -55,6 +56,18 @@ struct Args {
     /// [`ligate_stf::genesis_config`] for the expected layout.
     #[arg(long, default_value = "devnet/genesis")]
     genesis_config_dir: PathBuf,
+
+    /// Address to bind the Prometheus `/metrics` endpoint on.
+    ///
+    /// Defaults to `127.0.0.1:9100` so a fresh `cargo run --bin
+    /// ligate-node` exposes metrics for local scraping without
+    /// leaking them to the network. Operators behind a reverse
+    /// proxy override to a public bind. Pass `off` to disable the
+    /// endpoint entirely.
+    ///
+    /// Tracking issue: #110.
+    #[arg(long, default_value = "127.0.0.1:9100")]
+    metrics_bind: String,
 }
 
 /// DA layers we know how to dispatch into.
@@ -117,8 +130,32 @@ async fn run() -> anyhow::Result<()> {
         da_layer = ?args.da_layer,
         rollup_config_path = %rollup_config_path,
         genesis_config_dir = ?args.genesis_config_dir,
+        metrics_bind = %args.metrics_bind,
         "Starting Ligate rollup",
     );
+
+    // Spawn the Prometheus `/metrics` server before the rollup
+    // takes the foreground tokio task. If the user passed
+    // `--metrics-bind off`, skip the spawn and run blind. We do
+    // NOT join the metrics task back into the main flow; on
+    // rollup shutdown the task gets dropped with the runtime.
+    if !is_metrics_disabled(&args.metrics_bind) {
+        let addr: SocketAddr = args
+            .metrics_bind
+            .parse()
+            .with_context(|| format!("invalid --metrics-bind value: {}", args.metrics_bind))?;
+        // Pre-touch the attestation counters so they appear in
+        // `/metrics` output even before the first tx lands.
+        attestation::metrics::init();
+        let listener = metrics::bind(addr)
+            .await
+            .with_context(|| format!("metrics server failed to bind {addr}"))?;
+        tokio::spawn(async move {
+            if let Err(e) = metrics::serve(listener).await {
+                tracing::error!(error = ?e, "metrics server stopped");
+            }
+        });
+    }
 
     let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);
 
@@ -126,6 +163,12 @@ async fn run() -> anyhow::Result<()> {
         SupportedDaLayer::Mock => run_with_mock(&rollup_config_path, &genesis_paths).await,
         SupportedDaLayer::Celestia => run_with_celestia(&rollup_config_path, &genesis_paths).await,
     }
+}
+
+/// `--metrics-bind off` (case-insensitive) disables the metrics
+/// endpoint entirely. Any other value gets parsed as a `SocketAddr`.
+fn is_metrics_disabled(value: &str) -> bool {
+    matches!(value.to_ascii_lowercase().as_str(), "off" | "none" | "disabled")
 }
 
 async fn run_with_mock(

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -1,0 +1,86 @@
+//! Prometheus `/metrics` endpoint for `ligate-node`.
+//!
+//! Phase 1 of #110: exposes a single GET route on a configurable
+//! TCP socket (default `127.0.0.1:9100`). The route gathers the
+//! global Prometheus default registry and renders it as
+//! Prometheus text format. The counters that show up here are
+//! defined in [`attestation::metrics`]; future modules add their
+//! own and they appear automatically because everything lives on
+//! the same default registry.
+//!
+//! ## Why a separate axum task
+//!
+//! The SDK's blueprint mounts its own REST server (the runtime
+//! per-module routes plus the sequencer / ledger APIs). Adding a
+//! `/metrics` route to that router requires either patching the
+//! blueprint or wrapping it. Spawning a second axum server on a
+//! different port keeps the metrics surface independent of the
+//! SDK's internal routing and matches the conventional "9100 for
+//! Prometheus, the rest is your app" pattern.
+//!
+//! ## Why bind to localhost by default
+//!
+//! Operators run a reverse proxy (nginx, Caddy) in front of the
+//! node when they want metrics scraped externally. Binding to
+//! `0.0.0.0` by default would expose internal counters to anyone
+//! on the network. The `--metrics-bind` flag overrides for ops
+//! who know what they're doing.
+
+use std::net::SocketAddr;
+
+use anyhow::Context as _;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use prometheus::{Encoder, TextEncoder};
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+
+/// Build the axum router with a single `/metrics` GET route.
+///
+/// Pulled out into its own function so the integration test can
+/// instantiate the same router and exercise it without binding a
+/// real TCP socket.
+pub fn router() -> Router {
+    Router::new().route("/metrics", get(handle_metrics))
+}
+
+/// Render the global Prometheus default registry as text. Returns
+/// 200 with `Content-Type: text/plain; version=0.0.4` on success.
+async fn handle_metrics() -> Response {
+    let mut buf = Vec::with_capacity(4096);
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    if let Err(e) = encoder.encode(&metric_families, &mut buf) {
+        warn!(error = %e, "failed to encode metrics");
+        return (StatusCode::INTERNAL_SERVER_ERROR, format!("encode error: {e}")).into_response();
+    }
+    let mut resp = (StatusCode::OK, buf).into_response();
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_str(encoder.format_type())
+            .unwrap_or(HeaderValue::from_static("text/plain")),
+    );
+    resp
+}
+
+/// Bind a TCP listener for the metrics endpoint. Pulled out from
+/// `serve` so callers (including tests) can request an ephemeral
+/// port via `127.0.0.1:0` and read back the actual bound address.
+pub async fn bind(addr: SocketAddr) -> anyhow::Result<TcpListener> {
+    TcpListener::bind(addr).await.with_context(|| format!("metrics server failed to bind {addr}"))
+}
+
+/// Drive the metrics server on `listener` until the task is
+/// cancelled (e.g. via tokio runtime shutdown). Once `bind`
+/// returns successfully, this loop only fails if axum's accept
+/// loop itself errors out (rare; usually a fatal OS-level fault).
+pub async fn serve(listener: TcpListener) -> anyhow::Result<()> {
+    let actual = listener.local_addr()?;
+    info!(bind = %actual, "metrics endpoint listening at /metrics");
+    let app = router();
+    axum::serve(listener, app)
+        .await
+        .with_context(|| format!("metrics server crashed (was bound to {actual})"))
+}

--- a/crates/rollup/tests/metrics_smoke.rs
+++ b/crates/rollup/tests/metrics_smoke.rs
@@ -1,0 +1,93 @@
+//! End-to-end smoke test for the Prometheus `/metrics` endpoint.
+//!
+//! Boots the same axum router that `ligate-node` runs in production
+//! on an ephemeral port, scrapes `/metrics` over real HTTP, and
+//! asserts the attestation counters render. Catches:
+//!
+//! 1. The `bind` -> `serve` plumbing in `ligate_rollup::metrics`.
+//! 2. The Prometheus default-registry encoding (text/plain v0.0.4
+//!    with the right metric names + HELP / TYPE preambles).
+//! 3. The `attestation::metrics::init()` cold-start touch:
+//!    counters are emitted at zero before any handler fires.
+//!
+//! Tracking issue: #110 (Phase 1 scope).
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use ligate_rollup::metrics;
+
+/// Bind on `127.0.0.1:0`, spawn the server, return the actual
+/// listening address. The server task is leaked into the runtime;
+/// it gets dropped when the test's tokio runtime tears down.
+async fn spawn_metrics_server() -> SocketAddr {
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let listener = metrics::bind(addr).await.expect("ephemeral bind succeeds");
+    let actual = listener.local_addr().expect("listener has local addr");
+    tokio::spawn(async move {
+        let _ = metrics::serve(listener).await;
+    });
+    // axum's serve sets up the loop on the listener inside the
+    // spawned task; on most platforms `bind` already accepts
+    // connections by the time we return here, but yield once so
+    // the spawned task gets to wire its handler before we connect.
+    tokio::task::yield_now().await;
+    actual
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_endpoint_serves_attestation_counters_at_zero() {
+    // Pre-touch the counters so they emit a zero line before any
+    // handler fires. This is what `main.rs` does at startup; the
+    // test mirrors the production cold-start path.
+    attestation::metrics::init();
+
+    let addr = spawn_metrics_server().await;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("reqwest client builds");
+
+    let url = format!("http://{addr}/metrics");
+    let resp = client.get(&url).send().await.expect("metrics endpoint responds");
+    assert_eq!(resp.status().as_u16(), 200, "expected 200, got {}", resp.status());
+
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        content_type.starts_with("text/plain"),
+        "expected text/plain content-type, got {content_type}",
+    );
+
+    let body = resp.text().await.expect("body is utf-8");
+
+    // Each counter has a HELP line, a TYPE line, and a value line.
+    // We assert the metric name shows up at least once; the
+    // Prometheus parser will validate the rest at scrape time.
+    for expected in [
+        "ligate_attestor_sets_registered_total",
+        "ligate_schemas_registered_total",
+        "ligate_attestations_submitted_total",
+    ] {
+        assert!(
+            body.contains(expected),
+            "expected metric '{expected}' in /metrics body, got:\n{body}",
+        );
+    }
+
+    // Cold-start values should all be zero. Substring matches the
+    // line `<metric_name> 0` (Prometheus text format puts the
+    // value after the name, no labels for these counters).
+    for expected in [
+        "ligate_attestor_sets_registered_total 0",
+        "ligate_schemas_registered_total 0",
+        "ligate_attestations_submitted_total 0",
+    ] {
+        assert!(body.contains(expected), "expected '{expected}' (cold-start zero), got:\n{body}",);
+    }
+}

--- a/docs/development/devnet.md
+++ b/docs/development/devnet.md
@@ -360,9 +360,34 @@ operator should watch:
 - Any unexpected signing requests (digests that did not come from the
   authorised quorum endpoint). Treat as a security event.
 
-A Prometheus `/metrics` endpoint on `ligate-node` is **future work** —
-the SDK exposes hooks but we haven't wired them or shipped Grafana
-templates. Tracked as a follow-up in the chain backlog.
+### Prometheus `/metrics` endpoint
+
+`ligate-node` exposes a Prometheus text-format `/metrics` endpoint at
+`http://127.0.0.1:9100/metrics` by default. Phase 1 of [#110](https://github.com/ligate-io/ligate-chain/issues/110)
+ships three counters:
+
+- `ligate_attestor_sets_registered_total`
+- `ligate_schemas_registered_total`
+- `ligate_attestations_submitted_total`
+
+Cold-start values are zero; each counter increments on a successful call
+to the corresponding `RegisterAttestorSet` / `RegisterSchema` /
+`SubmitAttestation` handler.
+
+```bash
+# Default bind (localhost-only, safe for direct scraping in dev).
+curl http://127.0.0.1:9100/metrics
+
+# Behind a reverse proxy with operator-controlled exposure.
+ligate-node --metrics-bind 127.0.0.1:9100 ...
+
+# Disable the endpoint entirely.
+ligate-node --metrics-bind off ...
+```
+
+Phase 2 expands the metric set (DA submission latency, mempool depth,
+RPC histograms, state DB size) and ships a starter Grafana dashboard.
+Tracked under follow-up issues filed alongside the Phase 1 PR.
 
 ## 9. Known limitations (devnet phase)
 
@@ -377,7 +402,7 @@ templates. Tracked as a follow-up in the chain backlog.
 | Multi-sequencer / leader rotation | #82 (v1) |
 | Block indexer service (Postgres + ingest) | #91 |
 | WebSocket / SSE live event stream | #92 |
-| Prometheus metrics endpoint on `ligate-node` | not yet filed |
+| Full Prometheus metric set + Grafana dashboard | follow-up to #110 |
 | `ligate-cli` operator tool | not yet filed |
 
 The chain itself is live: `Schema`, `AttestorSet`, `Attestation`, the


### PR DESCRIPTION
## Summary

Phase 1 of #110: ships the `/metrics` endpoint plus three attestation counters. Establishes the observability pattern operators will dashboard against. Phase 2 fills in the rest of the issue's metric set + Grafana dashboard (follow-up issues filed after merge).

## What ships

**Counters (wired into the success exit of each call handler):**

- `ligate_attestor_sets_registered_total` (bumps on `RegisterAttestorSet` success)
- `ligate_schemas_registered_total` (bumps on `RegisterSchema` success)
- `ligate_attestations_submitted_total` (bumps on `SubmitAttestation` success)

Defined in `crates/modules/attestation/src/metrics.rs`, gated behind the `native` feature so the in-zkVM guest build stays free of `prometheus`. `attestation::metrics::init()` is called once at node startup so cold-start `/metrics` emits zeros for all three (avoids "metric absent" alerting false positives).

**Endpoint** (`crates/rollup/src/metrics.rs`): a separate axum server on its own tokio task. Default bind `127.0.0.1:9100`; CLI override `--metrics-bind <addr>` or `off` / `none` / `disabled` to skip the spawn entirely. Localhost-only by design so unconfigured nodes don't leak metrics to the network; operators behind a reverse proxy override.

**Smoke test** (`crates/rollup/tests/metrics_smoke.rs`): boots the same axum router on an ephemeral port, scrapes `/metrics` over real HTTP via `reqwest`, asserts the three counters render at zero. Catches encoding regressions, content-type drift, and the bind/serve plumbing.

**Docs:** `docs/development/devnet.md` §8 replaces the "future work" placeholder with the actual endpoint + CLI flags. Limitations table updates accordingly.

## Notable design calls

1. **Separate axum task, not the SDK's REST router.** The SDK's blueprint mounts its own router with its own port; adding a `/metrics` route would mean patching the blueprint or wrapping it. A second axum server on `:9100` keeps the metrics surface independent and matches the conventional "9100 = Prometheus, the rest = your app" pattern.
2. **`native` feature, not a separate `metrics` feature.** The metrics counters are pure observability and only meaningful on the host. Folding them into `native` rather than a standalone `metrics` feature keeps Cargo's feature-resolution surface small and avoids needing every consumer to opt-in twice.
3. **Localhost-only default.** `127.0.0.1:9100`. Exposing metrics to the network unconfigured is a footgun (process info, internal counters); operators put a reverse proxy in front when they want external scraping.
4. **`--metrics-bind off` instead of a separate `--no-metrics` flag.** Single CLI surface for "where does it bind / does it bind at all" makes the disable path discoverable from `--help` without a second flag.

## Phase 2 (filed as separate issues after merge)

The issue's full metric list isn't in this PR. Next items, ordered by likely impact:

- DA submission latency histogram + failure counter (sequencer hooks)
- Mempool depth + block height gauges
- RPC request count + duration histograms (axum middleware)
- State DB size gauge
- Process metrics (CPU/memory/FDs) via `prometheus`'s `process` feature
- `{reason}`-labelled rejection counter for `AttestationError` variants
- Starter Grafana dashboard JSON checked in at `ops/grafana/`

## Test plan

- [x] `cargo test -p ligate-rollup --test metrics_smoke` (1 test, passes)
- [x] `cargo test -p attestation --test integration` (32 tests, all still passing with counter wiring)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] `scripts/check-da-isolation.sh`
- [ ] CI green
- [ ] After merge: Tier 1 manual verification (boot `cargo run --bin ligate-node`, curl /metrics, send tx, re-curl, watch counter increment)