### PR TITLE
chore(devnet-1): substitute genesis with operator-controlled keys (closes #231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+### Changed
+
+- `devnet-1/genesis/` substituted with operator-controlled keys for `ligate-devnet-1`. The placeholder bootstrap address (`lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt`, derivable from a public seed) is replaced with the real operator key (`lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8`) across all 6 module configs that reference it (sequencer registry, attester / prover / operator incentives, bank treasury + admins, attestation treasury). Two demo wallets (`lig19tzz...`, `lig1e0lp...`) ship pre-funded with 10M LGT each for partner-integration testing. v0 uses the single-operator-key model: one address fills bootstrap + sequencer + treasury + reward; security-separated treasury / sequencer keys land at testnet (#231 follow-up). Private keys live offline at `~/.ligate-keys/devnet-1/<role>.key` (chmod 600, never in repo). The `chain_hash` is now finalised for `ligate-devnet-1` — anything signed against the prior placeholder hash will fail signature verification on the public network. Closes [#231](https://github.com/ligate-io/ligate-chain/issues/231).
+
 ### Added
 
 - `crates/rollup/tests/devnet_config.rs` gains `devnet_1_does_not_ship_a_rollup_toml` — a one-line file-inventory guard for the Celestia-only-by-design `devnet-1/` directory (`devnet-1/README.md`). If a future PR copy-pastes `devnet/rollup.toml` into `devnet-1/` by mistake, the test breaks loudly at PR time rather than silently letting an operator boot the public-devnet config in MockDA mode. Companion to the existing chain-id pin in `devnet_1_celestia_toml_parses_against_celestia_blueprint_types`. Closes [#190](https://github.com/ligate-io/ligate-chain/issues/190) (the public-devnet config drift coverage).

--- a/devnet-1/genesis/attestation.json
+++ b/devnet-1/genesis/attestation.json
@@ -1,10 +1,10 @@
 {
-  "treasury": "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt",
-  "lgt_token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
   "attestation_fee": "100000",
-  "schema_registration_fee": "100000000",
   "attestor_set_fee": "50000000",
   "initial_attestor_sets": [],
   "initial_schemas": [],
-  "max_builder_bps": 5000
+  "lgt_token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
+  "max_builder_bps": 5000,
+  "schema_registration_fee": "100000000",
+  "treasury": "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
 }

--- a/devnet-1/genesis/attester_incentives.json
+++ b/devnet-1/genesis/attester_incentives.json
@@ -1,10 +1,19 @@
 {
-  "minimum_attester_bond": [1000, 1000],
-  "minimum_challenger_bond": [1000, 1000],
   "initial_attesters": [
-    ["lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt", "1000000000000"]
+    [
+      "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8",
+      "1000000000000"
+    ]
   ],
-  "rollup_finality_period": 5,
+  "light_client_finalized_height": 0,
   "maximum_attested_height": 0,
-  "light_client_finalized_height": 0
+  "minimum_attester_bond": [
+    1000,
+    1000
+  ],
+  "minimum_challenger_bond": [
+    1000,
+    1000
+  ],
+  "rollup_finality_period": 5
 }

--- a/devnet-1/genesis/bank.json
+++ b/devnet-1/genesis/bank.json
@@ -1,15 +1,24 @@
 {
   "gas_token_config": {
-    "token_name": "LGT",
-    "token_decimals": 9,
     "address_and_balances": [
-      ["lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt", "100000000000000000"],
-      ["lig1d0vqhkvnlaga6xe8rfed900qxnzhqnmhweqe3rxqdexp56lvqv7", "10000000000000000"],
-      ["lig1njjerykggkxvwa55x4lupkl67qnxsx9rwqxpuq4s3cmh7vmn7kx", "10000000000000000"]
+      [
+        "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8",
+        "100000000000000000"
+      ],
+      [
+        "lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544",
+        "10000000000000000"
+      ],
+      [
+        "lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz",
+        "10000000000000000"
+      ]
     ],
     "admins": [
-      "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"
-    ]
+      "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
+    ],
+    "token_decimals": 9,
+    "token_name": "LGT"
   },
   "tokens": []
 }

--- a/devnet-1/genesis/chain_state.json
+++ b/devnet-1/genesis/chain_state.json
@@ -1,7 +1,25 @@
 {
   "current_time": 0,
+  "genesis_da_height": 0,
+  "inner_code_commitment": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
   "operating_mode": "zk",
-  "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-  "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-  "genesis_da_height": 0
+  "outer_code_commitment": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ]
 }

--- a/devnet-1/genesis/operator_incentives.json
+++ b/devnet-1/genesis/operator_incentives.json
@@ -1,3 +1,3 @@
 {
-  "reward_address": "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"
+  "reward_address": "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
 }

--- a/devnet-1/genesis/prover_incentives.json
+++ b/devnet-1/genesis/prover_incentives.json
@@ -1,7 +1,16 @@
 {
-  "proving_penalty": [10, 10],
-  "minimum_bond": [1000, 1000],
   "initial_provers": [
-    ["lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt", "1000000000000"]
+    [
+      "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8",
+      "1000000000000"
+    ]
+  ],
+  "minimum_bond": [
+    1000,
+    1000
+  ],
+  "proving_penalty": [
+    10,
+    10
   ]
 }

--- a/devnet-1/genesis/sequencer_registry.json
+++ b/devnet-1/genesis/sequencer_registry.json
@@ -1,9 +1,9 @@
 {
   "minimum_bond": "1000000000000",
   "sequencer_config": {
-    "seq_rollup_address": "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt",
-    "seq_da_address": "0000000000000000000000000000000000000000000000000000000000000000",
+    "is_preferred_sequencer": true,
     "seq_bond": "5000000000000",
-    "is_preferred_sequencer": true
+    "seq_da_address": "0000000000000000000000000000000000000000000000000000000000000000",
+    "seq_rollup_address": "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
   }
 }


### PR DESCRIPTION
## What

Locks the chain identity for `ligate-devnet-1` by substituting the placeholder addresses in `devnet-1/genesis/` with operator-controlled keys.

After this PR merges, the genesis bundle on `main` is what the public-devnet boots from. The `chain_hash` derived from this commit is the final `ligate-devnet-1` chain hash; anything signed against the prior placeholder hash will fail signature verification on the public network.

## Substitutions

| Role | Placeholder (public seed, anyone could sign) | Real (operator-controlled, key offline) |
|---|---|---|
| operator (bootstrap + sequencer + treasury + reward + admin + bonds) | `lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt` | `lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8` |
| demo1 (10M LGT pre-funded test wallet) | `lig1d0vqhkvnlaga6xe8rfed900qxnzhqnmhweqe3rxqdexp56lvqv7` | `lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544` |
| demo2 (10M LGT pre-funded test wallet) | `lig1njjerykggkxvwa55x4lupkl67qnxsx9rwqxpuq4s3cmh7vmn7kx` | `lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz` |

The operator address now appears in 6 of the 8 module configs (bank treasury + admins, attestation treasury, sequencer registry, attester / prover / operator incentives). `chain_state.json` formatting expanded but no semantic change. `accounts.json` unchanged (no accounts in placeholder bundle).

## v0 design choice: single-operator-key model

For devnet we use one operator key for sequencer + treasury + reward + bond. Testnet/mainnet split these (treasury cold, sequencer hot) — that's a #231 follow-up, not a blocker for `ligate-devnet-1`. Documented in CHANGELOG.

## Scope deliberately NOT changed here

- **Faucet hot key**: not seeded in this ceremony. Day-2 decision: faucet either signs from operator key or from demo1/demo2.
- **Celestia signer key (`SOV_CELESTIA_SIGNER_KEY`)**: separate from this ceremony, sourced via Mocha Discord faucet, lives in `/etc/ligate/env` on the GCP VM.
- **Initial attestor sets / schemas**: still empty (`initial_*: []`). Registered post-genesis via the `ligate-bootstrap` ceremony from #249.

## Verification

```sh
$ cargo run -p ligate-genesis-tool -- verify --dir devnet-1/genesis
verify: OK
  treasury: lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8
  lgt_token_id: token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7
  initial_attestor_sets: 0
  initial_schemas: 0

$ cargo test -p ligate-rollup --test devnet_config
running 6 tests
test devnet_1_does_not_ship_a_rollup_toml ... ok
test devnet_1_genesis_jsons_load_and_pass_cross_module_validation ... ok
test devnet_1_celestia_toml_parses_against_celestia_blueprint_types ... ok
... (3 more) ...
test result: ok. 6 passed
```

Workspace tests all green (`cargo test --workspace --lib --tests`).

## Operational note

Private keys live offline at `~/.ligate-keys/devnet-1/<role>.key` (chmod 600), never committed. `devnet-1/keys.toml` (the substitution map) is gitignored.

After this PR lands, the operator key gets loaded into `/etc/ligate/keys/operator.key` on the GCP sequencer VM (#79 / #125). The chain only signs sequencer batches with that key; lose it and the chain can't sequence — backup before the GCP boot.

## Closes

#231 — operator key generation + genesis substitution