### PR TITLE
docs: operator runbooks cluster + partner quickstart

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -93,6 +93,7 @@ packages:
   - git
   - jq
   - rsync
+  - chrony
 
 write_files:
   - path: /etc/systemd/system/celestia-light.service
@@ -175,6 +176,47 @@ The cloud-init does the chassis. The operator still has to:
   RUST_LOG=info,sov=info
   ```
 - `systemctl enable --now ligate-node.service`.
+
+## Step 2.5: NTP / clock sync (required)
+
+`ligate-node` stamps each slot with `Time::now()` at production. Operators whose host clocks disagree by more than a second produce skewed `slot.timestamp` values, which corrupts dashboards / SLA computations and — once attesters are in the loop — can drive quorum disputes when attesters disagree on whether a batch arrived before its deadline.
+
+This step is not optional on bare-metal. GCP, AWS, and Azure all run managed NTP by default and the cloud-init above installs `chrony` as belt-and-braces. Verify before starting `ligate-node`:
+
+```bash
+chronyc tracking | grep -E "Reference|Stratum|System time|Last offset"
+# Expected: System time drift < 1.0 seconds, Last offset within a few ms
+```
+
+If `chronyc tracking` reports drift > 1s or shows the system as unsynchronised, fix it before starting the node. Common causes:
+
+- **Air-gapped or firewall-blocked machine.** `chrony` defaults to public NTP pools; if outbound UDP/123 is blocked you'll never sync. Either open the port to `pool.ntp.org`, or point `chrony` at an internal NTP server via `/etc/chrony/chrony.conf` (`server <internal-ntp> iburst` line).
+- **VM clock drift after host migration.** GCP live-migration occasionally jumps the clock. `chronyc makestep` once to correct, then verify with `chronyc tracking`.
+- **macOS workstation hosting `ligate-node` for local dev.** The system uses `timed` rather than chrony; verify with `sudo sntp -sS time.apple.com`. Same < 1s requirement.
+
+### Failure mode if drift exceeds threshold
+
+The chain doesn't refuse to start with a skewed clock — it just produces bad data. What you observe:
+
+- `slot.timestamp` values from this sequencer drift relative to wall clock and to other operators' followers.
+- Dashboards that compute "blocks per second" from timestamps misreport.
+- Once attesters check timestamp claims against their own clocks (post-#268 attester-side checks), attesters disagree on whether a batch is fresh enough; quorum disputes appear in attester logs.
+
+The simplest mitigation is to never let drift get to that point. The `chronyc tracking` check above takes 2 seconds to run. Wire it into your monitoring (the [#268](https://github.com/ligate-io/ligate-chain/issues/268) Alertmanager work has a candidate `clock_skew_seconds` metric for exactly this).
+
+### Optional: clock-skew Prometheus metric
+
+A follow-up to this section: expose `ligate_node_clock_skew_seconds` from `ligate-node` itself by comparing `Time::now()` against an external NTP source on a 30s tick. Pair with an Alertmanager rule:
+
+```yaml
+- alert: LigateNodeClockSkew
+  expr: abs(ligate_node_clock_skew_seconds) > 1.0
+  for: 2m
+  annotations:
+    runbook: docs/development/public-devnet-deploy.md#step-25-ntp--clock-sync-required
+```
+
+Tracked as a follow-up to [#268](https://github.com/ligate-io/ligate-chain/issues/268).
 
 ## Step 3: Caddy reverse proxy + TLS
 

--- a/docs/development/quickstart-partner.md
+++ b/docs/development/quickstart-partner.md
@@ -1,0 +1,219 @@
+# Partner Quickstart — Zero to First Attestation on `ligate-devnet-1`
+
+**Status:** Pre-devnet. The flow below is what `ligate-devnet-1` will support on Day 1 (target Q2 2026). Sections marked with **⚠ Preview** are wired in code but the public infrastructure they depend on (faucet, hosted RPC, canonical schemas, explorer) is still spinning up.
+
+This page takes a partner from "I just heard about Ligate" to "my first attestation landed on the public chain" in one continuous flow. No tribal knowledge, no jumping between three doc sites.
+
+If you're building the protocol (chain core, modules, SDK), [`docs/protocol/attestation-v0.md`](../protocol/attestation-v0.md) is the right entry point instead.
+
+---
+
+## 0. What you'll need
+
+| Item | Source |
+|---|---|
+| `ligate-cli` binary | Pre-built tarball from [`ligate-io/ligate-cli` releases](https://github.com/ligate-io/ligate-cli/releases), or `cargo install --git` (fallback). [Install docs](https://github.com/ligate-io/ligate-cli#install). |
+| A ligate address with `$LGT` | Generate locally + claim from the devnet faucet. Steps 1–3. |
+| Optional: an attestor set you trust | The canonical Themisra set ships with devnet-1. Step 4 documents how to discover it. |
+
+You do NOT need:
+
+- A node binary. Partners talk to the hosted public RPC, not their own node.
+- A keystore service. `ligate-cli` writes keys to the OS-default data dir (mode 0600) by default.
+
+---
+
+## 1. Install `ligate-cli`
+
+```bash
+# Pick the platform tarball from the latest release. PLATFORM is one
+# of: linux-amd64, linux-arm64, darwin-arm64, darwin-amd64.
+curl -L -o ligate.tar.gz \
+  https://github.com/ligate-io/ligate-cli/releases/latest/download/ligate-PLATFORM.tar.gz
+tar -xzf ligate.tar.gz
+sudo mv ligate /usr/local/bin/
+ligate --help
+```
+
+Verify the binary speaks to the public devnet:
+
+```bash
+$ ligate --rpc https://rpc.ligate.io info
+chain_id:   ligate-devnet-1
+chain_hash: lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v
+version:    0.1.0-devnet
+```
+
+Set `LIGATE_RPC=https://rpc.ligate.io` in your shell so subsequent commands don't need `--rpc`.
+
+---
+
+## 2. Generate a keypair
+
+```bash
+$ ligate keys generate --name first
+generated keypair:
+  role:    first
+  address: lig1u8z2rxh6ymjwkqsasme64f5kfphtfm2kf4kkn0clusfpr34amezsp5j7yp
+  key:     ~/Library/Application Support/io.ligate.cli/keys/first.key (mode 0600)
+```
+
+The private key never leaves your machine. The address is what partners trade and the chain references. Address derivation rule: `pubkey[..28]`, bech32m-encoded with the `lig` HRP.
+
+If you want to inspect the address later:
+
+```bash
+$ ligate keys show first
+lig1u8z2rxh6ymjwkqsasme64f5kfphtfm2kf4kkn0clusfpr34amezsp5j7yp
+```
+
+---
+
+## 3. Get `$LGT` from the faucet
+
+⚠ **Preview**: `faucet.ligate.io` infrastructure is on the pre-devnet checklist. Until then, the flow uses the same endpoint from a localnet node.
+
+```bash
+$ ligate faucet $(ligate keys show first)
+dripped 1 $LGT to lig1u8z2rxh6ymjwkqsasme64f5kfphtfm2kf4kkn0clusfpr34amezsp5j7yp
+tx_hash: ltx1qqu226ttcgnq8rv5x0klvxalv9pkk2hwkj8s8w834a4p7tgznvts0sekwe
+```
+
+Verify the balance arrived (the faucet waits for chain inclusion before returning, so this should be non-zero immediately):
+
+```bash
+$ ligate balance $(ligate keys show first) \
+    --token-id token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7
+lig1u8z2rxh6ymjwkqsasme64f5kfphtfm2kf4kkn0clusfpr34amezsp5j7yp: 1.000000000 $LGT (1000000000 nano)
+```
+
+Rate limit: one drip per address per 24 hours on devnet-1. If you need more for testing, ask in `#dev` (Discord pending) or run a localnet node.
+
+---
+
+## 4. Pick a canonical schema
+
+⚠ **Preview**: canonical schemas land at genesis on devnet-1. List them via the indexer:
+
+```bash
+$ curl -s https://api.ligate.io/v1/schemas | jq -r '.data[] | "\(.id) \(.name) v\(.version)"'
+lsc1abc... themisra.proof-of-prompt 1
+lsc1def... themisra.content-provenance 1
+```
+
+For a partner just exploring, **`themisra.proof-of-prompt/v1`** is the canonical demo schema: it attests "this prompt was sent to this model and produced this output." Documented in [LIP-1 (RFC 0001 in the marketing repo)](https://docs.ligate.io/lips/lip-1).
+
+Inspect one:
+
+```bash
+$ curl -s https://api.ligate.io/v1/schemas/lsc1abc... | jq
+{
+  "id": "lsc1abc...",
+  "name": "themisra.proof-of-prompt",
+  "version": 1,
+  "owner": "lig1...",
+  "attestor_set_id": "las1xyz...",
+  "fee_routing_bps": 0,
+  "fee_routing_addr": null,
+  "payload_shape_hash": "0xdeadbeef...",
+  "registered_at": { "block_height": 12345, "tx_hash": "ltx1...", "timestamp": "2026-05-12T01:23:45.678Z" },
+  "attestation_count": 1234
+}
+```
+
+The `payload_shape_hash` is what every attestation must commit to. You hash your evidence document the same way (SHA-256 of canonical bytes) and pass it as `--payload-shape-hash` in step 5.
+
+---
+
+## 5. Submit your first attestation
+
+⚠ **Preview**: `ligate-cli attest` subcommand is on the pre-devnet feature list (chain repo issue #112's v0 surface). Until it ships, the chain repo's `bootstrap-cli` is the path; see [`devnet/README.md`](../../devnet/README.md).
+
+For the v0 partner flow with `ligate-cli`:
+
+```bash
+$ EVIDENCE_HASH=$(echo -n '{"prompt":"hello","output":"hi"}' | sha256sum | awk '{print $1}')
+$ ligate attest \
+    --schema lsc1abc... \
+    --payload-hash "lph1$(echo $EVIDENCE_HASH | bech32 encode lph)" \
+    --signer first \
+    --chain-hash "$(ligate info --json | jq -r .chain_hash)" \
+    --chain-id 4242
+submitted attestation:
+  schema_id:    lsc1abc...
+  payload_hash: lph1...
+  tx_hash:      ltx1xyz...
+  outcome:      committed
+```
+
+The `--chain-hash` and `--chain-id 4242` bind the signature to the chain so it can't be replayed against testnet or another devnet revision. Pull `chain-hash` from `ligate info --json`; the numeric `chain-id` is fixed (`4242` for ligate-devnet-1; the Cosmos-style string id `ligate-devnet-1` is separate).
+
+---
+
+## 6. Verify it landed
+
+Two ways:
+
+```bash
+# Via ligate-cli (uses the chain RPC directly)
+$ ligate get-tx ltx1xyz...
+  block_height: 12999
+  block_hash:   lblk1...
+  outcome:      committed
+  kind:         submit_attestation
+  details: { schema_id: ..., payload_hash: ..., signature_count: 3 }
+
+# Via the indexer (faster for explorer-style views)
+$ curl -s https://api.ligate.io/v1/txs/ltx1xyz... | jq
+```
+
+Or in the browser, open `https://explorer.ligate.io/tx/ltx1xyz...`.
+
+---
+
+## 7. (Optional) Register your own schema
+
+If the canonical schemas don't fit your use case, register your own. Trade-off: you bind to your own attestor set (which you supply pubkeys for), and you pay the registration fee.
+
+```bash
+# 1. Pick or register an attestor set. For a solo proof-of-concept,
+#    bind to a 1-of-1 set with your own pubkey.
+$ MY_PUBKEY=$(ligate keys show first --pubkey)
+$ ligate register-attestor-set \
+    --member "$MY_PUBKEY" \
+    --threshold 1 \
+    --signer first
+
+# 2. Hash your schema doc (canonical JSON Schema, sorted keys, no trailing
+#    whitespace). Same SHA-256 the chain uses.
+$ SHAPE_HASH=$(jq -S -c . my-schema.json | sha256sum | awk '{print $1}')
+
+# 3. Register the schema.
+$ ligate register-schema \
+    --name "mycompany.my-schema" \
+    --version 1 \
+    --attestor-set las1abc... \
+    --payload-shape-hash "0x${SHAPE_HASH}" \
+    --signer first
+```
+
+Schema id derivation: `SHA-256(owner_addr || name || version_le)`. Deterministic — you can compute it offline before submission.
+
+---
+
+## 8. What's next
+
+- [Chain protocol spec](../protocol/attestation-v0.md) — types, state, invariants, fees.
+- [`ligate-js`](https://github.com/ligate-io/ligate-js) — TypeScript SDK if you'd rather build in Node/browser than shell out to `ligate-cli`.
+- [`ligate-api`](https://github.com/ligate-io/ligate-api) — REST surface the explorer uses; same endpoints partners can query directly.
+- [Mneme](https://mneme.xyz) (status: pre-devnet) — first-party browser wallet that signs attestations from a single click. Replaces the `ligate-cli` step for end users.
+
+---
+
+## Help
+
+- File chain issues at [`ligate-io/ligate-chain`](https://github.com/ligate-io/ligate-chain/issues).
+- File CLI / SDK issues at [`ligate-io/ligate-cli`](https://github.com/ligate-io/ligate-cli/issues) or [`ligate-io/ligate-js`](https://github.com/ligate-io/ligate-js/issues).
+- Reach Ligate Labs at `hello@ligate.io`.
+
+⚠ Discord pending — link will land here when it ships.

--- a/docs/development/runbooks/da-signer-rotation.md
+++ b/docs/development/runbooks/da-signer-rotation.md
@@ -1,0 +1,122 @@
+# Runbook — DA Signer (Celestia) Key Rotation
+
+**Status:** v0 — covers the procedure for Celestia DA. Mock DA needs no DA-side key. Companion to [`sequencer-key-rotation.md`](./sequencer-key-rotation.md), which covers the chain-side signing key.
+
+This page is about `da.signer_private_key` in `rollup.toml` — the Celestia wallet that signs blob-submission transactions on the DA layer. The blast radius of a DA-key incident is **different** from a chain-key incident: a DA-key compromise can drain TIA and halt blob submission, but it cannot rewrite chain state or forge attestations.
+
+---
+
+## When does the DA signer need rotation?
+
+| Cause | Severity | What it blocks |
+|---|---|---|
+| **DA key compromised** (private key leaked) | High | Adversary submits blobs as us, drains TIA, can DoS blob submission via gas-bidding wars. Chain state is safe. |
+| **DA key lost** (operator loses the file) | High | We can't submit blobs at all. Chain stalls until rotation. |
+| **TIA balance hits zero** | Medium | Submissions fail at the Celestia node. Chain stalls until refunded — easier fix than full rotation. |
+| **Routine policy** | Low | Periodic rotation per operator policy. |
+
+The first three are operational outages. The fourth is a planning exercise.
+
+---
+
+## Procedure A — Rotation under operator control (planned)
+
+1. **Generate the replacement Celestia keypair.**
+   ```sh
+   celestia-appd keys add ligate-da-2026q3 --keyring-backend file
+   # Records mnemonic — back it up immediately, separately from the
+   # node's filesystem. Mnemonic is the recovery primitive; the file
+   # on disk is the operational primitive.
+   ```
+
+2. **Fund the new address.**
+   - Mocha testnet (devnet target): hit the Mocha faucet (`https://faucet.celestia-mocha.com` or community channels).
+   - Internal transfer from the old address: `celestia-appd tx bank send <old> <new> <amount>utia`.
+   - **Target balance:** at least 30 days of expected blob-fee burn. For `ligate-devnet-1` with one blob per slot at ~1000ms block time, that's roughly `2.6M slots/month × avg_blob_fee_utia`. Pull the current avg from `[monitoring].telegraf_address` metrics or `celestia-appd query txs` on a sample.
+
+3. **Stop the sequencer.** Required to swap keys cleanly — partial-state rotation isn't supported by the DA adapter.
+   ```sh
+   systemctl stop ligate-node    # or pkill -f ligate-node
+   ```
+
+4. **Update `rollup.toml`.**
+   ```toml
+   [da]
+   signer_private_key = "<new-key-hex>"
+   sender_address = "<new-celestia-address>"  # matches the new key
+   ```
+
+5. **Update `genesis/sequencer_registry.json`.** `seq_da_address` must match `[da].sender_address` from step 4. Mismatch → sequencer refuses to start with a clear error.
+
+6. **Restart.** The node opens a fresh DA-adapter session with the new key and starts submitting blobs as the new wallet.
+
+7. **Verify.** Watch the next slot's blob land on Celestia from the new address:
+   ```sh
+   celestia-appd query txs \
+     --query "transfer.sender='<new-celestia-address>'" \
+     --limit 5
+   ```
+
+   And confirm our chain-side advance via `/v1/ledger/slots/latest` reporting a height beyond the rotation point.
+
+**Estimated downtime:** ~30 seconds (clean stop + key swap + restart). Coordinated with operators ahead of time; usually a maintenance window.
+
+---
+
+## Procedure B — Emergency rotation under compromise
+
+Adversary has the private key. Every additional minute is risk. Cut downtime corners:
+
+1. **Generate + fund the replacement key** ahead of time if you have one pre-staged (recommended; keep a warm spare in cold storage). If not, run step 1 of Procedure A as fast as the Celestia faucet allows.
+2. **Drain the compromised wallet** before the adversary does. Tx the entire balance minus a tiny rotation-fee buffer to the new address:
+   ```sh
+   celestia-appd tx bank send <old> <new> <balance-minus-fee>utia
+   ```
+3. **Stop + rotate + restart** per Procedure A steps 3-6, with no maintenance-window niceties.
+4. **Post-mortem.** How did the key leak? File a write-up; tighten key storage (HSM, sealed-secrets, whatever the gap was).
+
+The compromise window — from key leak to wallet drain — is what determines actual loss. Pre-staging a replacement key keeps this window seconds, not hours.
+
+---
+
+## TIA balance monitoring (avoids Procedure B entirely)
+
+Hitting zero is the most common "rotation" event. Avoid it with alerting:
+
+```yaml
+# Alertmanager rule (tracked in chain repo #268; sketch here)
+- alert: LigateDaSignerLowBalance
+  expr: ligate_da_signer_balance_utia < 50_000_000   # 50 TIA in utia
+  for: 5m
+  annotations:
+    runbook: docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
+```
+
+The chain doesn't emit this metric today; needs a Prometheus exporter that wraps `celestia-appd query bank balances <addr>`. Filed as a follow-up to [#268](https://github.com/ligate-io/ligate-chain/issues/268).
+
+**Manual check** until that ships:
+
+```sh
+celestia-appd query bank balances <da-address> --denom utia
+```
+
+Recommended threshold: keep at least 60 days of expected burn in the wallet, alert at 30 days remaining, urgent-page at 7 days remaining.
+
+---
+
+## What chain-side observers see during rotation
+
+- **`/v1/rollup/info`** unchanged. Chain identity doesn't depend on the DA signer.
+- **`/v1/ledger/slots/latest`** advances slowly (≤ ~30s gap) during the stop-restart window, then resumes normal cadence.
+- **Sequencer-registry state** unchanged. The DA address gets updated in genesis but the sequencer's chain-side identity stays the same.
+
+If observers see slot production halt for >2 minutes during a rotation, the operator should investigate (DA adapter failed to find the new key file, TIA wallet not yet funded, etc.) rather than assume it's normal.
+
+---
+
+## Cross-references
+
+- [`sequencer-key-rotation.md`](./sequencer-key-rotation.md) — companion runbook for the chain-side key.
+- [`docs/development/celestia-ops.md`](../celestia-ops.md) — broader Celestia-side operations notes.
+- [`devnet-1/celestia.toml`](../../../devnet-1/celestia.toml) — the production DA config the procedure above edits.
+- [Issue #268](https://github.com/ligate-io/ligate-chain/issues/268) — Alertmanager wiring; the TIA-balance alert lands there.

--- a/docs/development/runbooks/sequencer-key-rotation.md
+++ b/docs/development/runbooks/sequencer-key-rotation.md
@@ -1,0 +1,132 @@
+# Runbook — Sequencer Key Rotation
+
+**Status:** v0 — documents the procedure but warns where on-chain rotation primitives are missing today. Pre-devnet rotation is a re-genesis event; post-devnet rotation needs the upgrade module ([#42](https://github.com/ligate-io/ligate-chain/issues/42)) plus a `RotateSequencerKey` runtime call ([this runbook's open follow-up](#open-follow-ups)).
+
+This page covers rotating the **sequencer's chain-side signing key** — the ed25519 keypair that authorises sequencer-built batches. NOT the DA-side key that signs Celestia blob submissions; that's [`da-signer-rotation.md`](./da-signer-rotation.md).
+
+---
+
+## When does the chain-side sequencer key need rotation?
+
+1. **Compromise.** The private key file leaks, gets exfiltrated, ends up in a logged crash dump. **Severity: critical.** Adversary can forge batches; rotate immediately and re-genesis if any pre-rotation batch is suspect.
+2. **Lost key, recoverable state.** Operator machine dies but ledger / RocksDB lives. Key file is gone but on-chain state is intact. Need a way to swap the registered sequencer pubkey while keeping every existing slot.
+3. **Routine rotation policy.** Some operator policies mandate periodic key rotation (e.g. every 12 months). Pre-mainnet, this is a planning decision more than a forcing function.
+
+Cases 1 + 2 are operationally urgent. Case 3 is a planning exercise.
+
+---
+
+## What rotation means at the chain level
+
+The sequencer pubkey lives in `crates/sequencer-registry` / `genesis/sequencer_registry.json` as the on-chain authorised signer. Three different things could change:
+
+| Field | Where stored | Rotation primitive needed |
+|---|---|---|
+| `sequencer.rollup_address` (lig1...) | sequencer-registry state | `RotateSequencerAddress` runtime call (NOT shipped — [open follow-up](#open-follow-ups)) |
+| `sequencer.signer_private_key` | Operator's filesystem (NOT on-chain) | Filesystem operation, but only valid if `rollup_address` matches the on-chain entry |
+| `seq_da_address` | sequencer-registry + DA layer | Concert with DA-side rotation ([`da-signer-rotation.md`](./da-signer-rotation.md)) |
+
+The Sovereign SDK does **not** ship a hot-rotation primitive in v0. Until [#42 lands](https://github.com/ligate-io/ligate-chain/issues/42) + a sequencer-side rotation call lands on top, rotation is either:
+
+- **Re-genesis** (chain id ladder bumps, e.g. `ligate-devnet-1` → `ligate-devnet-2`), OR
+- **Coordinated restart with operator-side state surgery**, which we don't endorse for any state we want to keep.
+
+---
+
+## Procedure A — pre-devnet / localnet (re-genesis)
+
+Acceptable when state is disposable (devnet still bootstrapping, no partner data on the chain).
+
+1. **Stop the node.**
+   ```sh
+   pkill -f ligate-node
+   ```
+
+2. **Wipe state.**
+   ```sh
+   rm -rf devnet/data/*
+   ```
+
+3. **Generate the new key.**
+   ```sh
+   ligate-genesis-tool generate-key --role sequencer --out devnet/genesis/keys/
+   # writes sequencer.key (mode 0600) + sequencer.address
+   ```
+
+4. **Update genesis.**
+   - `devnet/genesis/sequencer_registry.json`: replace `address` with the new bech32m.
+   - `devnet/rollup.toml`: update `[sequencer].rollup_address` to match.
+   - Bump the chain id if state surgery would have leaked old data: `chain_id = "ligate-devnet-2"`.
+
+5. **Recompute `CHAIN_HASH`** (auto on next build — the chain pins it via `chain_hash_pin.rs`).
+
+6. **Reboot.** Every operator and partner re-onboards against the new genesis.
+
+This procedure loses every existing tx, attestor set, schema, and attestation. Don't run it after partners have started using the chain.
+
+---
+
+## Procedure B — post-devnet (designed; not yet shipped)
+
+Once [#42 (upgrade module)](https://github.com/ligate-io/ligate-chain/issues/42) and a sequencer-rotation call ship, the flow becomes:
+
+1. **Generate the replacement key** offline.
+2. **Sign a `RotateSequencerKey { new_pubkey, effective_at_slot }` tx** with the OLD key. Submit during normal sequencer operation.
+3. **Monitor inclusion** via `/v1/ledger/txs/{hash}`. The chain accepts the rotation tx, records the new pubkey, and schedules the cutover at `effective_at_slot`.
+4. **Race-condition guard.** Between submission and `effective_at_slot`, the sequencer keeps signing with the OLD key. Any in-flight batches confirm cleanly. After `effective_at_slot`, batches signed with the old key are rejected.
+5. **Swap the key on the operator filesystem** before `effective_at_slot` lands. If you don't, batch production halts at the cutover slot.
+6. **Verify** via `/v1/rollup/info` and `/v1/modules/sequencer-registry/sequencers/{addr}` that the new pubkey is live.
+
+This procedure is the desired Day-1 mainnet behaviour. **Not implemented yet.**
+
+---
+
+## Procedure C — recovery from lost key, state intact (operator-side surgery)
+
+Pre-devnet only. Use case: operator machine died, RocksDB exists on backup, key file is gone.
+
+1. **Stop the node.** (It can't sign anything anyway.)
+2. **Generate a fresh key.** Same as Procedure A step 3.
+3. **Edit `devnet/genesis/sequencer_registry.json`** to swap in the new address.
+4. **Recompute `CHAIN_HASH`** — this WILL change because the registered sequencer pubkey is part of the hash.
+5. **Re-genesis.** Even though the state directory exists, the chain hash mismatch makes it invalid. Wipe + rebuild from snapshot, see [#273](https://github.com/ligate-io/ligate-chain/issues/273) (state snapshot publishing) once that ships.
+
+In short: pre-#273, recovery from lost key without re-genesis is impossible. After #273, the operator can rebuild state from a published snapshot while swapping in a fresh key via the same upgrade-module path as Procedure B.
+
+---
+
+## Attester-side view
+
+Attestors don't see the sequencer's chain-side key directly. They see batches arrive with valid signatures (or not). When rotation happens:
+
+- **Procedure A** — attestors re-onboard against the new genesis. Their existing attestor-set memberships need re-registration if the chain id bumped (the attestor set's deterministic id depends on member pubkeys, which don't change — so the same `las1...` id should re-derive on the new chain, but the registration TX has to be re-submitted).
+- **Procedure B** — transparent. The chain emits an `Attestation/SequencerRotated` event ([open follow-up — needs filing](#open-follow-ups)) at `effective_at_slot`; attestors that depend on knowing the sequencer's identity (paranoid operators, monitoring dashboards) listen for that.
+
+---
+
+## Verification after rotation
+
+```sh
+# Chain identity should reflect the new chain_hash if you re-genesised
+ligate info
+
+# Sequencer registration entry on-chain
+curl -s https://rpc.ligate.io/v1/modules/sequencer-registry/sequencers/$ADDR | jq
+
+# Recent batches should be signed by the new pubkey — verify via the
+# batch detail endpoint
+curl -s https://rpc.ligate.io/v1/ledger/batches/latest | jq .signer_pubkey
+```
+
+---
+
+## Open follow-ups
+
+This runbook surfaces several gaps the chain still has to ship:
+
+1. **`RotateSequencerKey` runtime call.** Needs to live alongside `RegisterSequencer` in `sequencer-registry`. Bundles `(old_pubkey, new_pubkey, effective_at_slot)`, signed by the old key. Not yet filed; file as a follow-up to [#42](https://github.com/ligate-io/ligate-chain/issues/42).
+2. **`Attestation/SequencerRotated` event.** So attestors and dashboards know when rotation took effect. Same shape as the typed events from [#295](https://github.com/ligate-io/ligate-chain/issues/295); follow the same pattern.
+3. **State-snapshot publishing** ([#273](https://github.com/ligate-io/ligate-chain/issues/273)). Unblocks Procedure C — operators can rebuild state from a snapshot when their local DB is gone.
+4. **Pre-devnet drill.** Run Procedure A end-to-end on `ligate-localnet` and time it; record the operator-facing steps as a script so the actual devnet-1 rotation is mechanical.
+
+This page lands the procedure for state-disposable rotation today and clearly marks the gaps for state-preserving rotation. When the gaps close, this page tightens in lockstep.

--- a/docs/protocol/upgrades.md
+++ b/docs/protocol/upgrades.md
@@ -264,6 +264,72 @@ Ligate Chain consumes the Sovereign SDK via a fork at [`ligate-io/sovereign-sdk`
 
 The fork's branch model + rebase discipline lives in `CONTRIBUTING.ligate.md` on the fork itself. The chain's `Cargo.toml` has a `[patch."<sov-url>"]` block pinning the consumed `rev` so the chain rebuilds reproducibly. Bump that `rev` in a deliberate PR; never let it move under the chain.
 
+---
+
+## Operator recovery: `start_fresh_outer_proof_on_resync`
+
+Not an upgrade in the sense above, but an operator lever bundled with the SDK upgrade that introduced it ([`Sovereign-Labs/sovereign-sdk#2833`](https://github.com/Sovereign-Labs/sovereign-sdk/pull/2833)). Documented here because the failure modes it addresses look like upgrade-class incidents to an on-call.
+
+### What the flag controls
+
+The Sovereign prover aggregates inner ZK proofs into outer proofs across multiple slots. When a node restarts (`ligate-node` SIGTERM + restart, container OOM, host reboot), the prover service has to decide what to do with whatever partial outer-aggregation work was in flight at shutdown.
+
+- `start_fresh_outer_proof_on_resync = false` (**default**): on resync, the prover resumes the in-progress outer proof from disk state. Faster recovery in the happy path; no work is thrown away.
+- `start_fresh_outer_proof_on_resync = true`: on resync, the prover discards in-progress outer-aggregation work and starts a fresh outer proof from the current resync point. Slower (we re-prove anything that was mid-flight) but safe when the on-disk state is suspected to be wedged.
+
+The flag is wired through `FullNodeBlueprint::create_prover_service` and lives at every call site in [`crates/rollup/src/main.rs`](../../crates/rollup/src/main.rs). Today it's hardcoded `false` — recompile to flip it. The CLI-flag follow-up below removes the recompile.
+
+### Decision tree
+
+| Situation | Setting | Why |
+|---|---|---|
+| Routine restart (deploy, host reboot, planned maintenance) | `false` | Resume work; no proof gets thrown away |
+| Crash from a known bug, no on-disk corruption suspected | `false` | Same as routine. Restart, observe, file the bug |
+| Chain wedged: outer proofs stop landing on Celestia for >5 minutes after a clean restart, prover logs report repeated "outer aggregation step failed" | `true` | The on-disk partial outer state is suspect. Drop it and rebuild |
+| Recovery from a known-bad SDK rev (e.g. a fork rev that produced malformed partial outer proofs that the new binary refuses to consume) | `true` | The new binary can't parse the old partial state. Restart fresh |
+| Catastrophic disk loss + restore from backup snapshot | `true` | Trust nothing about the in-flight prover state |
+
+Default to `false`. Flip to `true` only when the prover is demonstrably stuck and a normal restart didn't clear it. Flipping pre-emptively wastes minutes per restart in the happy case.
+
+### How to flip it
+
+Today: edit the literal `false` arguments to `create_prover_service` in `crates/rollup/src/main.rs`, rebuild `ligate-node`, restart.
+
+Planned ([open follow-up](#open-follow-ups)): expose as `--start-fresh-outer-proof-on-resync` on the `ligate-node` binary so operators don't have to recompile mid-incident.
+
+### Recovery walkthrough
+
+Concrete scenario: Mocha had a brief outage at 03:14 UTC, `ligate-node` came back online but outer proofs haven't landed in the 7 minutes since.
+
+```sh
+# 1. Confirm the wedge: no new outer proofs in the prover log
+journalctl -u ligate-node | grep "outer_proof_committed" | tail -5
+# (no recent entries; last entry is pre-outage)
+
+# 2. Stop the node
+systemctl stop ligate-node
+
+# 3. Flip the flag (today: edit + rebuild; post-CLI-flag follow-up: drop the env var below)
+START_FRESH_OUTER_PROOF_ON_RESYNC=true systemctl start ligate-node
+# OR (today's recompile path)
+# - edit crates/rollup/src/main.rs, replace `false` arguments with `true`
+# - cargo build --release --bin ligate-node
+# - swap binary, restart
+
+# 4. Watch outer-aggregation restart from scratch
+journalctl -fu ligate-node | grep "outer_aggregation_started"
+
+# 5. Once a fresh outer proof lands, revert the flag back to false for the next restart
+```
+
+Time-to-recovery: roughly one outer-proof cycle (~minutes, depending on slot count between checkpoints). The trade-off is exactly that cycle: you re-prove what you already proved before the wedge. The alternative — leaving the node stuck — costs every subsequent slot.
+
+### Open follow-ups
+
+- Expose `--start-fresh-outer-proof-on-resync` as a CLI flag on `ligate-node` so flipping it doesn't require a rebuild. Filed as a follow-up to this section.
+- Surface a `prover_outer_aggregation_stuck_seconds` Prometheus metric so the wedge condition is observable from outside the journal. Pair with the Alertmanager wiring tracked in [#268](https://github.com/ligate-io/ligate-chain/issues/268).
+- Run this procedure end-to-end on `ligate-localnet` once we have a deterministic way to induce a wedged outer proof. The drill should produce a documented "min time to recovery" measurement.
+
 ## Related
 
 - [Protocol spec, "Chain id"](attestation-v0.md#chain-id) — the locked four-row identifier ladder


### PR DESCRIPTION
Ships five operator-facing docs:

- `docs/development/quickstart-partner.md` — zero-to-attestation flow for partners on `ligate-devnet-1` (closes #276)
- `docs/development/runbooks/sequencer-key-rotation.md` — chain-side key rotation procedures A (re-genesis), B (post-upgrade-module design), C (recovery from lost key) (closes #270)
- `docs/development/runbooks/da-signer-rotation.md` — Celestia DA signer rotation, planned + emergency, TIA balance monitoring (closes #272)
- `docs/protocol/upgrades.md` — adds `start_fresh_outer_proof_on_resync` section: what it controls, decision tree, recovery walkthrough, CLI-flag follow-up (closes #271)
- `docs/development/public-devnet-deploy.md` — Step 2.5 NTP / chrony requirement + verification + failure-mode + optional Prometheus metric. Also adds chrony to cloud-init packages (closes #279)

All five issues are p1/p2 pre-devnet operator-readiness items.

## Test plan

- [x] Renders cleanly in GitHub's Markdown viewer (intra-doc links resolve)
- [x] Cross-references between sequencer-key-rotation and da-signer-rotation work
- [x] `chrony` added to cloud-init packages list; verification command in NTP section is the real `chronyc tracking` invocation
- [x] `start_fresh_outer_proof_on_resync` decision tree references the actual SDK PR (Sovereign-Labs/sovereign-sdk#2833)
- [x] Open follow-ups in each runbook are linkable to existing issues (#42, #268, #273, #295) — no broken references