### PR TITLE
feat(node): return 503 on POST /v1/sequencer/txs in follower mode (closes #243)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,6 +4160,7 @@ dependencies = [
  "borsh",
  "clap",
  "ed25519-dalek",
+ "http-body-util",
  "ligate-prover-risc0",
  "ligate-stf",
  "prometheus",
@@ -4188,6 +4189,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tower",
  "tracing",
 ]
 

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -70,6 +70,8 @@ ed25519-dalek   = { workspace = true }
 serde_json      = { workspace = true }
 sov-test-utils  = { workspace = true }
 tempfile        = { workspace = true }
+tower           = { version = "0.5", features = ["util"] }
+http-body-util  = "0.1"
 # Re-list ligate-stf with the `test-utils` feature so the e2e smoke
 # tests get the `MinimalGenesis` impl on the production runtime that
 # `TestRunner` requires. Cargo unions this with the [dependencies]

--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -53,20 +53,38 @@ use sov_stf_runner::RollupConfig;
 #[derive(Clone, Debug)]
 pub struct CelestiaLigateRollup<M> {
     chain_id: std::sync::Arc<str>,
+    node_role: crate::NodeRole,
     phantom: std::marker::PhantomData<M>,
 }
 
 impl<M> Default for CelestiaLigateRollup<M> {
     fn default() -> Self {
-        Self { chain_id: std::sync::Arc::from(""), phantom: std::marker::PhantomData }
+        Self {
+            chain_id: std::sync::Arc::from(""),
+            node_role: crate::NodeRole::Sequencer,
+            phantom: std::marker::PhantomData,
+        }
     }
 }
 
 impl<M> CelestiaLigateRollup<M> {
     /// Build a blueprint with the configured chain id. Used by
-    /// `main.rs` after `[chain]` is loaded and validated.
+    /// `main.rs` after `[chain]` is loaded and validated. Defaults to
+    /// [`crate::NodeRole::Sequencer`] for backward-compat callers.
     pub fn new(chain_id: impl Into<std::sync::Arc<str>>) -> Self {
-        Self { chain_id: chain_id.into(), phantom: std::marker::PhantomData }
+        Self {
+            chain_id: chain_id.into(),
+            node_role: crate::NodeRole::Sequencer,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Build a blueprint with both chain id and node role.
+    pub fn new_with_role(
+        chain_id: impl Into<std::sync::Arc<str>>,
+        node_role: crate::NodeRole,
+    ) -> Self {
+        Self { chain_id: chain_id.into(), node_role, phantom: std::marker::PhantomData }
     }
 }
 
@@ -187,6 +205,16 @@ impl FullNodeBlueprint<Native> for CelestiaLigateRollup<Native> {
         router = crate::health::add_routes(router, health_state);
 
         router = router.layer(axum::middleware::from_fn(crate::metrics::record_rpc_request));
+
+        // #243: in follower mode, return 503 on POST /v1/sequencer/txs
+        // so submissions don't silently disappear into a local mempool
+        // that never propagates. In sequencer mode the layer is not
+        // applied at all (zero overhead for the common case).
+        if self.node_role == crate::NodeRole::Follower {
+            router = router.layer(axum::middleware::from_fn(
+                crate::follower_guard::block_sequencer_submission,
+            ));
+        }
 
         endpoints.axum_router = router;
 

--- a/crates/rollup/src/follower_guard.rs
+++ b/crates/rollup/src/follower_guard.rs
@@ -1,0 +1,145 @@
+//! Axum middleware that blocks transaction submission when the node
+//! is running in [`crate::NodeRole::Follower`].
+//!
+//! ## Why
+//!
+//! In follower mode the node still mounts the full chain REST surface
+//! (so users can hit `GET /v1/ledger/...`, `GET /v1/rollup/info`,
+//! etc. against a local follower without bouncing to the public
+//! sequencer). But the *submission* endpoint, `POST /v1/sequencer/txs`,
+//! must not silently accept a transaction that has nowhere to go. The
+//! follower's DA address isn't in the registry, so any blob it tried
+//! to post would be dropped at the STF level; without this guard the
+//! tx would queue locally, get dropped, and the user would never know
+//! why their tx didn't appear on chain.
+//!
+//! Returning `503 Service Unavailable` with a clear "this node is a
+//! follower; submit to <upstream>" message gives the user an obvious
+//! signal to redirect their submission.
+//!
+//! ## What it does
+//!
+//! Intercepts `POST` requests whose path ends in `/sequencer/txs`
+//! (matches both `/sequencer/txs` if mounted at root and
+//! `/v1/sequencer/txs` once the chain repo's `/v1` nesting is
+//! applied) and returns 503 with a JSON body matching the SDK's
+//! `ApiError` shape. Other requests pass through unchanged.
+//!
+//! Layered onto the master axum router in
+//! `mock_rollup::create_endpoints` and `celestia_rollup::create_endpoints`
+//! when [`crate::NodeRole`] is `Follower`. In `Sequencer` mode the
+//! middleware is not applied at all — zero runtime overhead for the
+//! common case.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+/// 503 message returned when a follower receives a submission. JSON
+/// shape matches the SDK's `ApiError` so existing clients deserialise
+/// it with their normal error path.
+const MESSAGE: &str = r#"{"status":503,"message":"This node is running in follower mode. Transaction submission is disabled. Submit to the upstream sequencer (e.g. https://rpc.ligate.io) and read state from this follower locally.","details":{}}"#;
+
+/// Middleware that intercepts `POST /...sequencer/txs` requests with
+/// a 503 response. Wire via `axum::middleware::from_fn` only when the
+/// node is in follower mode.
+pub async fn block_sequencer_submission(req: Request<Body>, next: Next) -> Response {
+    if req.method() == axum::http::Method::POST && req.uri().path().ends_with("/sequencer/txs") {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            MESSAGE,
+        )
+            .into_response();
+    }
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Method, Request};
+    use axum::middleware;
+    use axum::routing::{get, post};
+    use axum::Router;
+    use http_body_util::BodyExt as _;
+    use tower::ServiceExt as _;
+
+    /// A handler that stand-ins for the real sequencer's accept_tx —
+    /// returns 200 if reached, so the middleware blocking it shows up
+    /// as a 503 in the test response.
+    async fn would_accept_tx() -> &'static str {
+        "would accept"
+    }
+
+    fn router_with_follower_guard() -> Router {
+        Router::new()
+            .route("/v1/sequencer/txs", post(would_accept_tx))
+            .route("/v1/sequencer/ready", get(|| async { "ready" }))
+            .route("/v1/ledger/slots/latest", get(|| async { "{}" }))
+            .layer(middleware::from_fn(block_sequencer_submission))
+    }
+
+    async fn body_string(resp: Response) -> String {
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn post_sequencer_txs_is_blocked_with_503() {
+        let app = router_with_follower_guard();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/sequencer/txs")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = body_string(resp).await;
+        assert!(body.contains("follower mode"));
+        assert!(body.contains("submit to the upstream sequencer") || body.contains("Submit to"));
+    }
+
+    #[tokio::test]
+    async fn get_sequencer_ready_passes_through() {
+        let app = router_with_follower_guard();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/v1/sequencer/ready")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_string(resp).await, "ready");
+    }
+
+    #[tokio::test]
+    async fn get_ledger_slots_latest_passes_through() {
+        let app = router_with_follower_guard();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/v1/ledger/slots/latest")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_to_other_path_passes_through() {
+        // Even POST methods, as long as the path doesn't end in
+        // `/sequencer/txs`, are not affected. (None exist in our
+        // surface today; this test documents intent for future routes.)
+        let extra =
+            router_with_follower_guard().route("/v1/some/other/post", post(would_accept_tx));
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/some/other/post")
+            .body(Body::empty())
+            .unwrap();
+        let resp = extra.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/rollup/src/follower_guard.rs
+++ b/crates/rollup/src/follower_guard.rs
@@ -14,8 +14,8 @@
 //! why their tx didn't appear on chain.
 //!
 //! Returning `503 Service Unavailable` with a clear "this node is a
-//! follower; submit to <upstream>" message gives the user an obvious
-//! signal to redirect their submission.
+//! follower; submit to the upstream sequencer" message gives the user
+//! an obvious signal to redirect their submission.
 //!
 //! ## What it does
 //!

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -30,6 +30,7 @@
 
 mod celestia_rollup;
 pub mod chain_config;
+pub mod follower_guard;
 pub mod health;
 pub mod info;
 pub mod metrics;
@@ -38,3 +39,28 @@ mod mock_rollup;
 pub use celestia_rollup::{CelestiaLigateRollup, CelestiaRollupSpec};
 pub use chain_config::{ChainConfig, ChainIdError};
 pub use mock_rollup::{MockLigateRollup, MockRollupSpec};
+
+/// Operator role this node should run as.
+///
+/// `Sequencer` is the normal full-node-with-sequencer flow; the node
+/// builds batches and posts them to DA. `Follower` is a read-only
+/// sync mode for non-sequencer operators (design partners, auditors,
+/// anyone running their own Ligate node who isn't the registered
+/// sequencer).
+///
+/// In `Follower` mode `main.rs` disables `automatic_batch_production`
+/// (no posts to DA), and `create_endpoints` layers a middleware
+/// (see [`follower_guard`]) that returns `503 Service Unavailable`
+/// for `POST /v1/sequencer/txs` so submissions don't silently
+/// disappear into a local mempool that never propagates.
+///
+/// Tracking: [#243](https://github.com/ligate-io/ligate-chain/issues/243).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeRole {
+    /// Normal full node: produces batches, posts to DA, accepts
+    /// submissions on `/v1/sequencer/txs`.
+    Sequencer,
+    /// Read-only follower: syncs STF from DA, serves read endpoints,
+    /// does not auto-produce batches, returns 503 on submissions.
+    Follower,
+}

--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -105,15 +105,26 @@ enum SupportedDaLayer {
 }
 
 /// Role this node operates as. See `Args::mode` for the operator-
-/// facing semantics.
+/// facing semantics. Mirrors [`ligate_rollup::NodeRole`] but with
+/// `clap::ValueEnum` derived for CLI parsing; the lib's variant
+/// stays clap-free so the library has no clap dep.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 enum NodeRole {
     /// Normal full node: produces batches, posts to DA, accepts
     /// submissions on `/v1/sequencer/txs`.
     Sequencer,
     /// Read-only follower: syncs STF from DA, serves read endpoints,
-    /// does not auto-produce batches.
+    /// does not auto-produce batches, returns 503 on submissions.
     Follower,
+}
+
+impl From<NodeRole> for ligate_rollup::NodeRole {
+    fn from(role: NodeRole) -> Self {
+        match role {
+            NodeRole::Sequencer => ligate_rollup::NodeRole::Sequencer,
+            NodeRole::Follower => ligate_rollup::NodeRole::Follower,
+        }
+    }
 }
 
 impl SupportedDaLayer {
@@ -181,9 +192,9 @@ async fn run() -> anyhow::Result<()> {
         tracing::info!(
             "ligate-node booting in FOLLOWER mode: this node will sync the STF \
              from DA but will NOT produce batches. Submissions to this node's \
-             /v1/sequencer/txs endpoint do not propagate to the chain. Point \
+             /v1/sequencer/txs endpoint return 503 Service Unavailable. Point \
              clients at the upstream sequencer (e.g. https://rpc.ligate.io) for \
-             transaction submission. Tracking: #243."
+             transaction submission."
         );
     }
 
@@ -272,7 +283,7 @@ async fn run_with_mock(
         metrics::DEFAULT_STATE_DB_SIZE_POLL_INTERVAL,
     );
 
-    let rollup = MockLigateRollup::<Native>::new(chain.chain_id)
+    let rollup = MockLigateRollup::<Native>::new_with_role(chain.chain_id, mode.into())
         .create_new_rollup(
             genesis_paths,
             rollup_config,
@@ -321,7 +332,7 @@ async fn run_with_celestia(
         metrics::DEFAULT_STATE_DB_SIZE_POLL_INTERVAL,
     );
 
-    let rollup = CelestiaLigateRollup::<Native>::new(chain.chain_id)
+    let rollup = CelestiaLigateRollup::<Native>::new_with_role(chain.chain_id, mode.into())
         .create_new_rollup(
             genesis_paths,
             rollup_config,

--- a/crates/rollup/src/mock_rollup.rs
+++ b/crates/rollup/src/mock_rollup.rs
@@ -48,13 +48,16 @@ use sov_stf_runner::RollupConfig;
 ///
 /// Holds the configured `chain_id` so the blueprint's `create_endpoints`
 /// hook can mount `/v1/rollup/info` with the operator-supplied
-/// identifier (#181). The [`Default`] impl is kept so existing tests
-/// can construct the type without plumbing chain config; production
-/// code paths (`main.rs`) pass the loaded id via
-/// [`MockLigateRollup::new`].
+/// identifier (#181), and the [`crate::NodeRole`] so the `create_endpoints`
+/// hook can layer the [`crate::follower_guard`] middleware when
+/// running as a follower (#243). The [`Default`] impl is kept so
+/// existing tests can construct the type without plumbing chain
+/// config; production code paths (`main.rs`) pass the loaded id and
+/// role via [`MockLigateRollup::new`].
 #[derive(Clone, Debug)]
 pub struct MockLigateRollup<M> {
     chain_id: std::sync::Arc<str>,
+    node_role: crate::NodeRole,
     phantom: std::marker::PhantomData<M>,
 }
 
@@ -65,16 +68,33 @@ impl<M> Default for MockLigateRollup<M> {
         // `create_endpoints`, and a panicky `unwrap` in `Default`
         // would surface during macro-generated test compilation
         // before any meaningful diagnostic.
-        Self { chain_id: std::sync::Arc::from(""), phantom: std::marker::PhantomData }
+        Self {
+            chain_id: std::sync::Arc::from(""),
+            node_role: crate::NodeRole::Sequencer,
+            phantom: std::marker::PhantomData,
+        }
     }
 }
 
 impl<M> MockLigateRollup<M> {
-    /// Build a blueprint with the configured chain id. Used by
-    /// `main.rs` after [`crate::chain_config::load_split_config`]
-    /// reads + validates the `[chain]` section.
+    /// Build a blueprint with the configured chain id and node role.
+    /// Used by `main.rs` after [`crate::chain_config::load_split_config`]
+    /// reads + validates the `[chain]` section. Defaults to
+    /// [`crate::NodeRole::Sequencer`] for backward-compat callers.
     pub fn new(chain_id: impl Into<std::sync::Arc<str>>) -> Self {
-        Self { chain_id: chain_id.into(), phantom: std::marker::PhantomData }
+        Self {
+            chain_id: chain_id.into(),
+            node_role: crate::NodeRole::Sequencer,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Build a blueprint with both chain id and node role.
+    pub fn new_with_role(
+        chain_id: impl Into<std::sync::Arc<str>>,
+        node_role: crate::NodeRole,
+    ) -> Self {
+        Self { chain_id: chain_id.into(), node_role, phantom: std::marker::PhantomData }
     }
 }
 
@@ -207,6 +227,16 @@ impl FullNodeBlueprint<Native> for MockLigateRollup<Native> {
         // `MatchedPath::as_str()` keeps cardinality bounded by
         // route template, not concrete `:id`.
         router = router.layer(axum::middleware::from_fn(crate::metrics::record_rpc_request));
+
+        // #243: in follower mode, return 503 on POST /v1/sequencer/txs
+        // so submissions don't silently disappear into a local mempool
+        // that never propagates. In sequencer mode the layer is not
+        // applied at all (zero overhead for the common case).
+        if self.node_role == crate::NodeRole::Follower {
+            router = router.layer(axum::middleware::from_fn(
+                crate::follower_guard::block_sequencer_submission,
+            ));
+        }
 
         endpoints.axum_router = router;
 


### PR DESCRIPTION
Closes #243.

Step 1 of #243 (PR #244) added the `--mode follower` flag and disabled `automatic_batch_production`. Step 2 (this PR) closes the gap that step 1 explicitly left open: a follower's `POST /v1/sequencer/txs` was still mounted, so submissions still got accepted into the local mempool — they just never propagated. Users had no way to know.

This PR returns **503 Service Unavailable** with a clear JSON body explaining how to redirect submissions.

## What it does

- New `crate::NodeRole` enum in `lib.rs`. `Sequencer` (default) runs the normal flow; `Follower` triggers the new behaviour.
- New module `crate::follower_guard` with an axum middleware (`block_sequencer_submission`) that intercepts `POST` requests whose path ends in `/sequencer/txs` with a 503 response.
- `MockLigateRollup` and `CelestiaLigateRollup` get a `new_with_role` constructor and an internal `node_role` field. `create_endpoints` layers the follower-guard middleware *only* when `node_role == Follower` — sequencer mode pays zero overhead.
- `main.rs` converts the clap `NodeRole` to `ligate_rollup::NodeRole` and passes it to the blueprint constructor. Existing `MockLigateRollup::new(chain_id)` callers keep working (default sequencer).
- 4 new unit tests in `follower_guard` cover: blocked POST submission, passing-through GETs to other sequencer routes, passing-through GETs to ledger, and unrelated POST routes (future-proofing).

## Verification

End-to-end on localnet, follower mode:

```
$ cargo run --bin ligate-node -- --mode follower
[INFO] ligate-node booting in FOLLOWER mode: ...

# Reads still work:
$ curl http://127.0.0.1:12346/v1/rollup/info
{"chain_id":"ligate-localnet","chain_hash":"eec077...","version":"0.0.1"}

# Submission returns 503:
$ curl -sw '%{http_code}\n' -X POST http://127.0.0.1:12346/v1/sequencer/txs \
    -H 'Content-Type: application/json' -d '{"body":{"blob":"AAAA"}}'
{"status":503,"message":"This node is running in follower mode. Transaction submission is disabled. Submit to the upstream sequencer (e.g. https://rpc.ligate.io) and read state from this follower locally.","details":{}}
503
```

22 unit tests pass (`cargo test -p ligate-rollup --lib`).

## Diff size

| File | +/− |
|---|---|
| `crates/rollup/src/follower_guard.rs` | +145 (new) |
| `crates/rollup/src/lib.rs` | +29 |
| `crates/rollup/src/main.rs` | +18 / −5 |
| `crates/rollup/src/mock_rollup.rs` | +30 / −3 |
| `crates/rollup/src/celestia_rollup.rs` | +30 / −3 |
| `crates/rollup/Cargo.toml` | +2 (test deps: tower, http-body-util) |

## Out of scope

- Forwarding submissions transparently from a follower to a configured upstream sequencer. That's a future polish item (`--upstream-sequencer` flag); this PR does the safer thing of returning a clear error so misconfigured clients fail fast.
- Long-term: upstreaming a `node_role` field to Sovereign SDK's `RollupConfig` so the blueprint can branch natively. Not needed yet; the chain-side override is fine.
