### PR TITLE
feat(ops): extend Grafana dashboard with Phase 2 panels (closes #110, #164, #165 follow-up)

### DIFF
--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -1,14 +1,18 @@
 # Grafana dashboard for `ligate-node`
 
-Drop-in Grafana dashboard for the Phase 1 metrics shipped on
-`ligate-node:9100/metrics`. Three rows, eight panels:
+Drop-in Grafana dashboard for the Phase 1 + Phase 2 metrics shipped
+on `ligate-node:9100/metrics`. Five rows, fifteen panels:
 
 - **Chain activity** — schemas registered, attestor sets registered,
   attestation submission rate.
-- **Node health** — block height, state-DB size, RPC request rate by
-  endpoint.
-- **Errors / rejections** — top-10 rejection reasons over the last
-  hour, RPC p95 latency by endpoint.
+- **Node health** — block height, mempool depth, state-DB size, RPC
+  request rate by endpoint.
+- **DA layer** — DA submission failures by reason, DA finalization
+  latency p50 / p95 / p99 (Mocha-aware buckets).
+- **Errors / rejections** — top-10 attestation rejection reasons over
+  the last hour, RPC p95 latency by endpoint.
+- **Process / observability** — process CPU (cores), RSS, open FDs,
+  metrics-dropped rate (broadcast lag).
 
 Tracking issue: [#165](https://github.com/ligate-io/ligate-chain/issues/165).
 
@@ -69,10 +73,17 @@ recreate or fork them without re-importing.
 | Attestor sets registered | `ligate_attestor_sets_registered_total` |
 | Attestations submitted (rate) | `rate(ligate_attestations_submitted_total[5m])` |
 | Block height | `ligate_block_height` |
+| Mempool depth | `ligate_mempool_depth` |
 | State DB size | `ligate_state_db_size_bytes` |
 | RPC requests / sec | `sum by (endpoint) (rate(ligate_rpc_requests_total[5m]))` |
+| DA submission failures (rate, by reason) | `sum by (reason) (rate(ligate_da_submission_failures_total[5m]))` |
+| DA finalization latency p50 / p95 / p99 | `histogram_quantile(0.99, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket[5m])))` |
 | Rejections by reason (top 10) | `topk(10, sum by (reason) (rate(ligate_attestations_rejected_total[1h])))` |
 | RPC p95 latency | `histogram_quantile(0.95, sum by (le, endpoint) (rate(ligate_rpc_request_duration_seconds_bucket[5m])))` |
+| Process CPU (cores) | `rate(process_cpu_seconds_total[5m])` |
+| Process RSS | `process_resident_memory_bytes` |
+| Process open FDs | `process_open_fds` |
+| Metrics dropped (broadcast lagged) | `rate(ligate_metrics_dropped_total[5m])` |
 
 ## Versioning
 
@@ -80,10 +91,12 @@ The dashboard is checked into the repo at `ops/grafana/ligate-node.json`
 with `schemaVersion: 38` (Grafana 10.0+). Future schema bumps update
 the JSON in-place; operators re-import to pick up changes.
 
-When Phase 2 metrics ([#164](https://github.com/ligate-io/ligate-chain/issues/164))
-land — DA submission latency, sequencer-specific signals, RPC error
-histograms — this dashboard grows a fourth row. See [#165](https://github.com/ligate-io/ligate-chain/issues/165)
-for the layout discussion.
+Phase 2 metrics ([#164](https://github.com/ligate-io/ligate-chain/issues/164))
+landed in #281 (mempool, process collector, CHAIN_HASH pin) and #282
+(DA failures, DA finalization latency, broadcast-lag counter). The
+dashboard's "DA layer" and "Process / observability" rows wrap them.
+Future panels for sequencer signals not yet exposed (validator stalls,
+state-trie depth) will land via follow-up issues.
 
 ## Deploying a public Grafana
 

--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Operator dashboard for `ligate-node` Phase 1 metrics (chain #110). Three rows: chain activity, node health, errors / rejections. Imports against any Prometheus instance scraping `:9100/metrics` from a running ligate-node. Tracking issue: https://github.com/ligate-io/ligate-chain/issues/165",
+  "description": "Operator dashboard for `ligate-node` Phase 1 + Phase 2 metrics (chain #110, #164). Four rows: chain activity, node health, DA layer, process / observability. Imports against any Prometheus instance scraping `:9100/metrics` from a running ligate-node.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -58,30 +58,21 @@
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
-          "mappings": [],
           "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
           "unit": "short"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {"h": 5, "w": 6, "x": 0, "y": 1},
       "id": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {"calcs": ["lastNotNull"]},
         "textMode": "auto"
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "ligate_schemas_registered_total",
-          "legendFormat": "schemas",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_schemas_registered_total", "legendFormat": "schemas", "refId": "A"}
       ],
       "title": "Schemas registered",
       "type": "stat"
@@ -101,17 +92,12 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {"calcs": ["lastNotNull"]},
         "textMode": "auto"
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "ligate_attestor_sets_registered_total",
-          "legendFormat": "attestor sets",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_attestor_sets_registered_total", "legendFormat": "attestor sets", "refId": "A"}
       ],
       "title": "Attestor sets registered",
       "type": "stat"
@@ -122,19 +108,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "opacity",
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
-            "showPoints": "never",
-            "spanNulls": false
-          },
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never"},
           "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
           "unit": "ops"
         }
@@ -143,15 +117,10 @@
       "id": 3,
       "options": {
         "legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single", "sort": "none"}
+        "tooltip": {"mode": "single"}
       },
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "rate(ligate_attestations_submitted_total[5m])",
-          "legendFormat": "attestations / sec",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "rate(ligate_attestations_submitted_total[5m])", "legendFormat": "attestations / sec", "refId": "A"}
       ],
       "title": "Attestations submitted (rate)",
       "type": "timeseries"
@@ -166,7 +135,7 @@
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Current head slot number from `LedgerStateProvider`. Climbing = chain producing blocks. Flat for >60s = sequencer halted, DA submission failing, or follower disconnected from RPC.",
+      "description": "Current head slot number from `LedgerStateProvider`. Climbing = chain producing blocks. Flat for >60s = sequencer halted, DA submission failing, or follower disconnected.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -175,26 +144,51 @@
           "unit": "short"
         }
       },
-      "gridPos": {"h": 7, "w": 8, "x": 0, "y": 7},
+      "gridPos": {"h": 7, "w": 6, "x": 0, "y": 7},
       "id": 4,
       "options": {
         "legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true},
         "tooltip": {"mode": "single"}
       },
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "ligate_block_height",
-          "legendFormat": "block height",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_block_height", "legendFormat": "block height", "refId": "A"}
       ],
       "title": "Block height",
       "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Total on-disk allocation under `storage.path` (NOMT + RocksDB ledger + state-db). Useful for capacity planning. Per #171: reports actual on-disk allocation via `meta.blocks() * 512`, not nominal logical size.",
+      "description": "Pending tx count in the sequencer mempool. Sustained growth means the chain isn't including txs as fast as they arrive (DA throughput, validator stalls, or a publish backlog).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 100},
+              {"color": "red", "value": 1000}
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 7, "w": 6, "x": 6, "y": 7},
+      "id": 9,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_mempool_depth", "legendFormat": "pending txs", "refId": "A"}
+      ],
+      "title": "Mempool depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Total on-disk allocation under `storage.path` (NOMT + RocksDB ledger + state-db). Reports actual on-disk allocation via `meta.blocks() * 512`, not nominal logical size.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -210,26 +204,21 @@
           "unit": "bytes"
         }
       },
-      "gridPos": {"h": 7, "w": 8, "x": 8, "y": 7},
+      "gridPos": {"h": 7, "w": 6, "x": 12, "y": 7},
       "id": 5,
       "options": {
         "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
         "tooltip": {"mode": "single"}
       },
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "ligate_state_db_size_bytes",
-          "legendFormat": "state db",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_state_db_size_bytes", "legendFormat": "state db", "refId": "A"}
       ],
       "title": "State DB size",
       "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "RPC request rate by endpoint (5m window). Spikes mean an indexer is back-filling or a faucet is being hammered. Drops to zero mean the public RPC is unreachable.",
+      "description": "RPC request rate by endpoint (5m window). Spikes mean an indexer is back-filling or a faucet is being hammered.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -238,19 +227,14 @@
           "unit": "reqps"
         }
       },
-      "gridPos": {"h": 7, "w": 8, "x": 16, "y": 7},
+      "gridPos": {"h": 7, "w": 6, "x": 18, "y": 7},
       "id": 6,
       "options": {
         "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true},
         "tooltip": {"mode": "multi", "sort": "desc"}
       },
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "sum by (endpoint) (rate(ligate_rpc_requests_total[5m]))",
-          "legendFormat": "{{endpoint}}",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (endpoint) (rate(ligate_rpc_requests_total[5m]))", "legendFormat": "{{endpoint}}", "refId": "A"}
       ],
       "title": "RPC requests / sec (by endpoint)",
       "type": "timeseries"
@@ -258,6 +242,69 @@
     {
       "collapsed": false,
       "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+      "id": 250,
+      "panels": [],
+      "title": "DA layer",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Rate of DA submission failures by typed-error discriminant. Non-zero is operator-actionable. Reasons: `submission` (RPC error), `publish_timeout` (no inclusion within deadline), `reorg` (DA re-org), `finality_check` (finality query failed), `max_retries_exhausted` (rollup shutdown).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 1, "showPoints": "never", "stacking": {"mode": "normal"}},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 0.001}]},
+          "unit": "ops"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "id": 10,
+      "options": {
+        "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (reason) (rate(ligate_da_submission_failures_total[5m]))", "legendFormat": "{{reason}}", "refId": "A"}
+      ],
+      "title": "DA submission failures (rate, by reason)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "DA finalization latency: time from `Published` to `Finalized` for each blob. Mocha block time ~12s. Rising p99 means Celestia is slow to finalize, often a sign the network is congested or our light node is lagging.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 60},
+              {"color": "red", "value": 300}
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "id": 11,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true},
+        "tooltip": {"mode": "multi"}
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.50, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket[5m])))", "legendFormat": "p50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket[5m])))", "legendFormat": "p95", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket[5m])))", "legendFormat": "p99", "refId": "C"}
+      ],
+      "title": "DA finalization latency (Published -> Finalized)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
       "id": 300,
       "panels": [],
       "title": "Errors / rejections",
@@ -265,35 +312,30 @@
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Top rejection reasons over the last hour. Surfaces when builders are submitting attestations the chain refuses (unknown_schema, below_threshold, invalid_signature, duplicate_attestation, etc.). Each `reason` is one of the 18 stable snake_case discriminants on `AttestationError`.",
+      "description": "Top rejection reasons over the last hour. Each `reason` is one of the stable snake_case discriminants on `AttestationError`.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
-          "custom": {"axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "lineWidth": 1, "showPoints": "never", "stacking": {"mode": "normal"}},
+          "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "showPoints": "never", "stacking": {"mode": "normal"}},
           "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
           "unit": "short"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
       "id": 7,
       "options": {
         "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true},
         "tooltip": {"mode": "multi", "sort": "desc"}
       },
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "topk(10, sum by (reason) (rate(ligate_attestations_rejected_total[1h])))",
-          "legendFormat": "{{reason}}",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "topk(10, sum by (reason) (rate(ligate_attestations_rejected_total[1h])))", "legendFormat": "{{reason}}", "refId": "A"}
       ],
-      "title": "Rejections by reason (top 10, 1h)",
+      "title": "Attestation rejections by reason (top 10, 1h)",
       "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "p95 RPC latency by endpoint (5m window). Spikes to multi-second territory mean RocksDB iteration is slow (often a sign of fragmented compaction state) or the chain is producing blocks faster than the indexer can keep up.",
+      "description": "p95 RPC latency by endpoint (5m window). Spikes to multi-second territory mean RocksDB iteration is slow or the chain is producing blocks faster than the indexer can keep up.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -309,21 +351,130 @@
           "unit": "s"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24},
       "id": 8,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true},
         "tooltip": {"mode": "multi"}
       },
       "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-          "expr": "histogram_quantile(0.95, sum by (le, endpoint) (rate(ligate_rpc_request_duration_seconds_bucket[5m])))",
-          "legendFormat": "{{endpoint}}",
-          "refId": "A"
-        }
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le, endpoint) (rate(ligate_rpc_request_duration_seconds_bucket[5m])))", "legendFormat": "{{endpoint}}", "refId": "A"}
       ],
       "title": "RPC latency p95 (by endpoint)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+      "id": 400,
+      "panels": [],
+      "title": "Process / observability",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "CPU usage as a fraction of one core (5m rate). Linux only — non-Linux builds skip the process_collector. >0.8 sustained is a sign we're CPU-bound.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.8},
+              {"color": "red", "value": 1.5}
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {"h": 7, "w": 6, "x": 0, "y": 33},
+      "id": 12,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "rate(process_cpu_seconds_total[5m])", "legendFormat": "cores", "refId": "A"}
+      ],
+      "title": "Process CPU (cores)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Resident set size (RSS) of the ligate-node process. Linux only.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {"h": 7, "w": 6, "x": 6, "y": 33},
+      "id": 13,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "process_resident_memory_bytes", "legendFormat": "RSS", "refId": "A"}
+      ],
+      "title": "Process RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Open file descriptors. Climbing without bound means a leak (most likely a tokio task that never drops a TCP socket). Linux only.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1024},
+              {"color": "red", "value": 4096}
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 7, "w": 6, "x": 12, "y": 33},
+      "id": 14,
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "process_open_fds", "legendFormat": "open FDs", "refId": "A"}
+      ],
+      "title": "Process open FDs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Rate of metric events dropped because a metric observer's broadcast receiver lagged. Non-zero rate means we need to widen the BlobSender broadcast channel (currently 1024) or speed up the consumer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"drawStyle": "line", "fillOpacity": 30, "lineWidth": 2, "showPoints": "never"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 0.001}]},
+          "unit": "ops"
+        }
+      },
+      "gridPos": {"h": 7, "w": 6, "x": 18, "y": 33},
+      "id": 15,
+      "options": {
+        "legend": {"calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "rate(ligate_metrics_dropped_total[5m])", "legendFormat": "dropped/sec", "refId": "A"}
+      ],
+      "title": "Metrics dropped (broadcast lagged)",
       "type": "timeseries"
     }
   ],
@@ -353,6 +504,6 @@
   "timezone": "",
   "title": "Ligate Chain — ligate-node",
   "uid": "ligate-node",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

Phase 6.3 of #110: extends the existing `ops/grafana/ligate-node.json` dashboard with panels for the Phase 2 metrics that landed in #281 (mempool, process collector) and #282 (DA failures + finalization latency + broadcast lag counter).

Five rows / fifteen panels total now:

1. **Chain activity** — schemas / attestor sets / attestations submitted (rate)
2. **Node health** — block height, **mempool depth (new)**, state DB size, RPC requests/sec
3. **DA layer (new row)** — **DA submission failures by reason (new)**, **DA finalization latency p50/p95/p99 (new)**
4. **Errors / rejections** — top-10 attestation rejection reasons, RPC p95 latency
5. **Process / observability (new row)** — **process CPU/RSS/FDs (new, Linux-only)**, **metrics dropped rate (new)**

## Changes

- `ops/grafana/ligate-node.json` — added 7 panels (mempool depth, DA failures, DA latency, process CPU, RSS, open FDs, metrics dropped). Two new row separators (DA layer, Process / observability). All panel queries match metric names exactly as registered in `crates/rollup/src/metrics.rs`.
- `ops/grafana/README.md` — bumped to "5 rows / 15 panels", added new queries to the PromQL reference table, updated the Phase 2 status note.

## Verified

- `python3 -c 'import json; json.load(open("ops/grafana/ligate-node.json"))'` — JSON parses cleanly.
- Every panel query references a metric name we ship today (verified against `metrics.rs` + `attestation/src/metrics.rs`).
- Histogram queries use `histogram_quantile(...)` against `_bucket` series; bucket suffix is conventional for `prometheus::Histogram`.

## Manual verification (operator-side)

After import:
- Mocha-style: DA finalization p99 should land in the 12s-60s band on a healthy chain.
- Mempool depth idle on devnet (sequencer drains every batch); spikes during load tests.
- Metrics dropped rate should be flat-zero unless we're DoS'ing the chain.

## Refs

- #110 Prometheus + Grafana umbrella (Phase 1+2 dashboard parity reached)
- #164 Phase 2 metrics
- #165 starter Grafana dashboard (this is the layout discussion's resolution)
- #234 public Grafana host (will consume this dashboard)
- #281 Phase 6.1 metrics merged
- #282 Phase 6.2 metrics merged

## Test plan

- [x] JSON validates
- [x] Every metric name matches registered metric in code
- [x] README query reference matches dashboard queries
- [ ] CI green
- [ ] Manual import into a Grafana 10.x instance (operator follow-up)