### PR TITLE
feat(devnet): ship local dev keypair pre-funded with 10000 LGT

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ cargo run --bin ligate-node -- --da-layer celestia
 
 Defaults pick up `devnet/rollup.toml` (or `devnet/celestia.toml`) and the `devnet/genesis/*.json` files. The bootstrap account holds treasury, sequencer, attester, and prover roles for v0; two extra accounts (`lig1d0vqhk…` and `lig1njjery…`) ship with `$LGT` so you can exercise transfers without minting.
 
+#### Local dev key
+
+The bootstrap and dev accounts above are derived from string labels via SHA-256 and have no associated private key, so on a freshly-booted localnet there's no account anyone can sign with out-of-the-box. To make `cargo run --bin ligate-node` immediately useful, [`devnet/local-dev-key.json`](devnet/local-dev-key.json) ships a deterministic Ed25519 keypair (private-key seed = `0x0101…01`, address `lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u`) pre-funded with 10 000 `$LGT`. Treat it like Anvil's account-0: convenient for local testing, **never** for any real network.
+
+Operators deploying `ligate-devnet-1` MUST remove this address from `devnet/genesis/bank.json` (or use a substituted genesis bundle from [`ligate-genesis-tool`](crates/genesis-tool)) before producing the deploy artefacts. The `local-dev-key.json` file itself is harmless to ship publicly — its private key being well-known is the point.
+
+To use the dev key with [`ligate-cli`](https://github.com/ligate-io/ligate-cli):
+
+```bash
+mkdir -p ~/.local/share/io.ligate.cli/keys
+echo '0101010101010101010101010101010101010101010101010101010101010101' \
+    > ~/.local/share/io.ligate.cli/keys/dev.key
+chmod 600 ~/.local/share/io.ligate.cli/keys/dev.key
+echo 'lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u' \
+    > ~/.local/share/io.ligate.cli/keys/dev.address
+
+# Now you can transfer from `dev`:
+ligate transfer --signer dev --to lig1xyz... --amount 1.0 \
+    --chain-id 4242 --chain-hash $(curl -s http://127.0.0.1:12346/v1/rollup/info | jq -r .chain_hash) \
+    --token-id $(...)
+```
+
 ### Sequencer vs follower
 
 `ligate-node` accepts a `--mode {sequencer,follower}` flag (default `sequencer`).

--- a/devnet/genesis/bank.json
+++ b/devnet/genesis/bank.json
@@ -5,7 +5,8 @@
     "address_and_balances": [
       ["lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt", "100000000000000000"],
       ["lig1d0vqhkvnlaga6xe8rfed900qxnzhqnmhweqe3rxqdexp56lvqv7", "10000000000000000"],
-      ["lig1njjerykggkxvwa55x4lupkl67qnxsx9rwqxpuq4s3cmh7vmn7kx", "10000000000000000"]
+      ["lig1njjerykggkxvwa55x4lupkl67qnxsx9rwqxpuq4s3cmh7vmn7kx", "10000000000000000"],
+      ["lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u", "10000000000000"]
     ],
     "admins": [
       "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"

--- a/devnet/local-dev-key.json
+++ b/devnet/local-dev-key.json
@@ -1,0 +1,7 @@
+{
+  "_warning": "LOCAL DEVELOPMENT KEY ONLY. DO NOT USE FOR DEVNET, TESTNET, OR MAINNET. The private key is committed to the repo so anyone can sign transactions on a localnet boot. Equivalent of Anvil's account-0 dev key for Ethereum testing. Operators deploying ligate-devnet-1 must remove this key's address from `devnet/genesis/bank.json` before generating the genesis bundle (see crates/genesis-tool).",
+  "role": "dev",
+  "private_key_hex": "0101010101010101010101010101010101010101010101010101010101010101",
+  "public_key_hex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",
+  "address": "lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u"
+}


### PR DESCRIPTION
## Why

Today, `cargo run --bin ligate-node` boots a chain whose only funded accounts are SHA-256-of-string-label derived (bootstrap + two dev addresses): nobody has the private keys, so smoke-testing transfers requires a manual `devnet/genesis/bank.json` edit before every run. That's the wall every external dev hits the moment they try the README's 'exercise transfers' line.

This PR adds a deterministic Anvil-style local dev keypair to the genesis, so localnet is immediately useful out-of-the-box.

## What

- New file `devnet/local-dev-key.json` documents:
  - Private-key seed: 32 bytes of `0x01`
  - Public key: `8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c`
  - Address: `lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u`
  - Big DO-NOT-USE-FOR-DEVNET warning in the JSON itself.
- Adds the dev address to `devnet/genesis/bank.json` with 10 000 `$LGT` (10^13 nano-LGT).
- README "Run a node" section gets a new "Local dev key" subsection: explains the keypair, the Anvil parallel, and shows the `ligate-cli` import snippet.

## Verification

End-to-end on localnet (with cli #7's auto-/v1 fix on top):

```
$ ligate --rpc http://127.0.0.1:12346 balance \
    lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u --token-id <hex>
lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u: 10000.000000000 $LGT (10000000000000 nano)

$ ligate --rpc http://127.0.0.1:12346 transfer \
    --signer dev --to <bob> --amount 5 ...
# (chain accepts, receipt Successful)

$ ligate balance dev:  9994.999766550 $LGT  (started 10000, sent 5, gas ~0.000234)
$ ligate balance bob:     5.000000000 $LGT
```

## What this PR is NOT

- **Not a devnet-1 change.** Operators deploying `ligate-devnet-1` MUST remove this address from `devnet/genesis/bank.json` (or use a substituted genesis bundle from `ligate-genesis-tool`) before producing the public deploy artifacts. Both the JSON warning and the README spell this out. The ladder enforcement layer in `ligate-genesis-tool` is the right place to make this automatic; that's a follow-up.
- **Not a security risk.** The private key being well-known is the point. It cannot be confused for a real key (32 bytes of `0x01` is recognisable on sight) and it has no role outside localnet.

## Related

- Closes the localnet portion of the smoke-testing pain surfaced in #245.
- #231 (operator key gen + Mocha TIA) covers the parallel devnet-1 substitution flow.
