### PR TITLE
fix: pass CODECOV_TOKEN so coverage uploads land on protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,9 +230,12 @@ jobs:
   # Doctests are skipped in coverage because cargo-llvm-cov's
   # `--doctests` requires nightly.
   #
-  # `codecov-action@v5` on public repos uses GitHub OIDC; no
-  # CODECOV_TOKEN secret needed. `fail_ci_if_error: false` means
-  # codecov hiccups don't break the job.
+  # `codecov-action@v5` uploads with the `CODECOV_TOKEN` repo secret.
+  # Tokenless OIDC uploads work for PR runs but codecov rejects pushes
+  # to protected branches without a token ("Token required because
+  # branch is protected"), and `main` is protected by our branch
+  # ruleset. `fail_ci_if_error: false` means codecov hiccups don't
+  # break the job.
   #
   # Tracking issue: #219.
   coverage:
@@ -254,6 +257,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   # Single summary check that the branch ruleset can require. By

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ### Fixed
 
+- Codecov upload to protected `main` branch. Earlier integration ([#219](https://github.com/ligate-io/ligate-chain/issues/219)) assumed tokenless OIDC upload would work for public repos, but codecov rejects pushes to protected branches with `Token required because branch is protected`. Workflow now passes `token: ${{ secrets.CODECOV_TOKEN }}` (repo secret, not committed). PR-run uploads were unaffected; only main-branch uploads were dropped, so the badge stayed at "unknown" until this fix.
 - `ligate_state_db_size_bytes` gauge now reports actual on-disk allocation via `meta.blocks() * 512` instead of nominal logical size via `meta.len()`. Caught during Tier 1 manual verification: gauge was reading 61 GB on a node with 23 MB actual disk usage because of NOMT and RocksDB sparse-file preallocation ([#171](https://github.com/ligate-io/ligate-chain/pull/171)).
 
 ### Security


### PR DESCRIPTION
## Summary

Fixes the codecov upload failure on `main` that was leaving the coverage badge stuck at "unknown" since #219 merged.

**The bug**: original integration used codecov-action@v5's tokenless OIDC mode, expecting it to work on public repos. It does — for PR uploads. But codecov rejects pushes to protected branches without an explicit token:

```
error: Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

`main` is protected by our branch ruleset (#117 / required CI gates). Every post-merge upload was silently rejected.

**The fix**:
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to the `codecov-action@v5` step
- Update the rationale comment in the workflow to document why the token is needed
- Correct the original CHANGELOG entry's claim that "no token needed" via a Fixed entry

Token is stored as a repo secret (`CODECOV_TOKEN`), set via `gh secret set`. Not committed.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next `cargo llvm-cov` run on `main` uploads successfully (no `Token required` error in the job log)
- [ ] Codecov dashboard at https://app.codecov.io/gh/ligate-io/ligate-chain populates with first commit's coverage
- [ ] README codecov badge transitions from "unknown" to actual %