### PR TITLE
feat: consume sovereign-sdk fork (ligate-mainline) for bech32m tx hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 
 [[package]]
 name = "nmt-rs"
@@ -7645,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "backon",
@@ -7702,7 +7702,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7723,7 +7723,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7742,7 +7742,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7785,7 +7785,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7850,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7889,7 +7889,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "borsh",
  "derivative",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -7951,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -7965,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "axum",
@@ -7990,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8063,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8107,7 +8107,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -8129,7 +8129,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8169,7 +8169,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "axum",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8227,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8246,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8266,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "axum",
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8316,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -8344,7 +8344,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "derive_more",
  "rockbound",
@@ -8356,11 +8356,12 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
  "backon",
+ "bech32",
  "borsh",
  "bytes",
  "derive_more",
@@ -8380,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8431,7 +8432,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8447,7 +8448,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8473,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8508,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8569,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8582,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -8603,7 +8604,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "bech32",
  "borsh",
@@ -8620,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -8630,7 +8631,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8646,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f6cd64749edc56428fbeb7f22702458b0afb698a#f6cd64749edc56428fbeb7f22702458b0afb698a"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=4bc29843f56075a5149da12f34ee9b16ad1adba5#4bc29843f56075a5149da12f34ee9b16ad1adba5"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,3 +124,55 @@ codegen-units = 1
 # debugging when needed.
 [profile.dev]
 debug = 0
+
+# ----------------------------------------------------------------------------
+# Sovereign SDK fork (`ligate-io/sovereign-sdk`)
+# ----------------------------------------------------------------------------
+#
+# Every `sov-*` dep above resolves to our fork's `ligate-mainline` branch
+# instead of `Sovereign-Labs/sovereign-sdk@<rev>`. The fork carries patches
+# that aren't (yet) upstream:
+#
+# - `Sequencer::pending_tx_count()` for operator metrics (PR Sovereign-Labs/sovereign-sdk#2838)
+# - Typed `BlobSubmissionError` variant on `BlobSubmissionStatus` (PR Sovereign-Labs/sovereign-sdk#2839)
+# - `LtxHash` / `LblkHash` / `LsrHash` bech32m-encoded hash types
+#   (`pub type TxHash = LtxHash` so partner-facing tx hashes display as
+#   `ltx1...` instead of `0x...`)
+#
+# Pinned to a specific commit so chain rebuilds are reproducible. When
+# the fork advances (rebased on a new upstream tip, new patches added),
+# bump this `rev` in a deliberate PR — never let it move under the chain.
+#
+# Rebase discipline + workflow lives in the fork's CONTRIBUTING.md.
+[patch."https://github.com/Sovereign-Labs/sovereign-sdk.git"]
+sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }
+sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "236d4c80150f04428ae25f743a0de37132438f2a" }

--- a/deny.toml
+++ b/deny.toml
@@ -354,7 +354,16 @@ unknown-registry = "deny"
 unknown-git = "deny"
 required-git-spec = "rev"
 allow-git = [
+  # Upstream URL we patch against. The workspace `[patch]` redirects
+  # every `Sovereign-Labs/sovereign-sdk` dep to our fork (next entry),
+  # so Cargo.lock records the fork URL. We keep the upstream listed
+  # too because the [patch] block targets it and any non-patched
+  # transitive would still resolve there.
   "https://github.com/Sovereign-Labs/sovereign-sdk.git",
+  # Our fork of the SDK on `ligate-mainline`. Carries the bech32m
+  # tx hash types and the operator-facing fork patches. Workflow +
+  # patch list in CONTRIBUTING.ligate.md on the fork.
+  "https://github.com/ligate-io/sovereign-sdk.git",
   # SDK's RocksDB wrapper, pulled by sov-db / sov-blob-sender. Lives
   # in a separate repo from the main SDK; both are pinned by rev.
   "https://github.com/sovereign-labs/rockbound",

--- a/docs/protocol/upgrades.md
+++ b/docs/protocol/upgrades.md
@@ -249,16 +249,28 @@ For the full v0 attacker model and every mitigation across attestation, sequence
 | Change `attestation_fee` type (`Amount` → `u128` say) | Hard | Borsh snapshot fires | Coordinated reset |
 | Change attestor signature scheme | Hard | Every existing signature breaks | Coordinated reset, schema version bump |
 | Bump Sovereign SDK rev | Soft if `CHAIN_HASH` unchanged, hard otherwise | `CHAIN_HASH` derivation; review the SDK changelog | Test build, check the hash, then either soft-release or coordinated-reset |
+| Bump fork rev (`ligate-io/sovereign-sdk`) | Soft if `CHAIN_HASH` unchanged, hard otherwise | Same `CHAIN_HASH` guard as upstream rev bumps | Update the `[patch]` block's `rev = ...` in `Cargo.toml`; rebuild; check the hash; localnet smoke (submit a tx, confirm `ltx1...` round-trip). See `CONTRIBUTING.ligate.md` on the fork. |
 | Switch Celestia testnet (mocha → mocha-2) | Hard (operationally) | `celestia.toml` change | Coordinated reset (every operator re-syncs from the new namespace) |
 | Swap DA layer (Celestia → Avail / EigenDA / etc.) | Hard | New `--da-layer` arm; `CHAIN_HASH` may shift if guest crate changes | Coordinated reset; see [`da-layers.md`](da-layers.md) for the playbook |
 
 ---
+
+## Sovereign SDK fork
+
+Ligate Chain consumes the Sovereign SDK via a fork at [`ligate-io/sovereign-sdk`](https://github.com/ligate-io/sovereign-sdk), branch `ligate-mainline`. The fork carries:
+
+- Two upstream-PR-pending features (`Sequencer::pending_tx_count()`, typed `BlobSubmissionError`) that we use today and drop on rebase when Sovereign merges
+- Bech32m-encoded hash types (`LtxHash` / `LblkHash` / `LsrHash`) so partner-facing tx hashes display as `ltx1...` rather than `0x...`. Permanent for the fork's lifetime unless the upstream `HashEncoding` extension proposal lands ([`Sovereign-Labs/sovereign-sdk#2837`](https://github.com/Sovereign-Labs/sovereign-sdk/issues/2837))
+
+The fork's branch model + rebase discipline lives in `CONTRIBUTING.ligate.md` on the fork itself. The chain's `Cargo.toml` has a `[patch."<sov-url>"]` block pinning the consumed `rev` so the chain rebuilds reproducibly. Bump that `rev` in a deliberate PR; never let it move under the chain.
 
 ## Related
 
 - [Protocol spec, "Chain id"](attestation-v0.md#chain-id) — the locked four-row identifier ladder
 - [`crates/stf/build.rs`](../../crates/stf/build.rs) — `CHAIN_HASH` derivation
 - [`crates/stf/src/runtime_capabilities.rs`](../../crates/stf/src/runtime_capabilities.rs) — where `CHAIN_HASH` plugs into the runtime authenticator
+- [`ligate-io/sovereign-sdk`](https://github.com/ligate-io/sovereign-sdk) — our Sovereign SDK fork
+- [`Sovereign-Labs/sovereign-sdk#2837`](https://github.com/Sovereign-Labs/sovereign-sdk/issues/2837) — upstream proposal to retire the bech32m-encoding patch
 - [`tests/borsh_snapshot.rs`](../../crates/modules/attestation/tests/borsh_snapshot.rs) — the wire-format guard
 - [`audit.toml`](../../audit.toml) + [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — `cargo audit` gate
 - [`da-layers.md`](da-layers.md) — DA-agnostic-by-construction architecture and adapter playbook


### PR DESCRIPTION
Consumes the [`ligate-io/sovereign-sdk`](https://github.com/ligate-io/sovereign-sdk) fork via a `[patch.<sov-url>]` block in `Cargo.toml`. The fork carries three patches the chain wants today, two of which are open upstream PRs.

**Depends on #259** (the chain-side SDK pin bump). Merge that first.

## What ligate-chain gets

- `Sequencer::pending_tx_count()` for operator metrics (Sovereign-Labs/sovereign-sdk#2838)
- Typed `BlobSubmissionError` variant on `BlobSubmissionStatus` (Sovereign-Labs/sovereign-sdk#2839)
- **`LtxHash` / `LblkHash` / `LsrHash` bech32m-encoded hash types**. `pub type TxHash = LtxHash` flips partner-facing tx hashes from `0x...` to `ltx1...`. Plus the `NumberOrHash` path-deserialiser accepts `ltx1...` paths (so `GET /v1/ledger/txs/ltx1...` works).

## Configuration changes (breaking)

`devnet/rollup.toml` adds two new fields and renames one, all required by the SDK rev bump that Phase 1 absorbed:

```toml
[proof_manager]
+ max_number_of_aggregated_proofs_in_memory = 5

[sequencer]
- max_concurrent_blobs = 128
+ max_concurrent_batch_blobs = 128
+ max_concurrent_proof_blobs = 1024
```

## Smoke test (localnet)

```bash
$ cargo run --bin ligate-node
# ...
$ node /tmp/transfer.mjs
recipient: lig144kp9kf0prs5h29zwy7kw0ma444wa9hdmfc7k3x8feyjcm2dfj9
chain_hash: eec077f4736df42cddb547236468dad32f1fd6822aaad1e822ce596307552df2
nonce: 0n
SUCCESS at nonce=0: tx=ltx1986h2atfrlydz5xyr824jgy5lneg5rjef346xc6ttsmad9e4rt4sffuvv0

$ curl http://localhost:12346/v1/ledger/txs/ltx1986h2atfrlydz5xyr824jgy5lneg5rjef346xc6ttsmad9e4rt4sffuvv0
{ ..., "receipt": { "result": "successful" } }
```

Submit and lookup-by-hash both work end-to-end with `ltx1...` strings.

## What's in the fork's `ligate-mainline` (pinned)

Pinned to commit `236d4c80150f04428ae25f743a0de37132438f2a` (will bump as the fork advances). Branch carries 7 commits on top of `upstream/dev`:

```
72f64e545 Document fork rebase discipline + branch model
236d4c801 Path-parser: NumberOrHash::Hash uses TxHash so ltx1 paths deserialise
4bc29843f Add LtxHash / LblkHash / LsrHash bech32m hash types; alias TxHash to LtxHash
b2e381cdb Add CHANGELOG entry for #2839
0ba809f9e Add typed BlobSubmissionError variant to BlobSubmissionStatus
882e7e621 Add CHANGELOG entry for #2838
6d4c6bdac Add Sequencer::pending_tx_count() for operator metrics
```

## Rebase discipline

When Sovereign advances `dev`, we rebase `ligate-mainline` on top, drop any commits whose corresponding upstream PR has merged, fix conflicts, push. Then bump the `rev` in this `Cargo.toml`. Documented in [`CONTRIBUTING.ligate.md`](https://github.com/ligate-io/sovereign-sdk/blob/ligate-mainline/CONTRIBUTING.ligate.md) on the fork.

## CHAIN_HASH

The new types compile into the runtime schema, so `CHAIN_HASH` shifts the next time we boot. Captured in `chain_state.json` for `ligate-devnet-1` from genesis. Pre-mainnet hard fork classification (per `docs/protocol/upgrades.md`); fresh genesis required.

## Closes / refs

- Closes #256 (the fork-and-bech32m tracking issue)
- Refs Sovereign-Labs/sovereign-sdk#2837 (upstream-pluggable-encoding proposal that would let us retire the fork)
- Refs Sovereign-Labs/sovereign-sdk#2838 + Sovereign-Labs/sovereign-sdk#2839 (the two upstream PRs we're cherry-picking)