### PR TITLE
feat(attestation): emit typed AttestationEvents on register / submit calls (closes #295)

### DIFF
--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -98,8 +98,8 @@ use sha2::{Digest, Sha256};
 use sov_bank::{Amount, Bank, Coins, TokenId};
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
-    Context, DaSpec, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, SafeString,
-    SafeVec, Spec, StateMap, StateValue, TxState,
+    Context, DaSpec, EventEmitter, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi,
+    SafeString, SafeVec, Spec, StateMap, StateValue, TxState,
 };
 use thiserror::Error as ThisError;
 
@@ -1138,21 +1138,84 @@ impl AttestationError {
     Deserialize,
     schemars::JsonSchema,
 )]
+#[schemars(bound = "S: Spec", rename = "AttestationEvent")]
 #[non_exhaustive]
-pub enum AttestationEvent {
-    /// Placeholder variant. Never emitted in v0; reserved so the enum
-    /// is non-empty (Borsh derives require at least one variant on
-    /// enums) without committing to an event shape we'd later
-    /// regret. Real events land alongside the query RPC in #21.
+pub enum AttestationEvent<S: Spec> {
+    /// Placeholder variant. Never emitted; kept so older borsh-decoded
+    /// streams that wrote this variant still round-trip. Subsequent
+    /// variants are the real events the module emits at call time.
     #[doc(hidden)]
     Reserved,
+
+    /// Emitted on successful [`CallMessage::RegisterAttestorSet`].
+    ///
+    /// `members` carries the sorted post-canonicalisation list (matches
+    /// what's stored under `attestor_sets[id]`). `registered_by` is the
+    /// tx sender (paid the registration fee).
+    ///
+    /// Indexers key off `"Attestation/AttestorSetRegistered"`; see
+    /// `ligate-api/crates/indexer/src/parser.rs` for the consumer side.
+    AttestorSetRegistered {
+        /// Deterministic [`AttestorSetId`] (bech32m `las1...`).
+        attestor_set_id: AttestorSetId,
+        /// Member pubkeys, sorted by raw bytes per the canonicalisation
+        /// rule used by `derive_id`.
+        members: Vec<PubKey>,
+        /// M-of-N threshold (1..=members.len()).
+        threshold: u8,
+        /// Tx sender who paid the registration fee.
+        registered_by: S::Address,
+    },
+
+    /// Emitted on successful [`CallMessage::RegisterSchema`]. Carries
+    /// every column `ligate-api`'s `schemas` table needs to ingest
+    /// directly from the event (no follow-up state read required).
+    SchemaRegistered {
+        /// Deterministic [`SchemaId`] (bech32m `lsc1...`).
+        schema_id: SchemaId,
+        /// Schema name (e.g. `"themisra.proof-of-prompt"`).
+        name: String,
+        /// Schema version (monotonic per name+owner).
+        version: u32,
+        /// Owner address — receives schema-routed fees.
+        owner: S::Address,
+        /// Bound attestor set; submissions must carry signatures from
+        /// members of this set.
+        attestor_set_id: AttestorSetId,
+        /// Fee-routing share in basis points (0..=`max_builder_bps`).
+        fee_routing_bps: u16,
+        /// Destination address for the routed share (required iff
+        /// `fee_routing_bps > 0`).
+        fee_routing_addr: Option<S::Address>,
+        /// SHA-256 of the canonical schema-doc bytes.
+        payload_shape_hash: Hash32,
+    },
+
+    /// Emitted on successful [`CallMessage::SubmitAttestation`].
+    ///
+    /// `signature_count` matches `attestations[id].signatures.len()` —
+    /// always >= the bound schema's threshold (enforced upstream of
+    /// the emit). Submitter pubkey isn't carried at the call site so
+    /// only the address is exposed; partners who need the raw pubkey
+    /// can resolve it from `accounts` state.
+    AttestationSubmitted {
+        /// Schema this attestation is bound to.
+        schema_id: SchemaId,
+        /// SHA-256 of the off-chain payload that was attested.
+        payload_hash: PayloadHash,
+        /// Tx sender (the address that submitted the attestation;
+        /// pays the attestation fee).
+        submitter: S::Address,
+        /// Number of attestor signatures included in the submission.
+        signature_count: u32,
+    },
 }
 
 impl<S: Spec> Module for AttestationModule<S> {
     type Spec = S;
     type Config = AttestationConfig<S>;
     type CallMessage = CallMessage<S>;
-    type Event = AttestationEvent;
+    type Event = AttestationEvent<S>;
     type Error = anyhow::Error;
 
     fn genesis(
@@ -1347,7 +1410,24 @@ impl<S: Spec> AttestationModule<S> {
         let fee = self.attestor_set_fee.get(state)?.unwrap_or(DEFAULT_ATTESTOR_SET_FEE_LGT_NANOS);
         self.charge_to_treasury(context.sender(), fee, state)?;
 
-        self.attestor_sets.set(&id, &AttestorSet { members: sorted_members, threshold }, state)?;
+        self.attestor_sets.set(
+            &id,
+            &AttestorSet { members: sorted_members.clone(), threshold },
+            state,
+        )?;
+
+        // Emit typed event so the indexer (and any other consumer)
+        // can ingest from the event stream without a follow-up state
+        // read. Key auto-generates as `"Attestation/AttestorSetRegistered"`.
+        self.emit_event(
+            state,
+            AttestationEvent::AttestorSetRegistered {
+                attestor_set_id: id,
+                members: sorted_members,
+                threshold,
+                registered_by: *context.sender(),
+            },
+        );
 
         #[cfg(feature = "native")]
         metrics::record_attestor_set_registered();
@@ -1402,7 +1482,7 @@ impl<S: Spec> AttestationModule<S> {
             &id,
             &Schema {
                 owner,
-                name,
+                name: name.clone(),
                 version,
                 attestor_set,
                 fee_routing_bps,
@@ -1411,6 +1491,23 @@ impl<S: Spec> AttestationModule<S> {
             },
             state,
         )?;
+
+        // Emit typed event with every column the indexer's `schemas`
+        // table requires. Key auto-generates as
+        // `"Attestation/SchemaRegistered"`.
+        self.emit_event(
+            state,
+            AttestationEvent::SchemaRegistered {
+                schema_id: id,
+                name,
+                version,
+                owner,
+                attestor_set_id: attestor_set,
+                fee_routing_bps,
+                fee_routing_addr,
+                payload_shape_hash,
+            },
+        );
 
         #[cfg(feature = "native")]
         metrics::record_schema_registered();
@@ -1484,11 +1581,24 @@ impl<S: Spec> AttestationModule<S> {
             }
         }
 
+        let signature_count = signatures.len() as u32;
         self.attestations.set(
             &attestation_id,
             &Attestation { schema_id, payload_hash, submitter, timestamp, signatures },
             state,
         )?;
+
+        // Emit typed event. Key auto-generates as
+        // `"Attestation/AttestationSubmitted"`.
+        self.emit_event(
+            state,
+            AttestationEvent::AttestationSubmitted {
+                schema_id,
+                payload_hash,
+                submitter,
+                signature_count,
+            },
+        );
 
         #[cfg(feature = "native")]
         metrics::record_attestation_submitted();


### PR DESCRIPTION
## Summary

Resolves #295. Adds three typed event variants to \`AttestationEvent\` and emits each from its corresponding handler, so the on-chain event stream now carries every column ligate-api's indexer needs to ingest \`attestor_sets\` / \`schemas\` / \`attestations\` tables directly — no follow-up state read required.

Until this PR landed, \`AttestationEvent\` had only the \`Reserved\` placeholder and \`call(...)\` paths emitted nothing. ligate-api's indexer (Phase B / PR #16) keys off events to classify tx kinds; with no Attestation-module events, every register / submit tx classified as \`Unknown\` and the indexer's \`schemas\` / \`attestor_sets\` / \`attestations\` tables sat empty. The earlier PR #19 in ligate-api added a workaround that normalises hex/bech32m hash comparisons across event-vs-tx mismatch; this PR closes the bigger gap by giving the indexer real typed event payloads to work from.

## Changes

\`crates/modules/attestation/src/lib.rs\`:

- **\`AttestationEvent\` becomes generic over \`S: Spec\`** so it can carry \`S::Address\` fields. Pattern mirrors sov-bank's \`Event<S: Spec>\` (\`#[schemars(bound = \"S: Spec\", rename = \"AttestationEvent\")]\`).
- \`type Event = AttestationEvent\` → \`type Event = AttestationEvent<S>\` in the Module impl.
- **Three new variants** plus the retained \`Reserved\` placeholder (kept for borsh round-trip of any older serialised stream that might exist):

  - \`AttestorSetRegistered { attestor_set_id, members, threshold, registered_by }\` — carries the sorted post-canonicalisation \`members\` list matching what \`attestor_sets[id]\` stores. \`registered_by\` is the tx sender who paid the fee.
  - \`SchemaRegistered { schema_id, name, version, owner, attestor_set_id, fee_routing_bps, fee_routing_addr, payload_shape_hash }\` — every column \`ligate-api\`'s \`schemas\` table requires.
  - \`AttestationSubmitted { schema_id, payload_hash, submitter, signature_count }\` — \`signature_count\` matches the stored signatures vec length (always >= the bound schema's threshold; chain enforces upstream of the emit).
- **\`self.emit_event(state, AttestationEvent::...)\`** call sites added at the success path of each handler, just before the metric record. Imports \`EventEmitter\` from \`sov_modules_api\`. The SDK auto-keys events as \`\"Attestation/<VariantName>\"\` so indexers can filter on \`Attestation/AttestorSetRegistered\`, \`Attestation/SchemaRegistered\`, \`Attestation/AttestationSubmitted\`.

### Design notes baked into the variant docstrings

- **No \`submitter_pubkey\`** in \`AttestationSubmitted\` — the call-site \`Context\` doesn't expose the raw pubkey (only the derived address). Partners who need it can resolve it from the \`accounts\` module's state by address. Updated the chain-side spec I'd filed in #295 to drop this field; indexer side stays unaffected since \`pubkey\` isn't a column the \`attestations\` table requires.
- **Backward compat**: the existing \`Reserved\` variant stays so any borsh blob that happened to encode it (none today, but defensively) still round-trips. Adding new variants to a \`#[non_exhaustive]\` borsh enum is a soft fork — the discriminator widens, downstream decoders that don't know the new variants fail loudly rather than silently misinterpret.

## Test plan

- [x] \`cargo check -p attestation --features=native\` clean.
- [x] \`cargo check --workspace\` clean (14.43s).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo test -p attestation --features=native\` — 10/10 pass (existing integration tests in \`crates/modules/attestation/tests/integration.rs\`; doc tests + state tests still green).
- [ ] **Pending**: live local smoke against ligate-api's indexer once Phase D lands. The end-to-end signal is: register an attestor set via \`ligate-cli\`, watch \`/v1/ledger/slots/{n}/events\` return \`Attestation/AttestorSetRegistered\` with the new payload, watch the indexer write a row into \`attestor_sets\`.

## Refs

- Closes #295 (which I filed earlier when ligate-api PR #16 needed a typed-events upstream to classify register / submit txs).
- ligate-api Phase D (next PR in the queue) — the consumer side: extends \`parser::classify_events\` with the three new event keys, adds \`db::insert_attestor_set\` / \`insert_schema\` / \`insert_attestation\`, wires into the ingest loop.
- ligate-api Phase E (PR after D) — implements the \`/v1/schemas\` / \`/v1/attestor-sets/{id}\` handlers reading the now-populated tables.