### PR TITLE
Add attestations_rejected_total{reason} counter (refs #110, #164)

### DIFF
--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -38,6 +38,11 @@ sov-test-utils  = { workspace = true }
 tempfile.workspace = true
 strum.workspace = true
 tokio.workspace = true
+# Direct dep so the integration test can call `prometheus::gather()`
+# to introspect the rejection counter (Phase 2 of #110). Without
+# this, transitive visibility through `attestation/native` isn't
+# enough for `use prometheus`.
+prometheus.workspace = true
 
 [features]
 default = []

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -778,6 +778,46 @@ pub enum AttestationError {
     ChainNotConfigured,
 }
 
+impl AttestationError {
+    /// Stable snake_case label for this variant. Used as the `reason`
+    /// label on the `ligate_attestations_rejected_total` Prometheus
+    /// counter so dashboards can aggregate by failure category
+    /// without parsing the rendered error message.
+    ///
+    /// **Stability guarantee:** these strings are part of the
+    /// observability surface. Renaming a variant is a non-breaking
+    /// change (Rust-side); changing the discriminant string here is
+    /// a dashboard-breaking change and needs a coordinated update
+    /// to any operator's saved queries. Treat the mapping as wire
+    /// format for the metrics layer.
+    ///
+    /// Pinned by `discriminant_is_stable_per_variant` in
+    /// `tests/unit.rs` so adding a new variant without extending
+    /// this match fails CI.
+    pub fn discriminant(&self) -> &'static str {
+        match self {
+            Self::ThresholdExceedsMembers { .. } => "threshold_exceeds_members",
+            Self::ZeroThreshold => "zero_threshold",
+            Self::EmptyAttestorSet => "empty_attestor_set",
+            Self::DuplicateAttestorSet => "duplicate_attestor_set",
+            Self::DuplicateSchema => "duplicate_schema",
+            Self::UnknownAttestorSet => "unknown_attestor_set",
+            Self::FeeRoutingExceedsCap { .. } => "fee_routing_exceeds_cap",
+            Self::OrphanFeeRouting => "orphan_fee_routing",
+            Self::UnknownSchema => "unknown_schema",
+            Self::DuplicateAttestation => "duplicate_attestation",
+            Self::DuplicateSignaturePubkey => "duplicate_signature_pubkey",
+            Self::UnknownAttestorPubkey => "unknown_attestor_pubkey",
+            Self::InvalidAttestorPubkey => "invalid_attestor_pubkey",
+            Self::BadSignatureLength { .. } => "bad_signature_length",
+            Self::InvalidSignature => "invalid_signature",
+            Self::BelowThreshold { .. } => "below_threshold",
+            Self::MissingAttestorSet => "missing_attestor_set",
+            Self::ChainNotConfigured => "chain_not_configured",
+        }
+    }
+}
+
 // ============================================================================
 // Module implementation
 // ============================================================================
@@ -838,7 +878,7 @@ impl<S: Spec> Module for AttestationModule<S> {
         // boundary so the per-handler signatures stay in terms of
         // unbounded `String` / `Vec<T>`. Borsh round-trips through
         // SafeString/SafeVec preserve content losslessly.
-        match msg {
+        let result = match msg {
             CallMessage::RegisterAttestorSet { members, threshold } => {
                 let members: Vec<PubKey> = members.into_iter().collect();
                 self.handle_register_attestor_set(members, threshold, context, state)
@@ -862,7 +902,23 @@ impl<S: Spec> Module for AttestationModule<S> {
                 let signatures: Vec<AttestorSignature> = signatures.into_iter().collect();
                 self.handle_submit_attestation(schema_id, payload_hash, signatures, context, state)
             }
+        };
+
+        // Phase 2 of #110: bump `ligate_attestations_rejected_total`
+        // when the handler returned a typed `AttestationError`.
+        // Non-`AttestationError` rejections (e.g. bank `transfer`
+        // failures from insufficient balance) are intentionally not
+        // counted here; they belong to the bank module's own metric
+        // surface and would dilute the {reason} cardinality of this
+        // counter.
+        #[cfg(feature = "native")]
+        if let Err(e) = &result {
+            if let Some(typed) = e.downcast_ref::<AttestationError>() {
+                metrics::record_rejected(typed);
+            }
         }
+
+        result
     }
 }
 

--- a/crates/modules/attestation/src/metrics.rs
+++ b/crates/modules/attestation/src/metrics.rs
@@ -24,13 +24,14 @@
 
 use std::sync::OnceLock;
 
-use prometheus::{register_int_counter, IntCounter};
+use prometheus::{register_int_counter, register_int_counter_vec, IntCounter, IntCounterVec};
+
+use crate::AttestationError;
 
 /// Counter incremented once per `RegisterAttestorSet` handler
 /// invocation that returns `Ok(())`. A failed registration (e.g.
-/// `ZeroThreshold`, `DuplicateAttestorSet`) does NOT increment.
-/// Failure breakdown by reason lands in Phase 2 via a labelled
-/// counter vector; see #110 follow-up.
+/// `ZeroThreshold`, `DuplicateAttestorSet`) does NOT increment;
+/// failures bump `attestations_rejected_total{reason}` instead.
 fn attestor_sets_registered() -> &'static IntCounter {
     static M: OnceLock<IntCounter> = OnceLock::new();
     M.get_or_init(|| {
@@ -67,6 +68,30 @@ fn attestations_submitted() -> &'static IntCounter {
     })
 }
 
+/// Vector counter labelled by `reason`. Bumps once per call-handler
+/// invocation that returns an [`AttestationError`]. The label value
+/// comes from [`AttestationError::discriminant`] and is part of the
+/// observability wire format: stable across Rust-side variant
+/// renames, only changes via a coordinated dashboard update.
+///
+/// Per-handler kind isn't broken out (no separate counter for
+/// "register-attestor-set rejects" vs "submit-attestation rejects")
+/// because the failure space across handlers is mostly disjoint
+/// (`zero_threshold` only fires from `RegisterAttestorSet`,
+/// `unknown_schema` only from `SubmitAttestation`). Adding a `kind`
+/// label later if dashboards need it is a non-breaking change.
+fn attestations_rejected() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter_vec!(
+            "ligate_attestations_rejected_total",
+            "Number of attestation-module call handler invocations rejected with a typed AttestationError, by reason.",
+            &["reason"]
+        )
+        .expect("counter vec registers once")
+    })
+}
+
 // ----- Public API ------------------------------------------------------------
 
 /// Bump the attestor-set-registered counter. Called after a
@@ -87,12 +112,25 @@ pub fn record_attestation_submitted() {
     attestations_submitted().inc();
 }
 
+/// Bump the rejection counter under the variant's stable
+/// discriminant string. Called from the call dispatcher when a
+/// handler returns an [`AttestationError`].
+pub fn record_rejected(err: &AttestationError) {
+    attestations_rejected().with_label_values(&[err.discriminant()]).inc();
+}
+
 /// Touch every metric so they show up in the registry at startup
 /// even before any handler fires. Without this, a brand-new node
 /// returns an empty `/metrics` response until the first tx lands,
 /// which trips alerting rules that expect a known metric set.
+///
+/// The labelled rejection vector doesn't pre-emit per-label series
+/// (Prometheus aggregates 0 across unseen labels), but its `HELP`
+/// and `TYPE` lines are emitted so the metric is discoverable via
+/// `/metrics` even before a rejection happens.
 pub fn init() {
     let _ = attestor_sets_registered();
     let _ = schemas_registered();
     let _ = attestations_submitted();
+    let _ = attestations_rejected();
 }

--- a/crates/modules/attestation/tests/integration.rs
+++ b/crates/modules/attestation/tests/integration.rs
@@ -146,6 +146,28 @@ fn safe_name(s: &str) -> SafeString {
     SafeString::try_from(s.to_string()).expect("name fits SafeString default cap")
 }
 
+/// Read the current value of the rejection counter for a given
+/// `reason` label. Returns 0 if the counter / label hasn't been
+/// seen yet by the registry.
+///
+/// Walks the global Prometheus default registry rather than holding
+/// a direct handle to the counter, so this helper survives if the
+/// metrics module is refactored. Phase 2 of #110.
+fn rejection_counter(reason: &str) -> u64 {
+    for mf in prometheus::gather() {
+        if mf.name() != "ligate_attestations_rejected_total" {
+            continue;
+        }
+        for m in mf.get_metric() {
+            let matches = m.get_label().iter().any(|l| l.name() == "reason" && l.value() == reason);
+            if matches {
+                return m.get_counter().get_value() as u64;
+            }
+        }
+    }
+    0
+}
+
 /// Asserts the tx reverted AND the rendered reason contains `phrase`.
 ///
 /// Pinning the phrase guards against a refactor that changes which
@@ -519,6 +541,47 @@ fn register_schema_rejects_orphan_routing_addr_without_bps() {
             assert_reverted_with(&result.tx_receipt, "fee routing misconfigured");
         }),
     });
+}
+
+#[test]
+fn rejection_counter_bumps_on_typed_attestation_error() {
+    // Phase 2 of #110. Submits a tx that fires `UnknownSchema`
+    // (simplest variant to trigger: no setup needed beyond the
+    // default `setup`) and asserts the
+    // `ligate_attestations_rejected_total{reason="unknown_schema"}`
+    // counter increments by exactly 1.
+    //
+    // Uses a before/after delta because tests share the global
+    // Prometheus default registry; another test running in parallel
+    // could have bumped the counter between observations.
+
+    let before = rejection_counter("unknown_schema");
+
+    let mut env = setup(Amount::ZERO, Amount::ZERO, Amount::ZERO);
+
+    let bogus_schema = attestation::SchemaId::from([0xCAu8; 32]);
+    let bogus_payload = attestation::PayloadHash::from([0xFEu8; 32]);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.submitter.create_plain_message::<RT, AttestationModule<S>>(
+            CallMessage::SubmitAttestation {
+                schema_id: bogus_schema,
+                payload_hash: bogus_payload,
+                signatures: SafeVec::try_from(Vec::<AttestorSignature>::new()).unwrap(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert_reverted_with(&result.tx_receipt, "schema not found");
+        }),
+    });
+
+    let after = rejection_counter("unknown_schema");
+    assert_eq!(
+        after - before,
+        1,
+        "expected unknown_schema rejection counter to bump by 1, got delta {}",
+        after - before
+    );
 }
 
 #[test]

--- a/crates/modules/attestation/tests/unit.rs
+++ b/crates/modules/attestation/tests/unit.rs
@@ -372,3 +372,66 @@ fn default_max_builder_bps_is_half() {
 // reduction of the cap below ed25519's 64 fails the build.
 const _: () = assert!(MAX_ATTESTOR_SIGNATURE_BYTES >= 64);
 const _: () = assert!(MAX_ATTESTOR_SIGNATURE_BYTES >= 48);
+
+#[test]
+fn discriminant_labels_are_stable_and_unique() {
+    // Pins the snake_case mapping in `AttestationError::discriminant`.
+    // The discriminant strings ARE wire format for the Prometheus
+    // `ligate_attestations_rejected_total{reason}` label; renaming
+    // breaks every operator's saved Grafana queries. Treat any diff
+    // here as a coordinated change with the dashboard.
+    //
+    // The exhaustive match in `discriminant()` itself catches "added
+    // a variant, forgot to map it" at compile time. This test catches
+    // "renamed a label" or "two variants collapsed to the same label".
+    use std::collections::HashSet;
+
+    use attestation::AttestationError;
+
+    let variants: Vec<AttestationError> = vec![
+        AttestationError::ThresholdExceedsMembers { threshold: 0, count: 0 },
+        AttestationError::ZeroThreshold,
+        AttestationError::EmptyAttestorSet,
+        AttestationError::DuplicateAttestorSet,
+        AttestationError::DuplicateSchema,
+        AttestationError::UnknownAttestorSet,
+        AttestationError::FeeRoutingExceedsCap { bps: 0, cap: 0 },
+        AttestationError::OrphanFeeRouting,
+        AttestationError::UnknownSchema,
+        AttestationError::DuplicateAttestation,
+        AttestationError::DuplicateSignaturePubkey,
+        AttestationError::UnknownAttestorPubkey,
+        AttestationError::InvalidAttestorPubkey,
+        AttestationError::BadSignatureLength { actual: 0 },
+        AttestationError::InvalidSignature,
+        AttestationError::BelowThreshold { provided: 0, required: 0 },
+        AttestationError::MissingAttestorSet,
+        AttestationError::ChainNotConfigured,
+    ];
+
+    // Tripwire for new variants. Bumping this is the cue to add a
+    // row + check the dashboards.
+    assert_eq!(
+        variants.len(),
+        18,
+        "update this test when AttestationError gains a variant; \
+         also update docs/development/error-coverage.md"
+    );
+
+    let mut seen: HashSet<&'static str> = HashSet::new();
+    for variant in &variants {
+        let label = variant.discriminant();
+
+        assert!(!label.is_empty(), "discriminant for {variant:?} is empty");
+
+        assert!(
+            label.bytes().all(|b| b.is_ascii_lowercase() || b == b'_' || b.is_ascii_digit()),
+            "discriminant '{label}' for {variant:?} is not snake_case ASCII"
+        );
+
+        assert!(
+            seen.insert(label),
+            "discriminant '{label}' is shared across variants; metrics break"
+        );
+    }
+}

--- a/docs/development/error-coverage.md
+++ b/docs/development/error-coverage.md
@@ -8,26 +8,28 @@ The acceptance criterion: every `pub` Error variant has at least one test assert
 
 All in `crates/modules/attestation/src/lib.rs`. Tests in `crates/modules/attestation/tests/integration.rs` unless noted.
 
-| Variant | Phrase pinned | Test |
-|---|---|---|
-| `ThresholdExceedsMembers` | `exceeds member count` | `register_attestor_set_rejects_threshold_above_members` |
-| `ZeroThreshold` | `must be at least 1` | `register_attestor_set_rejects_zero_threshold` |
-| `EmptyAttestorSet` | `must have at least one member` | `register_attestor_set_rejects_empty_members` |
-| `DuplicateAttestorSet` | `attestor set already registered` | `register_attestor_set_rejects_duplicate` |
-| `DuplicateSchema` | `schema already registered` | `register_schema_rejects_duplicate` |
-| `UnknownAttestorSet` | `unregistered attestor set` | `register_schema_requires_existing_attestor_set` |
-| `FeeRoutingExceedsCap` | `exceeds protocol cap` | `register_schema_rejects_over_cap_fee_routing` + `register_schema_rejects_above_custom_cap` |
-| `OrphanFeeRouting` | `fee routing misconfigured` | `register_schema_rejects_orphan_routing_bps_without_addr` + `register_schema_rejects_orphan_routing_addr_without_bps` |
-| `UnknownSchema` | `schema not found` | `submit_attestation_requires_existing_schema` |
-| `DuplicateAttestation` | `attestation already exists` | `full_register_register_submit_flow` (write-once branch) |
-| `DuplicateSignaturePubkey` | `duplicate attestor pubkey` | `submit_with_duplicate_pubkey_rejects` |
-| `UnknownAttestorPubkey` | `not in the schema's attestor set` | `submit_with_unknown_pubkey_rejects` |
-| `InvalidAttestorPubkey` | `not a valid ed25519 point` | `submit_with_off_curve_pubkey_rejects` |
-| `BadSignatureLength` | `expected 64 for ed25519` | `submit_with_bad_sig_length_rejects` |
-| `InvalidSignature` | `did not verify` | `submit_with_invalid_signature_rejects` + `submit_digest_is_bound_to_submitter` |
-| `BelowThreshold` | `quorum not met` | `submit_below_threshold_rejects` + `submit_attestation_rejects_empty_signatures` |
-| `MissingAttestorSet` | n/a (unreachable in v0) | see "Unreachable variants" below |
-| `ChainNotConfigured` | n/a (unreachable in tests) | see "Unreachable variants" below |
+| Variant | Phrase pinned | Discriminant | Test |
+|---|---|---|---|
+| `ThresholdExceedsMembers` | `exceeds member count` | `threshold_exceeds_members` | `register_attestor_set_rejects_threshold_above_members` |
+| `ZeroThreshold` | `must be at least 1` | `zero_threshold` | `register_attestor_set_rejects_zero_threshold` |
+| `EmptyAttestorSet` | `must have at least one member` | `empty_attestor_set` | `register_attestor_set_rejects_empty_members` |
+| `DuplicateAttestorSet` | `attestor set already registered` | `duplicate_attestor_set` | `register_attestor_set_rejects_duplicate` |
+| `DuplicateSchema` | `schema already registered` | `duplicate_schema` | `register_schema_rejects_duplicate` |
+| `UnknownAttestorSet` | `unregistered attestor set` | `unknown_attestor_set` | `register_schema_requires_existing_attestor_set` |
+| `FeeRoutingExceedsCap` | `exceeds protocol cap` | `fee_routing_exceeds_cap` | `register_schema_rejects_over_cap_fee_routing` + `register_schema_rejects_above_custom_cap` |
+| `OrphanFeeRouting` | `fee routing misconfigured` | `orphan_fee_routing` | `register_schema_rejects_orphan_routing_bps_without_addr` + `register_schema_rejects_orphan_routing_addr_without_bps` |
+| `UnknownSchema` | `schema not found` | `unknown_schema` | `submit_attestation_requires_existing_schema` + `rejection_counter_bumps_on_typed_attestation_error` |
+| `DuplicateAttestation` | `attestation already exists` | `duplicate_attestation` | `full_register_register_submit_flow` (write-once branch) |
+| `DuplicateSignaturePubkey` | `duplicate attestor pubkey` | `duplicate_signature_pubkey` | `submit_with_duplicate_pubkey_rejects` |
+| `UnknownAttestorPubkey` | `not in the schema's attestor set` | `unknown_attestor_pubkey` | `submit_with_unknown_pubkey_rejects` |
+| `InvalidAttestorPubkey` | `not a valid ed25519 point` | `invalid_attestor_pubkey` | `submit_with_off_curve_pubkey_rejects` |
+| `BadSignatureLength` | `expected 64 for ed25519` | `bad_signature_length` | `submit_with_bad_sig_length_rejects` |
+| `InvalidSignature` | `did not verify` | `invalid_signature` | `submit_with_invalid_signature_rejects` + `submit_digest_is_bound_to_submitter` |
+| `BelowThreshold` | `quorum not met` | `below_threshold` | `submit_below_threshold_rejects` + `submit_attestation_rejects_empty_signatures` |
+| `MissingAttestorSet` | n/a (unreachable in v0) | `missing_attestor_set` | see "Unreachable variants" below |
+| `ChainNotConfigured` | n/a (unreachable in tests) | `chain_not_configured` | see "Unreachable variants" below |
+
+**Discriminant column** is the stable snake_case label produced by `AttestationError::discriminant()`. It's the value of the `reason` label on the Prometheus `ligate_attestations_rejected_total{reason}` counter. The `discriminant_labels_are_stable_and_unique` unit test in `tests/unit.rs` pins the mapping; renaming a label is a coordinated dashboard-update event, not a Rust-only change.
 
 ## `ligate_stf::genesis_config::GenesisError` (4 variants)
 


### PR DESCRIPTION
## Summary

First chunk of #164 (Phase 2 metrics): wires the labelled rejection counter the issue calls out as the next-most-useful signal beyond Phase 1's success counters. Self-contained; doesn't need sequencer/DA/RPC hooks. Lands the `AttestationError::discriminant()` API as a side benefit, locked down by a unit-level pinning test.

## What ships

**`AttestationError::discriminant() -> &'static str`** in `crates/modules/attestation/src/lib.rs`. Maps each of the 18 variants to a stable snake_case label (`zero_threshold`, `unknown_schema`, etc). Doc comment treats the mapping as observability wire format: renaming a label is a coordinated dashboard update, not a Rust-only change.

**`ligate_attestations_rejected_total{reason}` counter** in `crates/modules/attestation/src/metrics.rs`. Bumped from the dispatcher (`fn call`) when a handler returns a typed `AttestationError`. Non-`AttestationError` rejections (e.g. bank `transfer` failures from insufficient balance) are intentionally not counted here; they belong to the bank module's own metric surface.

**Three new tests:**
- `discriminant_labels_are_stable_and_unique` (unit): pins all 18 labels, asserts non-empty + snake_case + uniqueness, includes a `len() == 18` tripwire so adding a variant without updating the test fails CI.
- `rejection_counter_bumps_on_typed_attestation_error` (integration): submits a tx that fires `UnknownSchema`, asserts the counter for `reason="unknown_schema"` increments by exactly 1 (before/after delta to survive parallel test execution).
- The `init()` fn touches the rejection vector at startup so its `HELP` and `TYPE` lines are discoverable in `/metrics` even before any rejection happens.

**Audit doc updated:** `docs/development/error-coverage.md` gains a `Discriminant` column listing the label per variant. Header explains the mapping is part of the metrics wire format.

## Notable design calls

1. **Discriminant via exhaustive `match`, not `strum::AsRefStr`.** Compile-time check that every variant is mapped, no proc-macro footprint, no hidden coupling to `strum`'s naming defaults. The unit test pins the labels; the match pins the coverage.
2. **Counter wired at the dispatcher, not at each error site.** One downcast call instead of N inline `metrics::record_rejected()` calls in handlers. Cleaner diff (handler bodies stay focused on logic), and a future Phase 2.x that adds a `kind` label per handler can extend the dispatcher logic in one place.
3. **Don't count non-`AttestationError` rejections.** Bank-side `Insufficient balance` would dilute the `{reason}` cardinality and double-count failures already visible on the bank's own counters. Documented inline.
4. **Before/after delta in the integration test.** Tests run in parallel; counter is global state. Delta works regardless of execution order.

## Coverage scoreboard

The `Discriminant` column is now populated for all 18 `AttestationError` variants. Combined with #160's phrase-pinning, every rejected variant has both a wire-format label (for metrics) and a phrase-pinned test (for catching error-routing regressions). Two unreachable variants (`MissingAttestorSet`, `ChainNotConfigured`) keep their discriminants for future-proofing.

## Out of scope (still in #164)

- DA submission latency histogram + failures counter (sequencer hooks).
- Mempool depth + block height gauges.
- RPC request count + duration histograms.
- State DB size gauge.
- Process metrics via `prometheus`'s `process` collector.

## Test plan

- [x] `cargo test -p attestation` (78 tests across all bins, green).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [x] `scripts/check-da-isolation.sh`.
- [ ] CI green.