### PR TITLE
Add ligate_block_height gauge polled from LedgerDb (refs #110, #164)

### DIFF
--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -129,6 +129,14 @@ impl FullNodeBlueprint<Native> for CelestiaLigateRollup<Native> {
         _da_service: &Self::DaService,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
     ) -> anyhow::Result<NodeEndpoints> {
+        // Phase 2 of #110: same hook the mock-DA blueprint uses to
+        // spawn the block-height polling task. `LedgerDb` is only
+        // handed to us here.
+        crate::metrics::spawn_block_height_task(
+            ledger_db.clone(),
+            crate::metrics::DEFAULT_BLOCK_HEIGHT_POLL_INTERVAL,
+        );
+
         sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver,
             sync_status_receiver,

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -37,6 +37,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use prometheus::{register_int_gauge, Encoder, IntGauge, TextEncoder};
+use sov_db::ledger_db::LedgerDb;
+use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use tokio::net::TcpListener;
 use tracing::{debug, info, warn};
 
@@ -178,6 +181,71 @@ pub fn spawn_state_db_size_task(storage_path: PathBuf, interval: Duration) {
         loop {
             ticker.tick().await;
             sample_state_db_size(&storage_path);
+        }
+    });
+}
+
+// ============================================================================
+// Block height gauge (#110 Phase 2)
+// ============================================================================
+
+/// Default polling interval for the block-height sampler.
+///
+/// Slot times are typically 1s on devnet; polling every 2s catches
+/// the head with one cycle of headroom and keeps the LedgerDb read
+/// rate well below RocksDB's read budget. Tighter cadence is fine
+/// (the read is cheap, just a single key lookup) but doesn't help
+/// any dashboard scraping at 5-15s intervals.
+pub const DEFAULT_BLOCK_HEIGHT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// `ligate_block_height` gauge. Current head slot number observed
+/// by this node. For a sequencer, this is the head it's producing;
+/// for a follower, it's the head it has replayed from DA.
+fn block_height() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_block_height",
+            "Current rollup head slot number observed by this node. Sequencers report what \
+             they're producing; followers report what they've replayed from DA."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+/// Touch the gauge so its `HELP` and `TYPE` show up in `/metrics`
+/// from the very first scrape, before the first poll completes.
+pub fn init_block_height() {
+    let _ = block_height();
+}
+
+/// Set the block-height gauge to a specific slot number. Pulled out
+/// of the polling loop so tests can drive a single sample without
+/// constructing a `LedgerDb`.
+pub fn sample_block_height(slot: SlotNumber) {
+    init_block_height();
+    block_height().set(slot.get() as i64);
+}
+
+/// Spawn a tokio task that polls `ledger_db.get_head_slot_number()`
+/// every `interval` and updates `ligate_block_height`. Runs until
+/// the runtime drops.
+///
+/// The polling pattern (vs `subscribe_slots()`) avoids pulling
+/// `futures_util::StreamExt` into the deps and matches the polling
+/// shape we already use for `state_db_size`. Slot rate (1Hz) is
+/// well under poll cadence (2s) on devnet, so resolution is fine.
+pub fn spawn_block_height_task(ledger_db: LedgerDb, interval: Duration) {
+    init_block_height();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            match ledger_db.get_head_slot_number().await {
+                Ok(slot) => sample_block_height(slot),
+                Err(e) => warn!(error = ?e, "failed to read head slot number"),
+            }
         }
     });
 }

--- a/crates/rollup/src/mock_rollup.rs
+++ b/crates/rollup/src/mock_rollup.rs
@@ -118,9 +118,17 @@ impl FullNodeBlueprint<Native> for MockLigateRollup<Native> {
         _da_service: &Self::DaService,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
     ) -> anyhow::Result<NodeEndpoints> {
+        // Phase 2 of #110: spawn the block-height polling task here
+        // because `LedgerDb` is only handed to us via this hook.
+        // The task lives until the tokio runtime tears down.
+        crate::metrics::spawn_block_height_task(
+            ledger_db.clone(),
+            crate::metrics::DEFAULT_BLOCK_HEIGHT_POLL_INTERVAL,
+        );
+
         // Stock SDK helper. Wires the standard sequencer + ledger
         // RPCs and the runtime's per-module REST routers (currently
-        // empty — see `ligate_stf::runtime_capabilities`).
+        // empty, see `ligate_stf::runtime_capabilities`).
         sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver,
             sync_status_receiver,

--- a/crates/rollup/tests/metrics_smoke.rs
+++ b/crates/rollup/tests/metrics_smoke.rs
@@ -138,3 +138,33 @@ async fn state_db_size_gauge_reflects_disk_usage() {
         "expected gauge to read 6 bytes after sampling 3 x 2-byte files, got:\n{body}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_height_gauge_renders_sample_value() {
+    // Phase 2 of #110. Drives `sample_block_height` directly with a
+    // known SlotNumber and asserts `/metrics` reflects it. Skips the
+    // polling task + LedgerDb (testing both end-to-end requires a
+    // booted node, which is the Tier 2 manual-verification surface).
+    use sov_rollup_interface::common::SlotNumber;
+
+    metrics::sample_block_height(SlotNumber::new(1234));
+
+    let addr = spawn_metrics_server().await;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("reqwest client builds");
+    let body = client
+        .get(format!("http://{addr}/metrics"))
+        .send()
+        .await
+        .expect("metrics endpoint responds")
+        .text()
+        .await
+        .expect("body is utf-8");
+
+    assert!(
+        body.contains("ligate_block_height 1234"),
+        "expected `ligate_block_height 1234` after sampling slot 1234, got:\n{body}",
+    );
+}

--- a/docs/development/devnet.md
+++ b/docs/development/devnet.md
@@ -378,6 +378,7 @@ operator should watch:
 **Gauges:**
 
 - `ligate_state_db_size_bytes` — total on-disk size of the rollup's storage directory, sampled every 30 seconds. Captures RocksDB SST files, WAL, manifest, and the ledger DB.
+- `ligate_block_height` — current rollup head slot number observed by this node, sampled every 2 seconds via the SDK's `LedgerDb::get_head_slot_number`. Sequencers report what they're producing; followers report what they've replayed from DA. Lag between two nodes scraping the same chain is the follower-vs-sequencer sync gap.
 
 **Process metrics** (Linux only): `process_cpu_seconds_total`, `process_resident_memory_bytes`, `process_open_fds`, `process_max_fds`, `process_start_time_seconds`, `process_virtual_memory_bytes`. Auto-registered by the `prometheus` crate's `process` feature; macOS and Windows builds skip them.
 


### PR DESCRIPTION
## Summary

Third chunk of #164 (Phase 2 metrics). Hooks the rollup's current head slot number into a Prometheus gauge. Required investigating the SDK to find the right capture point; no upstream changes needed (clean hook in `FullNodeBlueprint::create_endpoints`).

## What ships

**`ligate_block_height` gauge** in `crates/rollup/src/metrics.rs`:
- Current head slot number observed by this node.
- Sequencers report what they're producing; followers report what they've replayed from DA.
- Polled every 2 seconds via `LedgerDb::get_head_slot_number`.
- Polling pattern (vs `subscribe_slots()`) avoids pulling `futures_util::StreamExt` into the deps and matches the `state_db_size` shape we just shipped in #168.

**Wired in `mock_rollup.rs` and `celestia_rollup.rs` `create_endpoints`:** the SDK passes `&LedgerDb` to this hook, the only blueprint surface that has it. We clone (LedgerDb is `Clone` via `Arc<RwLock<DeltaReader>>`) and spawn a tokio task. Same shape on both DA flavours.

**Test:** `block_height_gauge_renders_sample_value` in `crates/rollup/tests/metrics_smoke.rs`. Drives `sample_block_height(SlotNumber::new(1234))` directly and asserts `/metrics` shows `ligate_block_height 1234`. Skips the polling task + LedgerDb construction; testing both end-to-end requires a booted node (Tier 2 manual-verification surface).

## SDK exploration findings

Used the SDK source at the pinned rev to confirm the hook:

- `LedgerDb::get_head_slot_number` is at `crates/full-node/sov-db/src/ledger_db/rpc.rs:582`, async, returns `Result<SlotNumber, anyhow::Error>`.
- The trait `LedgerStateProvider` lives at `crates/rollup-interface/src/node/ledger_api.rs:292`; bringing it into scope makes the methods callable on `LedgerDb`.
- `LedgerDb` is `Clone`, so the polling task can own its own handle without lifetime gymnastics.
- The blueprint's `create_endpoints` is the only hook that hands us `&LedgerDb` before `Rollup::run` consumes the runner. Capturing here lets us spawn the task as a side-effect of endpoint creation.

The SDK also exposes `subscribe_slots()` (broadcast stream) and `subscribe_finalized_slots()` (watch stream) for an event-driven alternative. Polling won out for Phase 1 simplicity (no new transitive dep on `futures_util`); a future PR can swap to streams if dashboard cadence demands it.

## Out of scope (still in #164)

- Mempool depth gauge (sequencer hooks; SDK exposure unclear).
- DA submission latency + failures counter (sequencer-side hooks).
- RPC histograms (axum middleware on the SDK's existing router; touches blueprint impls more invasively).

## Test plan

- [x] `cargo test -p ligate-rollup --test metrics_smoke` (3 tests, all pass).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [x] `scripts/check-da-isolation.sh`.
- [ ] CI green.