### PR TITLE
fix: drop double-wrap in submit + correct address derivation (closes #245)

### DIFF
--- a/crates/client-rs/src/submit.rs
+++ b/crates/client-rs/src/submit.rs
@@ -50,9 +50,22 @@
 //!    the sequencer's `accept_tx` endpoint and (optionally) polls
 //!    `wait_for_tx_processing` until the chain has executed it.
 //!
+//! ## Important: do NOT pre-wrap on the client
+//!
+//! The chain's `POST /v1/sequencer/txs` handler ([`axum_accept_tx`])
+//! wraps the request body in `AuthenticatorInput::Standard(RawTx {
+//! data })` server-side. **Pass the borsh-encoded `Transaction` bytes
+//! directly to `submit_raw_tx`; do NOT call `encode_with_standard_auth`
+//! on the client.** Pre-wrapping double-wraps and the chain rejects
+//! with `signature error: Cannot decompress Edwards point`. See
+//! [`ligate-chain#245`].
+//!
 //! See the integration test in `tests/submit.rs` for a worked example
 //! (when localnet harness is available) and the faucet repo's
 //! `signer.rs` for production usage.
+//!
+//! [`axum_accept_tx`]: https://github.com/Sovereign-Labs/sovereign-sdk/blob/f89964c/crates/full-node/sov-sequencer/src/rest_api.rs
+//! [`ligate-chain#245`]: https://github.com/ligate-io/ligate-chain/issues/245
 //!
 //! # Why not a single high-level helper?
 //!
@@ -115,11 +128,16 @@ impl Submitter {
         &self.inner
     }
 
-    /// Submit a pre-built, pre-signed, Borsh-encoded transaction to
-    /// the chain's sequencer. Returns the transaction hash.
+    /// Submit a borsh-encoded signed transaction to the chain's
+    /// sequencer. Returns the transaction hash.
     ///
-    /// The `bytes` MUST be the output of step 4 in the module-level
-    /// walkthrough (Borsh-encoded `AuthenticatorInput::Standard(...)`).
+    /// `bytes` MUST be `borsh::to_vec(&signed_transaction)` where
+    /// `signed_transaction` is a `Transaction<R, S>` produced by
+    /// [`UnsignedTransaction::sign`]. The chain's
+    /// `POST /v1/sequencer/txs` handler wraps the bytes in
+    /// `AuthenticatorInput::Standard(RawTx { data })` server-side;
+    /// do NOT pre-wrap on the client (see module docs for why).
+    ///
     /// Garbage in produces a server-side `FatalError::DeserializationFailed`
     /// rather than a panic.
     ///

--- a/crates/genesis-tool/src/keys.rs
+++ b/crates/genesis-tool/src/keys.rs
@@ -27,7 +27,6 @@ use anyhow::{Context, Result};
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use rand::RngCore;
-use sha2::{Digest, Sha256};
 use sov_modules_api::Address;
 
 /// Result of generating one role-tagged keypair.
@@ -70,13 +69,21 @@ pub fn generate_role(role: &str, output_dir: &Path) -> Result<GeneratedKey> {
     let signing_key = SigningKey::from_bytes(&secret_bytes);
     let pubkey_bytes = signing_key.verifying_key().to_bytes();
 
-    // Address derivation: SHA-256(pubkey)[..28]. Matches the pattern
-    // used in `crates/stf/tests/devnet_addresses.rs` for deterministic
-    // devnet fixtures, but here the pubkey is the input rather than a
-    // string label.
-    let digest = Sha256::digest(pubkey_bytes);
+    // Address derivation: first 28 bytes of the public key.
+    //
+    // The chain authenticates a transaction by computing
+    // `credential_id = HexString(pubkey_bytes)` (per
+    // `MockZkvmCryptoSpec::PublicKey::credential_id`), then
+    // `Address::from(credential_id) = pubkey[..28]` (per
+    // `sov_modules_api::common::address::From<HexString<[u8;32]>>`).
+    // Operators who substitute keys into `keys.toml` need the keypair
+    // → address derivation to match what the chain re-derives at
+    // signature-verification time. Using `SHA-256(pubkey)[..28]`
+    // (which is what `crates/stf/tests/devnet_addresses.rs` does for
+    // string-label-derived devnet fixtures) produces a different
+    // address that fails the chain's lookup. See ligate-chain#245.
     let mut addr_bytes = [0u8; 28];
-    addr_bytes.copy_from_slice(&digest[..28]);
+    addr_bytes.copy_from_slice(&pubkey_bytes[..28]);
     let address = Address::from(addr_bytes);
     let address_str = address.to_string();
 


### PR DESCRIPTION
Fixes the two coupled bugs that the cli/faucet smoke test surfaced today against localnet. Both blocked devnet day-1 transfers.

## Bug 1: Submitter docs claimed clients should pre-wrap

The chain's \`POST /v1/sequencer/txs\` HTTP handler ([\`sov-sequencer::rest_api::axum_accept_tx\`](https://github.com/Sovereign-Labs/sovereign-sdk/blob/f89964c/crates/full-node/sov-sequencer/src/rest_api.rs#L508-L530)) wraps the request body in \`AuthenticatorInput::Standard(RawTx { data })\` server-side:

\`\`\`rust
let raw_tx = RawTx::new(tx.0.body.blob);
let baked_tx = ...::encode_with_standard_auth(raw_tx);
\`\`\`

But this repo's \`crates/client-rs/src/submit.rs\` documented that consumers MUST pre-wrap with \`encode_with_standard_auth\` before calling \`Submitter::submit_raw_tx\`. Both \`ligate-faucet\` and \`ligate-cli\` followed those (wrong) docs and double-wrapped. The chain decoded the outer wrapping fine, then tried to deserialize the contents as a \`Transaction\` and read garbage at the public-key offset, producing:

\`\`\`
Transaction deserialization error: signature error: Cannot decompress Edwards point
\`\`\`

This commit fixes the docstrings (do NOT pre-wrap; pass borsh-encoded \`Transaction\` directly).

## Bug 2: \`genesis-tool keys generate\` derived addresses wrongly

The chain's authentication flow:

1. Take the public key from the signed tx.
2. \`credential_id = HexString(pubkey_bytes)\` — the raw 32-byte pubkey, per [\`MockZkvmCryptoSpec::Ed25519PublicKey::credential_id\`](https://github.com/Sovereign-Labs/sovereign-sdk/blob/f89964c/crates/adapters/mock-zkvm/src/crypto.rs#L177-L182).
3. \`Address::from(credential_id)\` = first 28 bytes of the pubkey, per [\`From<HexString<[u8;32]>> for Address\`](https://github.com/Sovereign-Labs/sovereign-sdk/blob/f89964c/crates/module-system/sov-modules-api/src/common/address.rs#L436-L440).

But our \`genesis-tool\` derived addresses as \`SHA-256(pubkey)[..28]\` — to match the existing \`crates/stf/tests/devnet_addresses.rs\` pattern, but that's a separate string-label-based derivation for static fixtures, not the keypair-to-address flow. The mismatch meant operators substituting genesis-tool-generated keys into \`keys.toml\` got addresses the chain couldn't match at signature-verification time, producing \`CannotReserveGas(\"Insufficient balance\")\` for the (correctly-derived but unfunded) sender.

This commit fixes the derivation to \`pubkey[..28]\`.

## Verification

End-to-end smoke test on localnet (mock DA):

1. \`cargo run --bin ligate-node\` — chain produces blocks normally.
2. \`ligate keys generate --name alice\` — uses corrected derivation.
3. Edit \`devnet/genesis/bank.json\` to fund alice with 100 LGT.
4. \`ligate transfer --to <bob> --amount 0.5 --signer alice ...\`.
5. Chain log: \`accept_tx tx_hash=0xb911c4... discriminant=\"Bank_Transfer\"\` → \`Successful(GasUnit[16675, 16675])\`.
6. Post-transfer balances: alice = 99.499766550 LGT (sent 0.5, paid ~0.000234 LGT in gas), bob = 0.500000000 LGT.

## Diff size

| File | +/− |
|---|---|
| \`crates/client-rs/src/submit.rs\` | docstring updates only |
| \`crates/genesis-tool/src/keys.rs\` | one-line behaviour change + comment |

Total: 2 files, +36 / −11.

## Why we didn't catch this earlier

Per the comment in \`crates/rollup/tests/e2e_smoke.rs\`, the chain repo has no working end-to-end test that signs and submits a real tx through the production \`RollupAuthenticator\`. PR #241 introduced \`Submitter\` with mockito unit tests that proved the HTTP plumbing but never exercised the actual chain decode path. The faucet + cli inherited the same gap.

## Follow-ups (out of scope here)

- ligate-io/faucet#3: faucet's parallel fix (drop double-wrap)
- ligate-io/ligate-cli#5: cli's parallel fix (drop double-wrap + correct address derivation)
- A real chain-side e2e test that signs + submits + asserts inclusion. Tracked separately.