### PR TITLE
Install libclang in release workflow (Linux only)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # Linux runners need libclang-dev for `clang-sys` (pulled in
+      # transitively via risc0's build deps). macOS runners ship
+      # Xcode CLI tools, which provides clang already; skip there.
+      # The same install step appears in `ci.yml`.
+      - name: Install libclang (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev clang
+
       - name: Cache cargo
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

The release workflow we just shipped (#202) failed within 1 minute on both Linux targets (`x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`) when smoke-tested via tag \`v0.0.1-rc.1\`. Root cause: \`clang-sys\` (pulled in transitively via risc0's build deps) needs \`libclang-dev\` + \`clang\` on the runner, and \`release.yml\` didn't install them.

CI's \`ci.yml\` already installs both packages on every relevant job (lines 99-100, 114-115, 129-130, 156-157). The release workflow needs the same step.

## Failure detail

```
error: failed to run custom build command for `clang-sys v1.8.1`
...
"couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so'],
set the LIBCLANG_PATH environment variable to a path where one of these files can be found"
```

## Fix

8 lines: add an \`Install libclang\` step to the release matrix, gated on \`runner.os == 'Linux'\`. Mirrors the install step pattern \`ci.yml\` already uses.

macOS runners ship Xcode CLI tools, which provides clang at the standard search path, so the step is Linux-only.

## Test plan

- [x] YAML parses cleanly
- [ ] Re-tag \`v0.0.1-rc.2\` after this lands; verify the matrix builds green on all three targets

## Notes

- The Docker workflow (#203) was unaffected because the Dockerfile already installs \`libclang-dev\` + \`clang\` explicitly during the builder stage.
- The macOS leg of the release matrix was still in progress at the time of the failure report; if it also fails for a different reason we'll iterate. For now, the Linux fix is the immediate issue.