### PR TITLE
Set LIBCLANG_PATH on macOS runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,36 @@ jobs:
           targets: ${{ matrix.target }}
 
       # Linux runners need libclang-dev for `clang-sys` (pulled in
-      # transitively via risc0's build deps). macOS runners ship
-      # Xcode CLI tools, which provides clang already; skip there.
-      # The same install step appears in `ci.yml`.
+      # transitively via risc0's build deps). The same install step
+      # appears in `ci.yml`.
       - name: Install libclang (Linux only)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libclang-dev clang
+
+      # macOS runners ship Xcode + CLI tools, but `libclang.dylib`
+      # lives inside the active developer toolchain rather than on
+      # the default dyld search path. `librocksdb-sys` and
+      # `clang-sys` both load `libclang.dylib` at build-script
+      # runtime; without `LIBCLANG_PATH` / `DYLD_FALLBACK_LIBRARY_PATH`
+      # set, dyld can't find it and the build aborts with SIGABRT.
+      #
+      # Resolve the toolchain lib dir dynamically via `xcrun` so the
+      # path tracks whatever Xcode version GitHub's runner image
+      # currently ships. Sanity-checks via `ls` to fail loudly if
+      # the dylib isn't where we expect.
+      #
+      # Mirrors the per-machine workaround documented in
+      # `~/Desktop/ligate-docs/chain/STATE.md` under "Local dev
+      # workflow on macOS".
+      - name: Set LIBCLANG_PATH (macOS only)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -eu
+          LIBCLANG_DIR="$(dirname $(dirname $(xcrun --find clang)))/lib"
+          ls -la "${LIBCLANG_DIR}/libclang.dylib"
+          echo "LIBCLANG_PATH=${LIBCLANG_DIR}" >> "$GITHUB_ENV"
+          echo "DYLD_FALLBACK_LIBRARY_PATH=${LIBCLANG_DIR}" >> "$GITHUB_ENV"
 
       - name: Cache cargo
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Second iteration on the smoke-test from `v0.0.1-rc.1` / `v0.0.1-rc.2`. The Linux fix (#204) cleared the Linux failures; the macOS leg of `v0.0.1-rc.2` then surfaced a sibling libclang issue at a different layer.

## Failure detail (from `v0.0.1-rc.2` macOS build)

```
error: failed to run custom build command for `librocksdb-sys v0.17.3+10.4.2`

  process didn't exit successfully: ... build-script-build (signal: 6, SIGABRT)
  --- stderr
  dyld[6383]: Library not loaded: @rpath/libclang.dylib
    Referenced from: ... librocksdb-sys-.../build-script-build
    Reason: tried: '/Users/runner/work/ligate-chain/ligate-chain/target/release/libclang.dylib'
    (no such file), '/Users/runner/work/ligate-chain/ligate-chain/target/release/deps/libclang.dylib'
    (no such file), '/Users/runner/.rustup/.../lib/libclang.dylib' (no such file),
    ...
```

macOS runners ship Xcode + CLI tools, so clang itself is present. But `libclang.dylib` lives inside the active developer toolchain (`/Applications/Xcode_<version>.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/`), not on the default dyld search path. Both `librocksdb-sys` (via bindgen) and `clang-sys` load `libclang.dylib` at build-script runtime; without `LIBCLANG_PATH` / `DYLD_FALLBACK_LIBRARY_PATH` set, dyld can't find it and the build aborts with SIGABRT.

## Fix

New step in `release.yml`, gated on `runner.os == 'macOS'`. Resolves the toolchain lib dir dynamically via `xcrun --find clang` so the path tracks whatever Xcode version GitHub's runner image currently ships, then exports both env vars for downstream cargo invocations:

```yaml
LIBCLANG_DIR="$(dirname $(dirname $(xcrun --find clang)))/lib"
echo "LIBCLANG_PATH=${LIBCLANG_DIR}" >> "$GITHUB_ENV"
echo "DYLD_FALLBACK_LIBRARY_PATH=${LIBCLANG_DIR}" >> "$GITHUB_ENV"
```

`ls -la "${LIBCLANG_DIR}/libclang.dylib"` runs first as a sanity check; if libclang.dylib isn't where we expect, `set -eu` aborts the step loudly rather than letting the build fail later with a less-actionable error.

This mirrors the per-machine workaround documented in `~/Desktop/ligate-docs/chain/STATE.md` under "Local dev workflow on macOS".

## What we know works after this PR

After merging, re-tag `v0.0.1-rc.3`. Expected outcome:

- **Linux x86_64 + arm64**: green (already verified by `v0.0.1-rc.2` Docker workflow which uses the same Linux apt install pattern; release workflow now matches).
- **macOS arm64**: green (this fix addresses the only remaining issue surfaced).
- **Docker**: green (Dockerfile already installs libclang in the builder stage; not affected by either fix).

If a third platform-specific issue surfaces, we iterate to `rc.4`. So far the pattern is the standard libclang-dep gap that every Rust project linking bindgen-using crates eventually trips over.

## Test plan

- [x] YAML parses cleanly
- [ ] CI green on this PR (path-filtered)
- [ ] Re-tag `v0.0.1-rc.3` after this lands; verify all three matrix targets + Docker build green

## Notes

- Smoke-testing pre-devnet is exactly paying off here. Both bugs (Linux libclang + macOS LIBCLANG_PATH) would have surfaced during a real announcement window otherwise. `rc.1` cost ~5 minutes of debug; `rc.2` macOS leg cost another ~5 minutes. Both are 8-30 line YAML changes. Cheap.