### PR TITLE
fix(info): /v1/rollup/info chain_hash now bech32m (lsch1...) to match /v1/rollup/schema

### DIFF
--- a/crates/rollup/src/info.rs
+++ b/crates/rollup/src/info.rs
@@ -8,9 +8,11 @@
 //!   Bumps on state-breaking restarts only; stable across STF
 //!   upgrades.
 //! - `chain_hash`: the runtime's build-script-generated 32-byte
-//!   `CHAIN_HASH`, hex-encoded. Bumps on every runtime composition
-//!   change (added module, changed const, etc.). Used for tx
-//!   replay-protection in the signing domain.
+//!   `CHAIN_HASH`, bech32m-encoded with HRP `lsch` (`lsch1...`).
+//!   Matches the format used by the SDK's `/v1/rollup/schema`
+//!   endpoint so partners see the same identifier on both surfaces.
+//!   Bumps on every runtime composition change (added module, changed
+//!   const, etc.); used for tx replay-protection in the signing domain.
 //! - `version`: the `ligate-node` binary version (`CARGO_PKG_VERSION`).
 //!
 //! Why three: `chain_id` is the human-readable network identifier that
@@ -26,6 +28,7 @@ use axum::extract::State;
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
+use sov_rollup_interface::ChainHash;
 
 /// Inner state of the `/v1/rollup/info` handler.
 ///
@@ -51,8 +54,10 @@ impl InfoState {
 pub struct RollupInfo {
     /// Cosmos-style chain identifier from the `[chain]` config section.
     pub chain_id: String,
-    /// Runtime's build-time `CHAIN_HASH`, hex-encoded (lowercase, no
-    /// `0x` prefix, 64 chars).
+    /// Runtime's build-time `CHAIN_HASH`, bech32m-encoded with HRP
+    /// `lsch` (`lsch1...`). Matches the SDK's `/v1/rollup/schema`
+    /// response shape so wallets see one identifier across both
+    /// surfaces.
     pub chain_hash: String,
     /// `ligate-node` binary version (semver per `CARGO_PKG_VERSION`).
     pub version: String,
@@ -83,53 +88,21 @@ pub fn router_for_test(chain_id: impl Into<std::sync::Arc<str>>, chain_hash: [u8
 async fn handle_info(State(state): State<InfoState>) -> Json<RollupInfo> {
     Json(RollupInfo {
         chain_id: state.chain_id.to_string(),
-        chain_hash: hex_encode_lower(&state.chain_hash),
+        chain_hash: ChainHash::new(state.chain_hash).to_string(),
         version: state.version.to_string(),
     })
-}
-
-/// Lowercase hex encode, no separators, no `0x` prefix.
-///
-/// Inlined rather than pulling the `hex` crate; the chain_hash is the
-/// only place we need it on this code path.
-fn hex_encode_lower(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        // The two-char `{:02x}` form left-pads single-digit values
-        // with a `0`. Without the `02`, `0x0a` would render as `a`
-        // and break the fixed-width hex contract.
-        use std::fmt::Write as _;
-        let _ = write!(out, "{b:02x}");
-    }
-    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn hex_encode_lower_pads_single_digits() {
-        // 0x0A must render as "0a", not "a", so a 32-byte hash always
-        // produces 64 chars regardless of byte values.
-        assert_eq!(hex_encode_lower(&[0x0a]), "0a");
-        assert_eq!(hex_encode_lower(&[0xff, 0x00, 0x10]), "ff0010");
-    }
-
-    #[test]
-    fn hex_encode_lower_round_trips_zero_bytes() {
-        let zeros = [0u8; 32];
-        let s = hex_encode_lower(&zeros);
-        assert_eq!(s.len(), 64);
-        assert!(s.chars().all(|c| c == '0'));
-    }
-
     #[tokio::test(flavor = "multi_thread")]
     async fn info_endpoint_returns_configured_values() {
         // Spawn the router on an ephemeral port and hit `/rollup/info`
         // with a real HTTP client. Verifies the wire shape end-to-end:
-        // chain_id from state, chain_hash hex-encoded, version from
-        // env.
+        // chain_id from state, chain_hash bech32m-encoded, version
+        // from env.
         let state = InfoState::new("ligate-localnet", [0xABu8; 32]);
         let app: Router<()> = add_routes(Router::new(), state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
@@ -143,10 +116,11 @@ mod tests {
         assert_eq!(resp.status().as_u16(), 200);
         let body: RollupInfo = resp.json().await.expect("json");
         assert_eq!(body.chain_id, "ligate-localnet");
-        assert_eq!(
-            body.chain_hash,
-            "abababababababababababababababababababababababababababababababab"
-        );
+        // bech32m with HRP `lsch`. Decoding it back must yield the
+        // same 32 bytes we configured.
+        assert!(body.chain_hash.starts_with("lsch1"), "got {}", body.chain_hash);
+        let parsed: ChainHash = body.chain_hash.parse().expect("parse bech32m");
+        assert_eq!(parsed.0, [0xABu8; 32]);
         assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
     }
 }

--- a/crates/rollup/tests/info_smoke.rs
+++ b/crates/rollup/tests/info_smoke.rs
@@ -7,10 +7,10 @@
 //! Catches:
 //!
 //! 1. Router wiring + `State` extractor for `InfoState`.
-//! 2. JSON shape: `{"chain_id":"...","chain_hash":"...","version":"..."}`.
-//! 3. `chain_hash` always renders as exactly 64 hex chars (no `0x`
-//!    prefix, lowercase, padded). A regression here would break
-//!    wallets and explorers reading the value.
+//! 2. JSON shape: `{"chain_id":"...","chain_hash":"lsch1...","version":"..."}`.
+//! 3. `chain_hash` always renders as bech32m with HRP `lsch`, so a
+//!    regression in the encoder breaks wallets / explorers reading
+//!    the value. Decode round-trip pins the bytes.
 //! 4. The `version` field reflects the binary's `CARGO_PKG_VERSION`.
 //!
 //! Tracking issue: #181.
@@ -19,6 +19,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use ligate_rollup::info::{self, RollupInfo};
+use sov_rollup_interface::ChainHash;
 use tokio::net::TcpListener;
 
 async fn spawn_info_server(chain_id: &'static str, chain_hash: [u8; 32]) -> SocketAddr {
@@ -51,20 +52,25 @@ async fn info_returns_configured_chain_id_and_hash() {
 
     let body: RollupInfo = resp.json().await.expect("response is JSON of expected shape");
     assert_eq!(body.chain_id, "ligate-localnet");
-    assert_eq!(
-        body.chain_hash, "1212121212121212121212121212121212121212121212121212121212121212",
-        "chain_hash hex must be lowercase, 64 chars, no 0x prefix"
+    assert!(
+        body.chain_hash.starts_with("lsch1"),
+        "chain_hash must be bech32m with HRP `lsch`, got {}",
+        body.chain_hash
     );
+    let parsed: ChainHash = body.chain_hash.parse().expect("bech32m parses");
+    assert_eq!(parsed.0, chain_hash, "chain_hash decodes back to the configured bytes");
     assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn info_renders_zero_chain_hash_as_64_zeros() {
+async fn info_round_trips_zero_chain_hash() {
     // The placeholder CHAIN_HASH ([0; 32]) only fires before
     // `build.rs` has run; production never serves it. Snapshot the
-    // hex shape anyway so a regression in the encoder (e.g. dropping
-    // leading zeros) is caught even on the placeholder.
-    let addr = spawn_info_server("ligate-localnet", [0u8; 32]).await;
+    // bech32m shape anyway so a regression in the encoder (e.g.
+    // changing HRP, dropping leading bytes) is caught even on the
+    // placeholder.
+    let zeros = [0u8; 32];
+    let addr = spawn_info_server("ligate-localnet", zeros).await;
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
@@ -80,8 +86,9 @@ async fn info_renders_zero_chain_hash_as_64_zeros() {
         .await
         .expect("body parses");
 
-    assert_eq!(body.chain_hash.len(), 64);
-    assert!(body.chain_hash.chars().all(|c| c == '0'));
+    assert!(body.chain_hash.starts_with("lsch1"), "got {}", body.chain_hash);
+    let parsed: ChainHash = body.chain_hash.parse().expect("bech32m parses");
+    assert_eq!(parsed.0, zeros);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

The chain-specific `/v1/rollup/info` endpoint still emitted `chain_hash` as raw hex (`eec077f4...`) while the SDK-mounted `/v1/rollup/schema` already returns the bech32m form (`lsch1...`). One node, two different formats for the same value — embarrassing for partners and a forklift bug waiting to happen.

This patch encodes through `ChainHash::new(...)` so both endpoints agree on `lsch1...`.

## Verification

Localnet smoke against the patched binary:

```
GET /v1/rollup/info       -> "chain_hash": "lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v"
GET /v1/rollup/schema     -> "chain_hash": "lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v"
```

## Changes

- `crates/rollup/src/info.rs`
  - `handle_info` now encodes `chain_hash` via `ChainHash::new(...).to_string()`.
  - Dropped the inlined `hex_encode_lower` helper (no other callers).
  - Inline unit test updated to assert `lsch1` prefix + decode round-trip.
- `crates/rollup/tests/info_smoke.rs`
  - `info_returns_configured_chain_id_and_hash`: bech32m prefix check + decode round-trip against the configured bytes.
  - `info_renders_zero_chain_hash_as_64_zeros` → renamed to `info_round_trips_zero_chain_hash`. The placeholder `[0; 32]` value still encodes (now as `lsch1qq...`) and decodes back to zero bytes.
  - Module docstring updated to reflect the new format.

## Refs

- Closes the `/v1/rollup/info` row of the partner-visible hex audit done in the bech32m work (#256, #261).
- #181 chain id ladder (the endpoint this PR patches).
- Phase 6 closes the public-facing hex surface; this is the last chain-specific endpoint that lagged.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p ligate-rollup --all-targets -- -D warnings` clean
- [x] `cargo test -p ligate-rollup --test info_smoke --lib` green (3 integration + 20 lib tests)
- [x] Localnet smoke: both endpoints return the same `lsch1...` value
- [ ] CI green