### PR TITLE
Fix state_db_size to report on-disk blocks not nominal len

### DIFF
--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -133,18 +133,35 @@ pub fn init_state_db_size() {
     let _ = state_db_size_bytes();
 }
 
-/// Walk `path` recursively and sum every file's `len()`. Symlinks
-/// are followed only one level deep (the default for `read_dir`)
-/// to avoid loops; broken symlinks and unreadable entries are
-/// silently skipped so a transient mid-compaction view doesn't
-/// crash the sampler.
+/// Walk `path` recursively and sum the **on-disk** size of every
+/// file (allocated 512-byte blocks, not nominal length).
 ///
-/// Returns `0` for paths that don't exist, can't be read, or are
-/// empty.  That's intentional: the alternative (returning `Result`)
-/// would force the polling task to choose between propagating
-/// errors (kills the gauge) or swallowing them (loses signal).
-/// Returning a number that's "low or zero" lets dashboards show
-/// the regression as a graph dip and alerts catch it.
+/// `meta.len()` would return the file's logical size, which is
+/// wrong for the sparse-allocated files that NOMT and RocksDB
+/// produce: a 1M-bucket NOMT hash table reports its nominal
+/// preallocation (tens of GB) even when only a few MB of blocks
+/// are actually committed to disk. `du -sh` matches
+/// `meta.blocks() * 512`, and that's the value operators care
+/// about for capacity planning and what dashboards graph as
+/// "storage growth".
+///
+/// On non-Unix targets we fall back to `meta.len()` because the
+/// `MetadataExt::blocks` API is Unix-only. Production deployment is
+/// Linux; macOS dev gets the correct value too via the same code
+/// path. Windows would over-report on sparse files but isn't a
+/// supported target.
+///
+/// Symlinks are followed only one level deep (the default for
+/// `read_dir`) to avoid loops; broken symlinks and unreadable
+/// entries are silently skipped so a transient mid-compaction view
+/// doesn't crash the sampler.
+///
+/// Returns `0` for paths that don't exist or can't be read. The
+/// alternative (returning `Result`) would force the polling task to
+/// choose between propagating errors (kills the gauge) or
+/// swallowing them (loses signal). Returning a number that's "low
+/// or zero" lets dashboards show the regression as a graph dip and
+/// alerts catch it.
 fn directory_size_bytes(path: &Path) -> u64 {
     let mut total = 0u64;
     let Ok(entries) = std::fs::read_dir(path) else {
@@ -155,10 +172,23 @@ fn directory_size_bytes(path: &Path) -> u64 {
         if meta.is_dir() {
             total = total.saturating_add(directory_size_bytes(&entry.path()));
         } else {
-            total = total.saturating_add(meta.len());
+            total = total.saturating_add(file_disk_bytes(&meta));
         }
     }
     total
+}
+
+/// On-disk byte count for a single file. Unix: blocks * 512.
+/// Non-Unix: `len()` (over-reports on sparse files).
+#[cfg(unix)]
+fn file_disk_bytes(meta: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    meta.blocks().saturating_mul(512)
+}
+
+#[cfg(not(unix))]
+fn file_disk_bytes(meta: &std::fs::Metadata) -> u64 {
+    meta.len()
 }
 
 /// Sample the storage directory once and update the gauge. Pulled

--- a/crates/rollup/tests/metrics_smoke.rs
+++ b/crates/rollup/tests/metrics_smoke.rs
@@ -94,26 +94,35 @@ async fn metrics_endpoint_serves_attestation_counters_at_zero() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn state_db_size_gauge_reflects_disk_usage() {
-    // Phase 2 of #110. Builds a tempdir with a known total file
-    // size, drives `sample_state_db_size` once, and asserts the
-    // `ligate_state_db_size_bytes` gauge in `/metrics` matches the
-    // sampled value. Catches:
+    // Phase 2 of #110. Builds a tempdir with a 1 MB file, drives
+    // `sample_state_db_size` once, and asserts the
+    // `ligate_state_db_size_bytes` gauge in `/metrics` reflects
+    // the real on-disk allocation. Catches:
     //
-    // 1. The directory walker (recursive, follows symlinks one
-    //    level, skips unreadable entries).
+    // 1. The directory walker (recursive, skips unreadable entries).
     // 2. The Prometheus gauge wiring (`IntGauge::set` + Prometheus
     //    text-format encoding).
-    // 3. End-to-end /metrics rendering for a numeric metric (the
-    //    rest of the smoke test only exercises counters).
+    // 3. End-to-end /metrics rendering for a numeric metric.
+    // 4. The on-disk-vs-nominal semantics: we use `blocks() * 512`
+    //    (matches `du`), not `len()` (which over-reports on the
+    //    sparse-allocated files NOMT and RocksDB produce).
+    //
+    // 1 MB rather than a few bytes so filesystem block-size noise
+    // (4 KB on most setups) doesn't dominate the assertion.
+    use std::ops::RangeInclusive;
+
+    // A non-sparse 1 MiB file uses ~1 MiB of blocks. Allow a 5%
+    // over-allocation slack to absorb filesystem block sizing
+    // differences (ext4 / APFS / ZFS / tmpfs all behave a bit
+    // differently). Sparse files would trip a much smaller value;
+    // a `len()`-based regression would trip a much larger one.
+    const FILE_SIZE: usize = 1_048_576;
+    let acceptable: RangeInclusive<u64> = (FILE_SIZE as u64)..=(FILE_SIZE as u64 * 105 / 100);
 
     let dir = tempfile::tempdir().expect("tempdir");
-
-    // Write three files at different depths totalling 6 bytes.
     let nested = dir.path().join("nested");
     std::fs::create_dir(&nested).unwrap();
-    std::fs::write(dir.path().join("a.bin"), b"AA").unwrap();
-    std::fs::write(dir.path().join("b.bin"), b"BB").unwrap();
-    std::fs::write(nested.join("c.bin"), b"CC").unwrap();
+    std::fs::write(nested.join("blob.bin"), vec![0xABu8; FILE_SIZE]).unwrap();
 
     metrics::sample_state_db_size(dir.path());
 
@@ -131,11 +140,24 @@ async fn state_db_size_gauge_reflects_disk_usage() {
         .await
         .expect("body is utf-8");
 
-    // Substring match: `ligate_state_db_size_bytes 6` is the
-    // canonical Prometheus text-format line for our gauge.
+    // Extract the numeric value from the gauge line.
+    let line = body
+        .lines()
+        .find(|l| l.starts_with("ligate_state_db_size_bytes "))
+        .unwrap_or_else(|| panic!("ligate_state_db_size_bytes missing from /metrics:\n{body}"));
+    let value: u64 = line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("could not parse value from line: {line}"));
+
     assert!(
-        body.contains("ligate_state_db_size_bytes 6"),
-        "expected gauge to read 6 bytes after sampling 3 x 2-byte files, got:\n{body}",
+        acceptable.contains(&value),
+        "expected gauge in {:?} after writing a 1 MiB file, got {} (bug regression: \
+         over-reports indicate `len()` semantics; under-reports indicate sparse-file \
+         under-counting)",
+        acceptable,
+        value,
     );
 }
 


### PR DESCRIPTION
## Summary

Tier 1 manual verification of metrics shipped this morning surfaced a real bug. Booted ligate-node locally, scraped `/metrics`, and saw `ligate_state_db_size_bytes 61595884508` (~61 GB). Real on-disk usage via `du -sh devnet/data` was ~23 MB. Off by ~2700x.

Root cause: `meta.len()` returns the file's **logical** size. NOMT's hash-table file and RocksDB's WAL/manifest are sparse-allocated — multi-GB of nominal length, only a few MB of actual blocks committed. We were summing the logical lengths.

Fix: use `meta.blocks() * 512` (Unix), which matches what `du` reports. Falls back to `meta.len()` on non-Unix targets (Windows isn't a deploy target; if that ever changes we revisit).

## Changes

- `directory_size_bytes` walks recursively as before, but per-file size now goes through a new `file_disk_bytes(meta)` helper that uses `MetadataExt::blocks()` on Unix.
- Doc-comments on the walker explicitly call out the on-disk-vs-nominal semantics so future readers don't unwind this.
- Smoke test rewritten to use a 1 MiB file (block-size noise of ~4 KB doesn't dominate). Asserts the gauge falls in `[1 MiB, 1.05 MiB]`. Old test used three 2-byte files asserting `gauge == 6` which was the original bug masked by tiny logical sizes.

## Verified locally

Re-booted ligate-node after the fix:
- `du -sk devnet/data`: 19,992 KiB (~19.5 MiB)
- `ligate_state_db_size_bytes` now: 24,469,504 bytes (~23.3 MiB)
- Same magnitude as `du`, ~20% gap is metadata blocks. Acceptable for a capacity-planning gauge; was 2700x off before.

Operators dashboarding "storage growth rate" or "disk free vs used" now get a value that matches what they'd see on the host.

## Test plan

- [x] `cargo test -p ligate-rollup --test metrics_smoke` (4 tests, all pass).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [x] `scripts/check-da-isolation.sh`.
- [x] Manual: gauge value matches `du -sk` magnitude on a real boot.
- [ ] CI green.