### PR TITLE
feat(bootstrap-cli): add disc_probe example for TS-side fixture regen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+### Added
+
+- `crates/bootstrap-cli/examples/disc_probe.rs` — one-shot fixture probe that prints byte-exact `borsh(RuntimeCall::Attestation(...))` output for `RegisterAttestorSet` / `RegisterSchema` / `SubmitAttestation`, plus the deterministic `AttestorSet::derive_id` / `Schema::derive_id` outputs for known-input fixtures. Used as the source-of-truth for the `@ligate/sdk` TS-side wire-format pinning (`ligate-js/test/attestation.test.ts`); regenerate fixtures after any Sovereign SDK pin bump that touches runtime composition or `attestation::CallMessage` shape. `cargo run --example disc_probe -p ligate-bootstrap-cli`. No CI changes — this is a developer tool, not a runtime gate.
+
 ### Changed
 
 - `docs/development/public-devnet-deploy.md` gains two new operator-flow steps: **Step 4.5** (run the canonical-schema ceremony from PR #249's `ligate-bootstrap` binary; the chain ships with `initial_attestor_sets: []` / `initial_schemas: []` so first-party schemas register post-genesis via on-chain tx) and **Step 4.7** (deploy the faucet on the same VM as `ligate-node`: install / fund-from-operator / systemd unit / env-var setup / smoke test). Both blocks lift the canonical commands operators run on Day 1, so the runbook is now end-to-end actionable from "GCP VM exists" to "partners can drip and use the chain". No code changes; documentation only.

--- a/crates/bootstrap-cli/examples/disc_probe.rs
+++ b/crates/bootstrap-cli/examples/disc_probe.rs
@@ -1,0 +1,79 @@
+// One-shot discriminant probe + borsh-fixture printer for
+// `RuntimeCall::Attestation(...)` variants. The TS SDK
+// (`ligate-js/test/transaction.test.ts`) pins these exact bytes
+// to catch wire-format drift between the chain (Rust borsh) and
+// the SDK (hand-rolled TS borsh).
+//
+// Run with:
+//
+//     cargo run --example disc_probe -p ligate-bootstrap-cli
+//
+use attestation::{
+    AttestorSet, AttestorSetId, AttestorSignature, CallMessage, PayloadHash, PubKey, Schema,
+    SchemaId, MAX_ATTESTATION_SIGNATURES, MAX_ATTESTOR_SET_MEMBERS, MAX_ATTESTOR_SIGNATURE_BYTES,
+};
+use ligate_rollup::MockRollupSpec;
+use ligate_stf::runtime::RuntimeCall;
+use sov_modules_api::execution_mode::Native;
+use sov_modules_api::{Address, SafeString, SafeVec, Spec};
+
+type S = MockRollupSpec<Native>;
+type SovAddress = <S as Spec>::Address;
+
+fn print_call(label: &str, call: RuntimeCall<S>) {
+    let bytes = borsh::to_vec(&call).unwrap();
+    println!("== {label} ==");
+    println!("  total: {} bytes", bytes.len());
+    println!("  hex:   {}", hex::encode(&bytes));
+    println!("  byte[0] (RuntimeCall variant): 0x{:02x}", bytes[0]);
+    println!("  byte[1] (CallMessage variant): 0x{:02x}", bytes[1]);
+}
+
+fn main() {
+    // RegisterAttestorSet — minimum: 1 member, threshold 1.
+    let members =
+        SafeVec::<PubKey, MAX_ATTESTOR_SET_MEMBERS>::try_from(vec![PubKey::from([0xAA; 32])])
+            .unwrap();
+    let register_set =
+        RuntimeCall::Attestation(CallMessage::RegisterAttestorSet { members, threshold: 1 });
+    print_call("RegisterAttestorSet (1-of-1, AAA pubkey)", register_set);
+
+    // RegisterSchema — name = "x", v1, attestor_set_id = BB..BB,
+    // no fee routing, payload_shape_hash all zero.
+    let attestor_set: AttestorSetId = AttestorSetId::from([0xBB; 32]);
+    let register_schema = RuntimeCall::Attestation(CallMessage::RegisterSchema {
+        name: SafeString::try_from("x".to_string()).unwrap(),
+        version: 1,
+        attestor_set,
+        fee_routing_bps: 0,
+        fee_routing_addr: None,
+        payload_shape_hash: [0u8; 32],
+    });
+    print_call("RegisterSchema (name='x', v1, BBB attestor_set)", register_schema);
+
+    // SubmitAttestation — 1 signature.
+    let schema_id = SchemaId::from([0xCC; 32]);
+    let payload_hash = PayloadHash::from([0xDD; 32]);
+    let sig = AttestorSignature {
+        pubkey: PubKey::from([0xEE; 32]),
+        sig: SafeVec::<u8, MAX_ATTESTOR_SIGNATURE_BYTES>::try_from(vec![0xFFu8; 64]).unwrap(),
+    };
+    let signatures =
+        SafeVec::<AttestorSignature, MAX_ATTESTATION_SIGNATURES>::try_from(vec![sig]).unwrap();
+    let submit = RuntimeCall::Attestation(CallMessage::SubmitAttestation {
+        schema_id,
+        payload_hash,
+        signatures,
+    });
+    print_call("SubmitAttestation (1 sig, all-FF)", submit);
+
+    // Deterministic id derivations the TS side can pin.
+    println!();
+    println!("== deterministic ids ==");
+    let pks = vec![PubKey::from([0xAA; 32])];
+    println!("  AttestorSet::derive_id(&[AAA], 1) = {}", AttestorSet::derive_id(&pks, 1));
+    // SovAddress = MultiAddress<EthereumAddress>; we cast a 28-byte
+    // fixture into the canonical chain-side Address.
+    let owner: SovAddress = SovAddress::from(Address::from([0x42u8; 28]));
+    println!("  Schema::derive_id(0x42x28, 'x', 1)  = {}", Schema::<S>::derive_id(&owner, "x", 1));
+}


### PR DESCRIPTION
## What

Adds a one-shot Rust example at `crates/bootstrap-cli/examples/disc_probe.rs` that prints byte-exact `borsh(RuntimeCall::Attestation(...))` output for the three user-callable variants, plus the `AttestorSet::derive_id` / `Schema::derive_id` outputs for known-input fixtures.

```sh
$ cargo run --example disc_probe -p ligate-bootstrap-cli

== RegisterAttestorSet (1-of-1, AAA pubkey) ==
  total: 39 bytes
  hex:   090001000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01
  byte[0] (RuntimeCall variant): 0x09
  byte[1] (CallMessage variant): 0x00
== RegisterSchema (...) ==
  ...
== SubmitAttestation (...) ==
  ...
== deterministic ids ==
  AttestorSet::derive_id(&[AAA], 1) = las1g26ad6dgyn5hywvtlc9cp2z0k24f0elelekdv6z52ms0cs579fps6h0vzx
  Schema::derive_id(0x42x28, 'x', 1)  = lsc1lwcumlz336grmejfvwm97pn33pes680cr7gc3el57gr34q33dhus0ytxrc
```

## Why

The `@ligate/sdk` TS implementation now ships hand-rolled borsh builders for `RegisterAttestorSet` / `RegisterSchema` / `SubmitAttestation` (see [`ligate-js#12`](https://github.com/ligate-io/ligate-js/pull/12)). Those builders are pinned against byte-exact fixtures captured from the Rust side. If a future Sovereign SDK pin bump shifts module composition (changing `RuntimeCall::Attestation` from `0x09`) or any field order in `attestation::CallMessage`, the TS pinning needs to be refreshed.

`disc_probe` makes that refresh a one-line operation: re-run the example, paste the new hex into `ligate-js/test/attestation.test.ts`. Without it, the procedure was "manually inspect borsh::to_vec output via println, hope you got it right" — fragile.

## Why an `example` not a `test`

The fixtures don't change often (only on Sovereign SDK pin bumps), so making it a CI-gated test would mostly just slow down CI. As an example it stays opt-in, runs explicitly when needed, and documents the "here's how the TS side knows what shape to use" pipeline.

## Refs

Closes the chain-side leg of [`ligate-js#12`](https://github.com/ligate-io/ligate-js/pull/12) (attestation builders + wire-format fixtures).