### PR TITLE
Add .github/CODEOWNERS for per-path review routing (closes #113)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,50 @@
+# CODEOWNERS for ligate-io/ligate-chain.
+#
+# Per-path review routing. GitHub auto-requests review from the listed
+# teams when a PR touches matching files. Last-match wins (CODEOWNERS
+# uses last-match, not first-match like .gitignore).
+#
+# Add patterns sparingly. Better to leave routing to default reviewers
+# than to spread ownership thin across files.
+#
+# Teams referenced here:
+# - @ligate-io/maintainers       repo-wide default reviewers
+# - @ligate-io/protocol-reviewers wire-format-adjacent changes
+#
+# Tracking issue: ligate-io/ligate-chain#113
+
+# Default fallback: maintainers
+*                                       @ligate-io/maintainers
+
+# Protocol module: data shapes, state layout, call handlers, fees,
+# signature validation. Every change here is wire-format adjacent.
+crates/modules/attestation/             @ligate-io/protocol-reviewers
+
+# Runtime composition: STF, genesis loader, CHAIN_HASH derivation.
+# State-shape changes here are hard forks per docs/protocol/upgrades.md.
+crates/stf/                             @ligate-io/protocol-reviewers
+crates/stf-declaration/                 @ligate-io/protocol-reviewers
+
+# Devnet config. Genesis JSON changes implicitly bump the chain id
+# trailing number (see docs/protocol/upgrades.md), so reviewer set
+# overlaps with protocol.
+devnet/                                 @ligate-io/protocol-reviewers
+
+# Protocol specification + upgrade story. Edits here often tighten or
+# loosen what's actually a hard fork; protocol-reviewers triple-check.
+docs/protocol/                          @ligate-io/protocol-reviewers
+
+# CI workflows + audit / supply-chain ignore lists. Security-sensitive:
+# an unjustified advisory ignore is the kind of thing a careful reviewer
+# should catch.
+.github/workflows/                      @ligate-io/maintainers
+audit.toml                              @ligate-io/maintainers
+deny.toml                               @ligate-io/maintainers
+
+# Top-level repo files. Maintainer-level review.
+/Cargo.toml                             @ligate-io/maintainers
+/README.md                              @ligate-io/maintainers
+/SECURITY.md                            @ligate-io/maintainers
+/CONTRIBUTING.md                        @ligate-io/maintainers
+/CODE_OF_CONDUCT.md                     @ligate-io/maintainers
+/.github/CODEOWNERS                     @ligate-io/maintainers


### PR DESCRIPTION
## Summary

Ships `.github/CODEOWNERS` with the routing matrix from [#113](https://github.com/ligate-io/ligate-chain/issues/113). Both teams (`@ligate-io/maintainers`, `@ligate-io/protocol-reviewers`) were created in the org earlier today; this PR wires them to specific paths.

## Routing

| Path | Reviewer |
|---|---|
| `*` (default) | `@ligate-io/maintainers` |
| `crates/modules/attestation/` | `@ligate-io/protocol-reviewers` |
| `crates/stf/` + `crates/stf-declaration/` | `@ligate-io/protocol-reviewers` |
| `devnet/` | `@ligate-io/protocol-reviewers` |
| `docs/protocol/` | `@ligate-io/protocol-reviewers` |
| `.github/workflows/` | `@ligate-io/maintainers` |
| `audit.toml`, `deny.toml` | `@ligate-io/maintainers` |
| Top-level repo files (Cargo.toml, README, SECURITY, etc.) | `@ligate-io/maintainers` |

## Notable design calls

1. **Two teams, not three.** The issue's prose mentioned a future `@ligate-io/node-reviewers` for `crates/rollup/`, but only listed maintainers + protocol-reviewers under "Teams to create". Since `crates/rollup/` is operational rather than wire-format-adjacent, it falls through to the default `*` rule (maintainers). Adding a third team is non-breaking when the ops team grows.
2. **`deny.toml` added to the supply-chain bucket.** Same security-sensitive category as `audit.toml` (an unjustified license/source allowance is the kind of thing a careful reviewer should catch). Wasn't in the issue's spec because deny.toml shipped after #113 was filed; including it now keeps the routing consistent.
3. **Last-match-wins is implicit.** GitHub uses last-match for CODEOWNERS, opposite of `.gitignore`'s first-match. The file's order matters: more-specific patterns later. Documented in the header comment so future editors don't reverse the order by accident.

## Test plan

- [x] Both teams exist in the org (`gh api orgs/ligate-io/teams/maintainers` and `protocol-reviewers` both return 200).
- [ ] CI green (`.github/CODEOWNERS` is in the path-filter exclude list, so code-checking jobs correctly skip).
- [ ] **After merge:** open a test PR touching `crates/modules/attestation/src/lib.rs` and verify `@ligate-io/protocol-reviewers` gets auto-requested.
- [ ] **After merge:** GitHub's `/community` profile should flag CODEOWNERS as present.

Closes #113.