### PR TITLE
feat(node): --mode {sequencer,follower} CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ cargo run --bin ligate-node -- --da-layer celestia
 
 Defaults pick up `devnet/rollup.toml` (or `devnet/celestia.toml`) and the `devnet/genesis/*.json` files. The bootstrap account holds treasury, sequencer, attester, and prover roles for v0; two extra accounts (`lig1d0vqhk…` and `lig1njjery…`) ship with `$LGT` so you can exercise transfers without minting.
 
+### Sequencer vs follower
+
+`ligate-node` accepts a `--mode {sequencer,follower}` flag (default `sequencer`).
+
+`sequencer` is the right mode for the official Ligate Labs node and any node whose DA address is in `sequencer_registry.json` and that holds the matching DA signer key with funded TIA. The node builds batches from incoming transactions and posts them to the DA layer.
+
+`follower` is the right mode for everyone else: design partners, auditors, and anyone running their own Ligate node who isn't the registered sequencer. The node still syncs the STF from DA and serves all read-side endpoints; it just doesn't auto-produce batches.
+
+```bash
+# Read-only follower against public devnet's Celestia config.
+cargo run --bin ligate-node -- --da-layer celestia --mode follower
+```
+
+Followers' `POST /v1/sequencer/txs` endpoint is currently still mounted but submissions don't propagate (the would-be blob is filtered at the STF level because the DA address isn't in the registry). Point clients at the upstream sequencer (`https://rpc.ligate.io` for public devnet) for transaction submission. A native 503 on the follower's submission endpoint is tracked as a follow-up under [#243](https://github.com/ligate-io/ligate-chain/issues/243).
+
 A public devnet with federated attestor orgs is targeted for **Q2 2026**. Until then the protocol runs single-node locally as above. Per-flavour boot details (Mock / Celestia, env vars, secret-store helpers) live in [`devnet/README.md`](devnet/README.md). Forward-looking operator notes (genesis ceremony, attestor key generation, multi-org topology) are in [`docs/development/devnet.md`](docs/development/devnet.md) — note that runbook still has sections marked **Preview only** from before Phase A landed; refresh tracked separately.
 
 ## What is this repo

--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -42,6 +42,31 @@ struct Args {
     #[arg(long, default_value = "mock", value_enum)]
     da_layer: SupportedDaLayer,
 
+    /// Operator role this node should run as.
+    ///
+    /// `sequencer` (default) runs the normal full-node-with-sequencer
+    /// flow: builds batches from incoming transactions and posts them
+    /// to the DA layer. Use this on the official Ligate Labs node and
+    /// any other node whose DA address is registered in
+    /// `sequencer_registry.json` and that holds the corresponding
+    /// signer key with funded TIA.
+    ///
+    /// `follower` runs the same binary but disables automatic batch
+    /// production. The node still syncs the STF from DA, serves all
+    /// read-side REST endpoints, and exposes `/health` and
+    /// `/metrics`. This is the right mode for design partners,
+    /// auditors, and anyone running their own Ligate node who isn't
+    /// the registered sequencer. Submission to a follower's
+    /// `POST /v1/sequencer/txs` is currently still accepted but will
+    /// not propagate (its blob would be filtered at the STF level
+    /// because the DA address isn't in the registry); point clients
+    /// at the upstream sequencer (`https://rpc.ligate.io` for public
+    /// devnet) for submission.
+    ///
+    /// Tracking: #243 (this flag), #82 (multi-sequencer for v1+).
+    #[arg(long, default_value = "sequencer", value_enum)]
+    mode: NodeRole,
+
     /// Path to the rollup config TOML.
     ///
     /// Format mirrors the SDK's `RollupConfig` (storage, sequencer,
@@ -77,6 +102,18 @@ enum SupportedDaLayer {
     Mock,
     /// Real Celestia DA. Requires a reachable light/bridge node.
     Celestia,
+}
+
+/// Role this node operates as. See `Args::mode` for the operator-
+/// facing semantics.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum NodeRole {
+    /// Normal full node: produces batches, posts to DA, accepts
+    /// submissions on `/v1/sequencer/txs`.
+    Sequencer,
+    /// Read-only follower: syncs STF from DA, serves read endpoints,
+    /// does not auto-produce batches.
+    Follower,
 }
 
 impl SupportedDaLayer {
@@ -128,11 +165,27 @@ async fn run() -> anyhow::Result<()> {
 
     debug!(
         da_layer = ?args.da_layer,
+        mode = ?args.mode,
         rollup_config_path = %rollup_config_path,
         genesis_config_dir = ?args.genesis_config_dir,
         metrics_bind = %args.metrics_bind,
         "Starting Ligate rollup",
     );
+
+    // Surface follower mode at INFO so it shows up in default-level
+    // operator logs. Followers behave very differently from
+    // sequencers in subtle ways (no batch production, submissions
+    // don't propagate); making this visible at startup avoids the
+    // "why aren't my transactions landing?" footgun.
+    if args.mode == NodeRole::Follower {
+        tracing::info!(
+            "ligate-node booting in FOLLOWER mode: this node will sync the STF \
+             from DA but will NOT produce batches. Submissions to this node's \
+             /v1/sequencer/txs endpoint do not propagate to the chain. Point \
+             clients at the upstream sequencer (e.g. https://rpc.ligate.io) for \
+             transaction submission. Tracking: #243."
+        );
+    }
 
     // Spawn the Prometheus `/metrics` server before the rollup
     // takes the foreground tokio task. If the user passed
@@ -160,8 +213,12 @@ async fn run() -> anyhow::Result<()> {
     let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);
 
     match args.da_layer {
-        SupportedDaLayer::Mock => run_with_mock(&rollup_config_path, &genesis_paths).await,
-        SupportedDaLayer::Celestia => run_with_celestia(&rollup_config_path, &genesis_paths).await,
+        SupportedDaLayer::Mock => {
+            run_with_mock(&rollup_config_path, &genesis_paths, args.mode).await
+        }
+        SupportedDaLayer::Celestia => {
+            run_with_celestia(&rollup_config_path, &genesis_paths, args.mode).await
+        }
     }
 }
 
@@ -174,6 +231,7 @@ fn is_metrics_disabled(value: &str) -> bool {
 async fn run_with_mock(
     rollup_config_path: &str,
     genesis_paths: &GenesisPaths,
+    mode: NodeRole,
 ) -> anyhow::Result<()> {
     // #181: pull `[chain]` out of the rollup TOML before handing the
     // rest to the SDK loader. The SDK's `RollupConfig` rejects
@@ -181,10 +239,20 @@ async fn run_with_mock(
     // typed deserialization.
     let (chain, residual_toml) = chain_config::load_split_config(rollup_config_path)
         .with_context(|| format!("Failed to load chain config from {rollup_config_path}"))?;
-    let rollup_config: RollupConfig<MultiAddressEvm, StorableMockDaService> =
+    let mut rollup_config: RollupConfig<MultiAddressEvm, StorableMockDaService> =
         toml::from_str(&residual_toml).with_context(|| {
             format!("Failed to read rollup configuration from {rollup_config_path}")
         })?;
+
+    // #243: in follower mode, disable automatic batch production. The
+    // sequencer machinery still instantiates (the SDK's blueprint
+    // requires a sequencer instance for `api_state` plumbing), but it
+    // doesn't post batches to DA, so no spam-failed blob submissions.
+    // The submission REST endpoint stays mounted; a true 503 there
+    // is a follow-up requiring an SDK override.
+    if mode == NodeRole::Follower {
+        rollup_config.sequencer.automatic_batch_production = false;
+    }
 
     // SQLite (mock DA) + RocksDB (state) both refuse to create
     // files if the parent directory is missing, and we want
@@ -222,15 +290,24 @@ async fn run_with_mock(
 async fn run_with_celestia(
     rollup_config_path: &str,
     genesis_paths: &GenesisPaths,
+    mode: NodeRole,
 ) -> anyhow::Result<()> {
     // #181: same two-pass split as the mock path. `[chain]` lives in
     // the rollup TOML alongside `[da]`, `[storage]`, etc.
     let (chain, residual_toml) = chain_config::load_split_config(rollup_config_path)
         .with_context(|| format!("Failed to load chain config from {rollup_config_path}"))?;
-    let rollup_config: RollupConfig<MultiAddressEvm, CelestiaService> =
+    let mut rollup_config: RollupConfig<MultiAddressEvm, CelestiaService> =
         toml::from_str(&residual_toml).with_context(|| {
             format!("Failed to read rollup configuration from {rollup_config_path}")
         })?;
+
+    // #243: see equivalent comment in `run_with_mock`. In follower
+    // mode we disable auto batch production so a follower never tries
+    // to post blobs to Celestia (which would burn TIA and fail at the
+    // STF level if the DA address isn't in the registry).
+    if mode == NodeRole::Follower {
+        rollup_config.sequencer.automatic_batch_production = false;
+    }
 
     std::fs::create_dir_all(&rollup_config.storage.path).with_context(|| {
         format!(
@@ -257,4 +334,40 @@ async fn run_with_celestia(
         .context("Failed to initialize Ligate rollup on Celestia DA")?;
 
     rollup.run().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Default `--mode` when omitted should be `sequencer` so existing
+    /// invocations of `cargo run --bin ligate-node` keep working
+    /// without operator action.
+    #[test]
+    fn mode_defaults_to_sequencer() {
+        let args = Args::parse_from(["ligate-node"]);
+        assert_eq!(args.mode, NodeRole::Sequencer);
+    }
+
+    #[test]
+    fn mode_parses_follower() {
+        let args = Args::parse_from(["ligate-node", "--mode", "follower"]);
+        assert_eq!(args.mode, NodeRole::Follower);
+    }
+
+    #[test]
+    fn mode_parses_explicit_sequencer() {
+        let args = Args::parse_from(["ligate-node", "--mode", "sequencer"]);
+        assert_eq!(args.mode, NodeRole::Sequencer);
+    }
+
+    /// Spelling counts: clap's `value_enum` produces `kebab-case`
+    /// matching the variant names. Guard against an inadvertent
+    /// rename (e.g. `replica`) breaking external operator scripts.
+    #[test]
+    fn mode_rejects_unknown_value() {
+        let result = Args::try_parse_from(["ligate-node", "--mode", "replica"]);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
First step toward closing #243. Adds a \`--mode\` CLI flag to \`ligate-node\` so non-Ligate-Labs operators can run nodes without spam-failing batch posts every interval.

## What this PR does

- New CLI flag \`--mode {sequencer,follower}\` on \`ligate-node\`. Default is \`sequencer\` (backward-compatible).
- In \`follower\` mode, \`rollup_config.sequencer.automatic_batch_production\` is forced to \`false\` before the SDK loads it. The sequencer machinery still instantiates (the SDK's blueprint requires it for \`api_state\` plumbing), but it no longer auto-posts batches.
- INFO-level startup banner explaining the implications when in follower mode (so operators don't get confused about why their submissions aren't landing).
- README \"Sequencer vs follower\" section.
- 4 unit tests on the CLI flag parsing.

## What this PR doesn't do (deliberate scope)

The local \`POST /v1/sequencer/txs\` endpoint stays mounted on follower nodes. Submissions are accepted, queued in the local mempool, and never propagate (the would-be blob would be filtered at the STF level because the DA address isn't in the registry). Returning a true 503 there requires overriding \`FullNodeBlueprint::create_sequencer\` to skip the \`SequencerApis::rest_api_server\` route merge. That's a deeper change; tracking it as a follow-up under #243.

The chain isn't compromised by this gap (registry gates state changes, STF is deterministic), but local UX of a follower's REST endpoint is still imperfect. Acceptable for v0; should clean up before we tell external teams to run their own nodes at scale.

## Verification

\`\`\`
cargo test -p ligate-rollup --bin ligate-node
\`\`\`
4 tests, all pass:
- \`mode_defaults_to_sequencer\` — default-flag behaviour preserved
- \`mode_parses_follower\` — \`--mode follower\` resolves correctly
- \`mode_parses_explicit_sequencer\` — \`--mode sequencer\` resolves correctly
- \`mode_rejects_unknown_value\` — clap rejects \`--mode replica\` etc.

\`\`\`
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo check --workspace --all-targets
\`\`\`
All clean.

## Diff size

| File | +/- |
|---|---|
| \`crates/rollup/src/main.rs\` | +117 / −4 |
| \`README.md\` | +15 / −0 |

## Related

- Closes step 1 of #243 (this flag).
- Step 2 (true 503 on follower's submission endpoint) tracked as remaining work in #243.
- #82 multi-sequencer is orthogonal v1+ work.