### PR TITLE
Add CHANGELOG.md with backfill of recent 28 PRs (closes #174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to Ligate Chain are tracked here. Pre-launch (devnet target Q2 2026); no semver releases yet, everything sits under `[Unreleased]`. The first tagged release will fold the Unreleased contents into a versioned section at devnet boot.
+
+Format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). Entries group as **Added** (new functionality), **Changed** (behaviour or API shifts on existing functionality), **Fixed** (bugfixes), **Security** (advisories, supply-chain, fuzz), and **Deps** (transitive bumps not otherwise interesting). Issue and PR numbers reference [`ligate-io/ligate-chain`](https://github.com/ligate-io/ligate-chain).
+
+This file is human-curated. Every PR adds an entry under `## [Unreleased]`; releases bump the buckets into a new `## [version] - YYYY-MM-DD` section.
+
+## [Unreleased]
+
+### Added
+
+- Prometheus `/metrics` endpoint on `ligate-node` with five core metrics: schema / attestor-set / attestation success counters, `attestations_rejected_total{reason}` labelled by `AttestationError` discriminant, `state_db_size_bytes` gauge (on-disk allocation), `block_height` gauge polled from `LedgerStateProvider`, and `rpc_requests_total` + `rpc_request_duration_seconds` histograms via axum middleware. Process metrics auto-ship on Linux. Tracking issue [#110](https://github.com/ligate-io/ligate-chain/issues/110), Phase 1 in [#163](https://github.com/ligate-io/ligate-chain/pull/163), Phase 2 across [#167](https://github.com/ligate-io/ligate-chain/pull/167) [#168](https://github.com/ligate-io/ligate-chain/pull/168) [#169](https://github.com/ligate-io/ligate-chain/pull/169) [#170](https://github.com/ligate-io/ligate-chain/pull/170).
+- `AttestationError::discriminant()` mapping all 18 variants to stable snake_case labels for the rejection counter, pinned by a unit test ([#167](https://github.com/ligate-io/ligate-chain/pull/167)).
+- `cargo-deny` supply-chain gate enforcing license allow-list, source-allow-list, and duplicate version policy alongside the existing `cargo audit` ([#154](https://github.com/ligate-io/ligate-chain/pull/154), closes [#120](https://github.com/ligate-io/ligate-chain/issues/120)).
+- `cargo-fuzz` harnesses for Borsh decoders (`CallMessage`, `Schema`, `AttestorSet`, `Attestation`, `SignedAttestationPayload`) plus Bech32m parsing and `AttestationId` round-trip. Nightly cron workflow with ~10 minute time budget. ([#156](https://github.com/ligate-io/ligate-chain/pull/156), closes [#119](https://github.com/ligate-io/ligate-chain/issues/119)).
+- `.github/CODEOWNERS` with per-path review routing to `@ligate-io/maintainers` and `@ligate-io/protocol-reviewers` ([#173](https://github.com/ligate-io/ligate-chain/pull/173), closes [#113](https://github.com/ligate-io/ligate-chain/issues/113)).
+- `docs/protocol/da-layers.md` documenting the DA-agnostic-by-construction architecture, surface inventory, and adapter playbook for adding a new DA backend ([#159](https://github.com/ligate-io/ligate-chain/pull/159), closes [#117](https://github.com/ligate-io/ligate-chain/issues/117)).
+- `docs/protocol/threat-model.md` covering trust posture across the chain-id ladder, attestation-layer adversaries, sequencer-layer threats, wire-format runtime risks, cryptographic primitive failure, operational adversaries, and protection inventory ([#148](https://github.com/ligate-io/ligate-chain/pull/148), closes [#121](https://github.com/ligate-io/ligate-chain/issues/121)).
+- `docs/protocol/rest-api.md` reference for all 114 auto-mounted REST endpoints with curl examples and Mermaid path map ([#147](https://github.com/ligate-io/ligate-chain/pull/147)).
+- `docs/development/error-coverage.md` audit doc mapping every public `Error` variant to its test (and discriminant for `AttestationError`); audit pass added 3 new tests covering `InvalidAttestorPubkey`, `AttestationSignaturesOverCap`, `SchemaNameOverCap`, and tightened 14 existing `Reverted(_)` assertions to pin specific phrases ([#160](https://github.com/ligate-io/ligate-chain/pull/160), closes [#124](https://github.com/ligate-io/ligate-chain/issues/124)).
+- `docs/development/celestia-ops.md` single-node Celestia runbook covering light-node provisioning, auth-token hygiene, env-var configuration, verification commands, and failure-mode triage ([#172](https://github.com/ligate-io/ligate-chain/pull/172)).
+- `docs/protocol/upgrades.md` soft / hard fork policy, `CHAIN_HASH` derivation guard, pre / post-mainnet upgrade flow, change-classification table ([#109](https://github.com/ligate-io/ligate-chain/pull/109), closes [#44](https://github.com/ligate-io/ligate-chain/issues/44)).
+- Borsh wire-format snapshot tests for all public protocol types: `CallMessage`, `Schema`, `Attestation`, `AttestorSet`, `SignedAttestationPayload`, `AttestorSignature`, `AttestationId` ([#108](https://github.com/ligate-io/ligate-chain/pull/108), closes [#45](https://github.com/ligate-io/ligate-chain/issues/45)).
+- E2E smoke test exercising the production runtime under `MockRollupSpec<Native>` against the auto-mounted REST surface, with state seeded through the production `AttestationConfig::initial_*` channels ([#145](https://github.com/ligate-io/ligate-chain/pull/145)).
+- DA-isolation CI guard preventing Celestia coupling from leaking into DA-agnostic crates (`crates/stf`, `crates/stf-declaration`, `crates/modules`, `crates/client-rs`) via `scripts/check-da-isolation.sh` ([#118](https://github.com/ligate-io/ligate-chain/pull/118)).
+- Chain-id string ladder locked in protocol spec, runbook, README, genesis example: `ligate-localnet`, `ligate-devnet-1`, `ligate-testnet-1`, `ligate-1` ([#105](https://github.com/ligate-io/ligate-chain/pull/105), refs [#54](https://github.com/ligate-io/ligate-chain/issues/54)).
+- `#[non_exhaustive]` on every public protocol enum so future variant additions stay non-breaking for downstream consumers ([#103](https://github.com/ligate-io/ligate-chain/pull/103), closes [#43](https://github.com/ligate-io/ligate-chain/issues/43)).
+- Research-primitive roadmap section in `upgrades.md` covering pre-mainnet vs post-mainnet integration story ([#135](https://github.com/ligate-io/ligate-chain/pull/135)).
+- REST point-lookup specification in protocol docs: list and range queries deliberately live in the indexer service, not the chain ([#116](https://github.com/ligate-io/ligate-chain/pull/116), closes [#21](https://github.com/ligate-io/ligate-chain/issues/21)).
+
+### Changed
+
+- `attestation::max_builder_bps` migrated from a compile-time const to runtime state, governance-tunable per [#40](https://github.com/ligate-io/ligate-chain/issues/40)'s constants-to-state path. Default still `5000` (50%) for genesis-omitting configs. ([#152](https://github.com/ligate-io/ligate-chain/pull/152)).
+- Devnet runbook (`docs/development/devnet.md`) refreshed to reflect post-Phase-A reality: actual binary, real config flags, current limitations table ([#107](https://github.com/ligate-io/ligate-chain/pull/107), closes [#84](https://github.com/ligate-io/ligate-chain/issues/84)).
+- README Labs wordmark goes fully sage in the brand lockup, drops the 0.65-opacity treatment ([#106](https://github.com/ligate-io/ligate-chain/pull/106)).
+- CI path-filter excludes `.github/dependabot.yml` so dependabot config edits don't trigger code-checking jobs ([#150](https://github.com/ligate-io/ligate-chain/pull/150)).
+- Dependabot config ignores the schemars major and strum minor bumps that the SDK pin holds back ([#102](https://github.com/ligate-io/ligate-chain/pull/102)).
+
+### Fixed
+
+- `ligate_state_db_size_bytes` gauge now reports actual on-disk allocation via `meta.blocks() * 512` instead of nominal logical size via `meta.len()`. Caught during Tier 1 manual verification: gauge was reading 61 GB on a node with 23 MB actual disk usage because of NOMT and RocksDB sparse-file preallocation ([#171](https://github.com/ligate-io/ligate-chain/pull/171)).
+
+### Security
+
+- Audit ignore additions for transitive `astral-tokio-tar` advisories `RUSTSEC-2026-0112` and `RUSTSEC-2026-0113`, both reachable only through `sov-test-utils`'s `testcontainers` dev-dep, no production exposure ([#104](https://github.com/ligate-io/ligate-chain/pull/104)).
+
+### Deps
+
+- `actions/upload-artifact` bumped from v4 to v7 (dependabot, [#161](https://github.com/ligate-io/ligate-chain/pull/161)).
+- `rustls` bumped from 0.23.39 to 0.23.40 (dependabot, [#162](https://github.com/ligate-io/ligate-chain/pull/162)).
+
+[Unreleased]: https://github.com/ligate-io/ligate-chain/compare/main...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,7 @@ For module-internal helpers, doc comments are encouraged but not enforced.
 ## Pull request conventions
 
 - **One concern per PR.** Reviewers should be able to summarise your PR in one sentence. If they can't, split it.
+- **CHANGELOG entry.** Add a one-line entry under the `## [Unreleased]` heading in [`CHANGELOG.md`](CHANGELOG.md), in the appropriate bucket (Added / Changed / Fixed / Security / Deps). Reference the PR number; releases bump the unreleased entries into a versioned section.
 - **Test plan in the description.** Use the `.github/PULL_REQUEST_TEMPLATE.md` checkboxes — it forces you to think through what you've actually verified.
 - **CI must be green.** The required check is `CI pass` (a summary that aggregates `fmt`, `clippy`, `check`, `test`, `doc`, `audit`). Docs-only PRs skip the heavy gates via `paths-filter`; that's intentional.
 - **Reviews.** One approving review required (currently bypassed for the founder; this changes when a second engineer joins). For external contributors, expect a review turnaround of 1-3 business days.


### PR DESCRIPTION
## Summary

Ships `CHANGELOG.md` at repo root, in [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format. Initial backfill covers the 28 PRs merged between 2026-04-28 and 2026-05-04 (cargo-deny, fuzz, threat model, da-layers, error coverage, Prometheus metrics phase 1+2, sparse-file fix, Celestia ops doc, CODEOWNERS, plus the upgrades / borsh-snapshot / threat-model / chain-id / non_exhaustive groundwork).

`CONTRIBUTING.md` updated: every PR gets a one-liner under `## [Unreleased]` in the appropriate bucket. Releases bump the unreleased entries into a versioned section.

## Format

- `## [Unreleased]` for ongoing work, populated now with the recent batch
- Per-bucket: **Added** / **Changed** / **Fixed** / **Security** / **Deps**
- Each entry references the PR number; closing PR numbers reference parent issues where relevant

When we cut the first tagged release at devnet boot, the `[Unreleased]` block flips to `## [0.0.1] - 2026-MM-DD`.

## Test plan

- [x] No em dashes (project convention).
- [x] All linked PR numbers resolve.
- [ ] CI green (CHANGELOG is excluded from code-checking jobs by the existing path-filter for `**.md`).

Closes #174.