### PR TITLE
Add RPC request + duration histograms via axum middleware (refs #110, #164)

### DIFF
--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -136,8 +136,9 @@ impl FullNodeBlueprint<Native> for CelestiaLigateRollup<Native> {
             ledger_db.clone(),
             crate::metrics::DEFAULT_BLOCK_HEIGHT_POLL_INTERVAL,
         );
+        crate::metrics::init_rpc_metrics();
 
-        sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
+        let mut endpoints = sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver,
             sync_status_receiver,
             shutdown_receiver,
@@ -145,7 +146,12 @@ impl FullNodeBlueprint<Native> for CelestiaLigateRollup<Native> {
             sequencer,
             rollup_config,
         )
-        .await
+        .await?;
+
+        endpoints.axum_router = std::mem::take::<axum::Router<()>>(&mut endpoints.axum_router)
+            .layer(axum::middleware::from_fn(crate::metrics::record_rpc_request));
+
+        Ok(endpoints)
     }
 
     async fn create_da_service(

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -32,11 +32,16 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::Context as _;
+use axum::extract::{MatchedPath, Request};
 use axum::http::{header, HeaderValue, StatusCode};
+use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
-use prometheus::{register_int_gauge, Encoder, IntGauge, TextEncoder};
+use prometheus::{
+    register_histogram_vec, register_int_counter_vec, register_int_gauge, Encoder, HistogramVec,
+    IntCounterVec, IntGauge, TextEncoder,
+};
 use sov_db::ledger_db::LedgerDb;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
@@ -226,6 +231,88 @@ pub fn sample_block_height(slot: SlotNumber) {
     init_block_height();
     block_height().set(slot.get() as i64);
 }
+
+// ============================================================================
+// RPC histograms (#110 Phase 2)
+// ============================================================================
+
+/// `ligate_rpc_requests_total{endpoint,status}` counter. One bump
+/// per request that hits a matched route. Unmatched routes (404s on
+/// arbitrary paths) are skipped to keep the `endpoint` label
+/// cardinality bounded by the actual route surface.
+fn rpc_requests() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter_vec!(
+            "ligate_rpc_requests_total",
+            "Number of REST requests received, labelled by route template and HTTP status.",
+            &["endpoint", "status"]
+        )
+        .expect("counter vec registers once")
+    })
+}
+
+/// `ligate_rpc_request_duration_seconds{endpoint}` histogram. One
+/// observation per request, in seconds. Default Prometheus buckets
+/// (0.005s through 10s) cover the realistic latency range for our
+/// REST surface (state lookups in milliseconds, slow queries up to
+/// a few seconds under load).
+fn rpc_request_duration() -> &'static HistogramVec {
+    static M: OnceLock<HistogramVec> = OnceLock::new();
+    M.get_or_init(|| {
+        register_histogram_vec!(
+            "ligate_rpc_request_duration_seconds",
+            "Duration of REST request handling in seconds, labelled by route template.",
+            &["endpoint"]
+        )
+        .expect("histogram vec registers once")
+    })
+}
+
+/// Touch both vectors so their `HELP` and `TYPE` lines appear in
+/// `/metrics` from the very first scrape, before the first request
+/// lands.
+pub fn init_rpc_metrics() {
+    let _ = rpc_requests();
+    let _ = rpc_request_duration();
+}
+
+/// Axum middleware: record one `rpc_requests_total` increment + one
+/// `rpc_request_duration_seconds` observation per matched route.
+///
+/// Mirrors the pattern in `sov-stf-runner/src/http/mod.rs:189-222`
+/// (`measure_time`): use `MatchedPath::as_str()` for the label so
+/// concrete `:id` values don't blow up the cardinality, skip
+/// unmatched routes entirely.
+///
+/// Wire via `endpoints.axum_router.layer(axum::middleware::from_fn(record_rpc_request))`
+/// inside `create_endpoints` so all SDK-mounted routes (sequencer,
+/// ledger, runtime modules) get the same instrumentation.
+pub async fn record_rpc_request(
+    matched_path: Option<MatchedPath>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let start = std::time::Instant::now();
+    let response = next.run(req).await;
+    let duration = start.elapsed();
+
+    // Unmatched routes (404s on arbitrary paths) are skipped.
+    // Otherwise an attacker could pump the cardinality of the
+    // `endpoint` label by hitting random URLs.
+    if let Some(path) = matched_path {
+        let endpoint = path.as_str();
+        let status = response.status().as_str().to_owned();
+        rpc_requests().with_label_values(&[endpoint, &status]).inc();
+        rpc_request_duration().with_label_values(&[endpoint]).observe(duration.as_secs_f64());
+    }
+
+    response
+}
+
+// ============================================================================
+// Block height gauge (#110 Phase 2)
+// ============================================================================
 
 /// Spawn a tokio task that polls `ledger_db.get_head_slot_number()`
 /// every `interval` and updates `ligate_block_height`. Runs until

--- a/crates/rollup/src/mock_rollup.rs
+++ b/crates/rollup/src/mock_rollup.rs
@@ -126,10 +126,14 @@ impl FullNodeBlueprint<Native> for MockLigateRollup<Native> {
             crate::metrics::DEFAULT_BLOCK_HEIGHT_POLL_INTERVAL,
         );
 
+        // Pre-touch the RPC counter + histogram so their HELP/TYPE
+        // lines appear from the first /metrics scrape.
+        crate::metrics::init_rpc_metrics();
+
         // Stock SDK helper. Wires the standard sequencer + ledger
         // RPCs and the runtime's per-module REST routers (currently
         // empty, see `ligate_stf::runtime_capabilities`).
-        sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
+        let mut endpoints = sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver,
             sync_status_receiver,
             shutdown_receiver,
@@ -137,7 +141,16 @@ impl FullNodeBlueprint<Native> for MockLigateRollup<Native> {
             sequencer,
             rollup_config,
         )
-        .await
+        .await?;
+
+        // Phase 2 of #110: layer the Prometheus middleware over the
+        // SDK-built router. Captures every matched REST route with
+        // {endpoint, status} labels using axum's `MatchedPath` for
+        // bounded cardinality.
+        endpoints.axum_router = std::mem::take::<axum::Router<()>>(&mut endpoints.axum_router)
+            .layer(axum::middleware::from_fn(crate::metrics::record_rpc_request));
+
+        Ok(endpoints)
     }
 
     async fn create_da_service(

--- a/crates/rollup/tests/metrics_smoke.rs
+++ b/crates/rollup/tests/metrics_smoke.rs
@@ -140,6 +140,81 @@ async fn state_db_size_gauge_reflects_disk_usage() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn rpc_middleware_records_matched_requests() {
+    // Phase 2 of #110. Spins up a tiny test router with one
+    // parameterised route, applies the metrics middleware, sends
+    // two requests against different concrete `:id` values, then
+    // asserts the counter and histogram both record under the
+    // route TEMPLATE label (not the concrete value).
+    //
+    // Catches:
+    //  1. Middleware wires correctly via `Router::layer`.
+    //  2. `MatchedPath::as_str()` collapses concrete IDs into the
+    //     template form, keeping label cardinality bounded.
+    //  3. Histogram counts (`_count`) and counter both increment.
+
+    use axum::routing::get;
+    use axum::Router;
+    use ligate_rollup::metrics::record_rpc_request;
+    use tokio::net::TcpListener;
+
+    metrics::init_rpc_metrics();
+
+    // Test router: `/test/:id` returns "ok" with a known body.
+    let app = Router::new()
+        .route("/test/{id}", get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(record_rpc_request));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind ephemeral");
+    let test_addr = listener.local_addr().expect("test listener has addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::task::yield_now().await;
+
+    let metrics_addr = spawn_metrics_server().await;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("reqwest client builds");
+
+    // Two requests with different concrete path params; both should
+    // collapse to the same `/test/{id}` template label.
+    for id in ["123", "456"] {
+        let resp = client
+            .get(format!("http://{test_addr}/test/{id}"))
+            .send()
+            .await
+            .expect("request succeeds");
+        assert_eq!(resp.status().as_u16(), 200);
+    }
+
+    let body = client
+        .get(format!("http://{metrics_addr}/metrics"))
+        .send()
+        .await
+        .expect("metrics endpoint responds")
+        .text()
+        .await
+        .expect("body is utf-8");
+
+    // Counter: two hits on the same template label.
+    assert!(
+        body.contains(r#"ligate_rpc_requests_total{endpoint="/test/{id}",status="200"} 2"#),
+        "expected counter to bump twice on the templated route, got:\n{body}",
+    );
+
+    // Histogram: `_count` line records two observations on the
+    // template label. Histogram bucket lines are also emitted but
+    // their values depend on timing; `_count` is deterministic.
+    assert!(
+        body.contains(r#"ligate_rpc_request_duration_seconds_count{endpoint="/test/{id}"} 2"#),
+        "expected histogram count to be 2, got:\n{body}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn block_height_gauge_renders_sample_value() {
     // Phase 2 of #110. Drives `sample_block_height` directly with a
     // known SlotNumber and asserts `/metrics` reflects it. Skips the

--- a/docs/development/devnet.md
+++ b/docs/development/devnet.md
@@ -380,6 +380,11 @@ operator should watch:
 - `ligate_state_db_size_bytes` — total on-disk size of the rollup's storage directory, sampled every 30 seconds. Captures RocksDB SST files, WAL, manifest, and the ledger DB.
 - `ligate_block_height` — current rollup head slot number observed by this node, sampled every 2 seconds via the SDK's `LedgerDb::get_head_slot_number`. Sequencers report what they're producing; followers report what they've replayed from DA. Lag between two nodes scraping the same chain is the follower-vs-sequencer sync gap.
 
+**RPC histograms** (axum middleware over the SDK's REST router):
+
+- `ligate_rpc_requests_total{endpoint,status}` — counter, one bump per matched request. The `endpoint` label is the route template (`/modules/attestation/schemas/{schema_id}`), not the concrete `:id` value. Unmatched routes (404s on arbitrary paths) are skipped to keep cardinality bounded.
+- `ligate_rpc_request_duration_seconds{endpoint}` — histogram, one observation per matched request, in seconds. Default Prometheus buckets (0.005s through 10s).
+
 **Process metrics** (Linux only): `process_cpu_seconds_total`, `process_resident_memory_bytes`, `process_open_fds`, `process_max_fds`, `process_start_time_seconds`, `process_virtual_memory_bytes`. Auto-registered by the `prometheus` crate's `process` feature; macOS and Windows builds skip them.
 
 ```bash


### PR DESCRIPTION
## Summary

Fourth chunk of #164 (Phase 2 metrics). Wraps the SDK's REST router with an axum middleware that records `ligate_rpc_requests_total{endpoint,status}` and `ligate_rpc_request_duration_seconds{endpoint}` per matched route. Pattern mirrors the SDK's own `measure_time` middleware (`sov-stf-runner/src/http/mod.rs:189-222`); cardinality bounded via `MatchedPath`.

## What ships

**`record_rpc_request` middleware** in `crates/rollup/src/metrics.rs`:

```rust
pub async fn record_rpc_request(
    matched_path: Option<MatchedPath>,
    req: Request,
    next: Next,
) -> Response {
    let start = std::time::Instant::now();
    let response = next.run(req).await;
    let duration = start.elapsed();

    if let Some(path) = matched_path {
        let endpoint = path.as_str();
        let status = response.status().as_str().to_owned();
        rpc_requests().with_label_values(&[endpoint, &status]).inc();
        rpc_request_duration().with_label_values(&[endpoint]).observe(duration.as_secs_f64());
    }
    response
}
```

**Wired in both blueprints' `create_endpoints`:**

```rust
let mut endpoints = sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(...).await?;
endpoints.axum_router = std::mem::take::<axum::Router<()>>(&mut endpoints.axum_router)
    .layer(axum::middleware::from_fn(crate::metrics::record_rpc_request));
Ok(endpoints)
```

The SDK's `NodeEndpoints.axum_router` is `pub` + mutable. No upstream changes needed.

**Smoke test** `rpc_middleware_records_matched_requests`: spins up a tiny test router with `/test/{id}`, applies the middleware, sends two requests against `/test/123` and `/test/456`, asserts both collapse to the same `endpoint="/test/{id}"` template label. Catches:
1. Middleware wires correctly via `Router::layer`.
2. `MatchedPath::as_str()` collapses concrete IDs into the template form.
3. Histogram `_count` and counter both increment.

## Notable design calls

1. **Skip unmatched routes (404s).** Following the SDK's `measure_time` pattern: an attacker pumping arbitrary URLs would otherwise blow up the `endpoint` label cardinality. Matched routes only.
2. **Status as a label, not a multi-counter.** A single `requests_total{endpoint,status}` is more compact than separate counters per status class. Five status code buckets (2xx/3xx/4xx/5xx, plus the few specific codes that show up) keep the cardinality reasonable.
3. **Default histogram buckets.** `0.005s, 0.01s, 0.025s, 0.05s, 0.1s, 0.25s, 0.5s, 1s, 2.5s, 5s, 10s` covers the realistic latency range for our REST surface (state lookups in milliseconds, slow queries up to a few seconds under load). If P99 starts pushing 10s in production we revisit.
4. **REST-only, not jsonrpsee.** The SDK mounts JSON-RPC at `/rpc` inside the same axum router; the middleware sees those as one path bucket. Per-method JSON-RPC instrumentation would need a jsonrpsee config layer, separate concern.

## Out of scope (still in #164)

- DA submission latency histogram — clean integration via `BlobSenderHooks::on_published_blob` + `on_finalized_blob`. Probably the next chunk if we keep going.
- DA submission failure categorization — gated on upstream `BlobSubmissionError` enum (filed as separate follow-up).
- Mempool depth gauge — gated on upstream `Sequencer::pending_tx_count` API.

## Test plan

- [x] `cargo test -p ligate-rollup --test metrics_smoke` (4 tests, all pass).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [x] `scripts/check-da-isolation.sh`.
- [ ] CI green.