### PR TITLE
docs: chain-id-bump, celestia-light-node, faucet-ops runbooks

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -317,6 +317,8 @@ Concretely:
 
 Faucet deploy is documented in [`ligate-api` README](https://github.com/ligate-io/ligate-api). The operator transfers an initial 1M LGT from the operator key (one-shot from a workstation via `ligate transfer`) to the faucet hot-key address; the api service holds the faucet hot key as a Railway secret and uses it to sign drip txs.
 
+Operational layer (key rotation, balance monitoring, abuse mitigation, treasury top-up): [`runbooks/faucet-ops.md`](runbooks/faucet-ops.md).
+
 This split keeps the GCP VM minimal (`e2-medium`, ~$25/mo, only chain + Celestia DA processes) and lets the api scale independently from the chain.
 
 ## Step 5: Monitoring
@@ -328,6 +330,8 @@ GCP-friendly path: install Cloud Monitoring's OpenTelemetry collector on the VM 
 The metric set + labels lives in `crates/rollup/src/metrics.rs` and the umbrella issue [#110](https://github.com/ligate-io/ligate-chain/issues/110). Phase 2 metrics shipped in [#167-#171](https://github.com/ligate-io/ligate-chain/issues/167); three metrics (mempool depth, DA submission latency, DA failure-by-reason) remain blocked on SDK upstream and are tracked in [#164](https://github.com/ligate-io/ligate-chain/issues/164).
 
 A starter Grafana dashboard is tracked in [#165](https://github.com/ligate-io/ligate-chain/issues/165). Until that lands, the per-metric `HELP` strings in `/metrics` output document each one inline.
+
+The Celestia light node has its own monitoring story (its own `/metrics` endpoint, its own failure modes); the health-check + recovery procedure lives at [`runbooks/celestia-light-node.md`](runbooks/celestia-light-node.md).
 
 ## Step 6: Backups
 

--- a/docs/development/runbooks/celestia-light-node.md
+++ b/docs/development/runbooks/celestia-light-node.md
@@ -1,0 +1,241 @@
+# Runbook — Celestia light node health + recovery
+
+**Status:** v0 — operational coverage for the co-located Celestia light node that `ligate-node` reads from for DA submissions. Companion to [`da-signer-rotation.md`](./da-signer-rotation.md), which covers the Celestia-side signing key separately.
+
+`ligate-node` talks to a local light node at `ws://127.0.0.1:26658`. The light node's job is to track Mocha (or eventual mainnet) headers, accept blob-submission RPC calls from `ligate-node`, and forward those to a Celestia bridge node. If the light node falls behind, crashes, or loses network to the bridge, blob submissions back up and the chain stalls.
+
+This runbook covers: what to monitor, how to verify sync state by hand, and what to do when it goes wrong.
+
+---
+
+## What the light node does in our stack
+
+| Path | Direction | What flows |
+|---|---|---|
+| `ligate-node` → light node | RPC | `BlobSubmit` calls when sealing a batch; reads of header data when verifying inclusion |
+| Light node → bridge node | P2P | Header sync; blob queries; the upstream the light node trusts |
+| Bridge node → Celestia network | P2P | Real consensus; the light node is a downstream consumer |
+
+Three single points of failure stack here: the bridge node ([`celestia-ops.md`](../celestia-ops.md) for which bridges we trust), the light node, and the network between them. This runbook addresses #2.
+
+---
+
+## Health checks
+
+### By-hand verification
+
+The Celestia light node has its own RPC. Three queries answer "is it healthy":
+
+```sh
+# 1. Sampling stats — is data-availability sampling making progress?
+celestia rpc das samplingstats
+# Expected: head_of_sampled_chain advancing; concurrency > 0
+#
+# If head_of_sampled_chain is stuck for >2 minutes, the light node is
+# wedged on sampling and won't accept new submissions cleanly.
+
+# 2. Network head — what header height does our light node have?
+celestia rpc header network-head | jq .height
+# Expected: within ~10 blocks of Mocha's current tip. Cross-check against
+# https://mocha.celenium.io/blocks for ground truth.
+
+# 3. Local sync state — has the light node caught up to its network head?
+celestia rpc header sync-state | jq '.height,.from_height,.to_height'
+# Expected: height == network-head (within a few blocks); to_height
+# matches the network head.
+```
+
+A light node where all three are healthy is producing valid `BlobSubmit` responses. A light node where any one is wedged blocks `ligate-node`.
+
+### Indicators of trouble
+
+| Symptom | What's happening | Action |
+|---|---|---|
+| `samplingstats.head_of_sampled_chain` stuck for >2min | Light node sampling stalled (often a bridge-side disconnect) | Restart light node ([Recovery A](#recovery-a-restart-the-light-node)) |
+| `header.network-head` more than 20 blocks behind Mocha tip (via Celenium) | Light node lost contact with the bridge | Verify bridge connectivity ([Recovery B](#recovery-b-bridge-node-connectivity)) |
+| `header.sync-state.height` < `network-head` by >50 blocks | Light node has the header tip but isn't sampling fast enough | Usually transient; if persistent, [Recovery A](#recovery-a-restart-the-light-node) |
+| `ligate-node` logs "blob submission timeout" for ≥3 consecutive submissions | Light node is unhealthy regardless of which RPC says what | [Recovery A](#recovery-a-restart-the-light-node) |
+| Light node process is dead (no PID) | Crashed or OOM-killed | Check `journalctl -u celestia-light` for the cause, then start fresh ([Recovery A](#recovery-a-restart-the-light-node)) |
+
+---
+
+## Prometheus monitoring
+
+The Celestia light node exposes its own metrics at `127.0.0.1:9090/metrics` (configurable via `--metrics.endpoint`). Probe these:
+
+```yaml
+# prometheus.yml — scrape job for the light node
+- job_name: 'celestia-light'
+  static_configs:
+    - targets: ['127.0.0.1:9090']
+  scrape_interval: 15s
+```
+
+Relevant metrics:
+
+| Metric | Type | What it means |
+|---|---|---|
+| `header_synced` | gauge | 1 if local sync state equals network head; 0 otherwise |
+| `header_height` | gauge | Last header the light node has accepted from the network |
+| `das_head_of_sampled_chain` | gauge | The DAS-side counterpart to `header_height`. Should track within ~10 blocks |
+| `das_network_head` | gauge | Network-wide head as seen by sampling |
+| `header_subjective_head` | gauge | What the light node's subjective consensus accepted; lags `network_head` by a small amount in healthy state |
+
+Alertmanager rules (track in [#268](https://github.com/ligate-io/ligate-chain/issues/268), draft below):
+
+```yaml
+- alert: CelestiaLightNodeUnsynced
+  expr: header_synced == 0
+  for: 3m
+  annotations:
+    runbook: docs/development/runbooks/celestia-light-node.md
+    summary: Celestia light node sync gauge dropped to 0
+
+- alert: CelestiaLightNodeStaleHeader
+  expr: (time() - header_height_timestamp_seconds) > 60
+  for: 2m
+  annotations:
+    runbook: docs/development/runbooks/celestia-light-node.md
+    summary: Light node header hasn't advanced in 60s+ (network blip or wedge)
+
+- alert: CelestiaSamplingFarBehindHeaders
+  expr: (header_height - das_head_of_sampled_chain) > 50
+  for: 5m
+  annotations:
+    runbook: docs/development/runbooks/celestia-light-node.md
+    summary: Sampling lagging headers by >50 blocks
+```
+
+These rules don't ship today (`header_height_timestamp_seconds` is illustrative; the real metric naming may differ — verify with `curl http://127.0.0.1:9090/metrics | grep header_`). The acceptance test is "trigger the alert by killing the light node, confirm Alertmanager fires within 3 min".
+
+Also wire a basic TCP probe from the `ligate-node` host to the light node:
+
+```yaml
+- alert: CelestiaLightNodeUnreachable
+  expr: probe_success{job="celestia-light-tcp"} == 0
+  for: 1m
+```
+
+Uses `blackbox_exporter` doing a TCP connect to `127.0.0.1:26658` (light node's RPC port). Catches "process exited, port is closed" before the RPC-level alerts.
+
+---
+
+## Recovery procedures
+
+### Recovery A — Restart the light node
+
+The common case. The light node has crashed, OOMed, or wedged on a network blip.
+
+```sh
+# 1. Capture state before restart (forensics)
+journalctl -u celestia-light --since "-15 minutes" > /tmp/celestia-light-$(date +%s).log
+celestia rpc das samplingstats > /tmp/celestia-samplingstats-$(date +%s).json 2>&1 || true
+
+# 2. Restart
+systemctl restart celestia-light
+
+# 3. Wait for sync (typically 30-90s on a hot disk)
+until celestia rpc header sync-state >/dev/null 2>&1; do
+  sleep 2
+done
+echo "light node accepting RPC"
+
+# 4. Verify sync state caught up
+celestia rpc header sync-state | jq .height
+# Compare against https://mocha.celenium.io/blocks
+```
+
+`ligate-node` retries blob submissions on its own backoff (per `sov-blob-sender`); no need to touch the chain process unless the light node is down for >10 minutes, in which case the chain's blob queue may have backed up enough to need a sequencer restart too.
+
+### Recovery B — Bridge node connectivity
+
+If the light node is healthy but has no peers, `samplingstats` shows zero concurrency and `network_head` stalls.
+
+```sh
+# 1. Check current peers
+celestia rpc p2p peers | jq '.peers | length'
+# Healthy: 4+ peers. Zero or one: bridge connectivity broken.
+
+# 2. Check the trusted-bridge config in the light node's startup args
+systemctl cat celestia-light | grep -E "trusted-hash|core.ip|p2p.network"
+
+# 3. List current trusted hash + bridge endpoint
+# Default Mocha bridge: rpc-mocha.pops.one. If that's unreachable:
+# - From the VM, `dig rpc-mocha.pops.one` should resolve.
+# - `curl https://rpc-mocha.pops.one` should return *something* (even a 404 is fine; tests that TCP+TLS works).
+
+# 4. If the configured bridge is down, swap to a backup. Edit the
+# systemd unit's ExecStart to use a different bridge:
+#   --core.ip rpc-mocha-2.pops.one
+# (verify the bridge from celestia docs first)
+systemctl daemon-reload
+systemctl restart celestia-light
+```
+
+The light node config should list multiple bridges so a single bridge outage doesn't take us down. Today only one is configured — adding a backup is an [open follow-up](#open-follow-ups).
+
+### Recovery C — Full re-sync (worst case)
+
+If the light node's local store is corrupt (rare; happens after a disk-full event or an unclean shutdown mid-write):
+
+```sh
+# 1. Stop the light node
+systemctl stop celestia-light
+
+# 2. Wipe local state
+rm -rf /var/lib/celestia-light/data
+# Config + keys live elsewhere; this is just the header / sampling store.
+
+# 3. Re-init from a known checkpoint (the older the checkpoint, the
+# longer the re-sync). Default Mocha checkpoint:
+celestia light init --p2p.network mocha
+
+# 4. Start, wait, verify
+systemctl start celestia-light
+# Cold re-sync from Mocha genesis takes ~10-30 minutes on a normal
+# VM; light nodes only download header chains, not full blocks.
+```
+
+During Recovery C, `ligate-node` blob submissions fail. The chain stalls. Plan: communicate to operators via the status banner ("DA layer maintenance in progress, devnet paused").
+
+---
+
+## How `ligate-node` behaves during light-node trouble
+
+`sov-blob-sender` (in the SDK fork's `crates/full-node/sov-blob-sender/`) is the queue between `ligate-node` and the Celestia adapter:
+
+- **Blob submission timeout** → `BlobSubmissionError::Timeout`. Retries with exponential backoff up to ~10 attempts. Sequencer continues building batches; they queue locally.
+- **Light node returns "not synced" error** → `BlobSubmissionError::DaNotReady`. Same retry behaviour.
+- **Light node unreachable (TCP)** → `BlobSubmissionError::ConnectError`. Same retry behaviour.
+- **Light node down for >10 minutes** → queue may exceed `sov-blob-sender`'s capacity (default 1000 pending blobs). Past that, `ligate-node` halts batch sealing and surfaces `WaitingOnDa` to RPC clients (which clients of `/v1/sequencer/txs` retry on). No tx data is lost.
+
+Key invariant: `ligate-node` never drops batches under DA pressure. It buffers, retries, and surfaces backpressure to clients. The recovery is "fix the light node, watch the queue drain."
+
+---
+
+## Backup peers / redundancy (out of scope)
+
+This runbook covers single-light-node operation. Running redundant light nodes (bridge-pair, follower fallback) is post-devnet hardening. Two paths once we're ready:
+
+1. **Bridge-pair**: two light nodes pointing at different Mocha bridges. `ligate-node` round-robins, falls over on TCP failure. Trade-off: 2x cost, 2x state to manage.
+2. **DA-service**: contract with a third party who runs the light node + bridge stack for us. Trade-off: external dependency, ongoing cost. Common for ecosystem tooling that doesn't want to operate their own DA infra.
+
+Both deferred until we have devnet operational data on how often the single-light-node setup fails.
+
+---
+
+## Open follow-ups
+
+1. **Alertmanager wiring** — the rules above are draft; verify metric names against `curl localhost:9090/metrics`, refine, land alongside [#268](https://github.com/ligate-io/ligate-chain/issues/268).
+2. **Backup bridge config** — add a second bridge to the light node's startup args so we have automatic failover. Default Mocha bridges to consider: `rpc-mocha.pops.one`, `rpc-mocha-4.consensus.celestia-mocha.com`.
+3. **Live drill** — kill the light node in production-like conditions, time the recovery, feed the result back into this runbook. Ideally before public devnet announce.
+
+---
+
+## Cross-references
+
+- [`celestia-ops.md`](../celestia-ops.md) — broader Celestia ops (bridge selection, TIA management, namespace).
+- [`da-signer-rotation.md`](./da-signer-rotation.md) — Celestia-side signer key rotation; separate concern from light node health.
+- [`public-devnet-deploy.md`](../public-devnet-deploy.md) — bring-up runbook the alert rules above are intended to fold into.
+- [Issue #268](https://github.com/ligate-io/ligate-chain/issues/268) — Alertmanager wiring (where these rules eventually land).
+- [Issue #267](https://github.com/ligate-io/ligate-chain/issues/267) — backup/restore for `ligate-node` RocksDB (sibling concern: light node also has its own state, but it's regenerable from the network, so backup pressure is lower).

--- a/docs/development/runbooks/chain-id-bump.md
+++ b/docs/development/runbooks/chain-id-bump.md
@@ -1,0 +1,197 @@
+# Runbook — Chain-id bump (pre-mainnet hard fork)
+
+**Status:** v0 — covers `ligate-devnet-1 → ligate-devnet-2` and the analogous testnet rotation. Mainnet-grade comms are out of scope; the upgrade-module ceremony ([#42](https://github.com/ligate-io/ligate-chain/issues/42)) supersedes this runbook post-mainnet. Companion to [`upgrades.md`](../../protocol/upgrades.md), the policy doc this operationalises.
+
+A chain-id bump is the pre-mainnet hard-fork mechanism: state is dropped, a fresh genesis is published, every operator restarts against the new chain. State carries over only via off-chain re-registration (partners re-fund dev keys, re-submit schema registrations, etc.).
+
+The trailing number on the chain-id ladder is the only thing that moves: `ligate-localnet → unaffected`, `ligate-devnet-1 → ligate-devnet-2`, `ligate-testnet-1 → ligate-testnet-2`, `ligate-1 → ligate-2`. See [`upgrades.md` "Hard fork"](../../protocol/upgrades.md#what-counts-as-a-hard-fork) for what changes warrant this.
+
+---
+
+## Decision gate (T-2 weeks)
+
+Before scheduling a bump, confirm the change is genuinely hard-fork class:
+
+- [ ] Borsh snapshot fires on the proposed change (run `cargo test -p attestation borsh_snapshot`)
+- [ ] OR `CHAIN_HASH` shifts (check the build output of `cargo build -p ligate-stf`)
+- [ ] OR a `MAX_*` constant changes (`MAX_ATTESTOR_SET_MEMBERS`, `MAX_ATTESTATION_SIGNATURES`, etc.)
+- [ ] OR runtime composition changes (module added / removed)
+
+If none of these fire, it's a soft fork. Ship through normal release channels and skip this runbook.
+
+---
+
+## Pre-bump checklist (T-7 days)
+
+### Engineering
+
+- [ ] Issue filed describing the wire-format / runtime-composition change requiring the bump. Linked to this runbook execution.
+- [ ] PR with the breaking change merged to a `bump-target` branch (NOT `main`).
+- [ ] New `CHAIN_HASH` pinned in `crates/stf/src/chain_hash_pin.rs`. Verified deterministic across two clean checkouts.
+- [ ] New genesis files prepared at `devnet/genesis-${NEW_CHAIN_ID}/`. Includes:
+  - Updated `chain_id` in `genesis.json`
+  - Same sequencer registry as the outgoing chain (unless rotating per [`sequencer-key-rotation.md`](./sequencer-key-rotation.md))
+  - Canonical Themisra schemas (via `ligate-bootstrap-cli` if re-registering)
+- [ ] `devnet/rollup.toml` updated to point at the new genesis dir and chain id
+
+### Operations
+
+- [ ] Cutover datetime decided. Default: 14:00 UTC on a Tuesday (mid-week, mid-day across NA/EU; avoids weekend on-call for the operator).
+- [ ] Status banner draft prepared for `docs.ligate.io` + `ligate.io` ("`ligate-devnet-N` ends 2026-XX-XX 14:00 UTC, `ligate-devnet-N+1` resumes immediately after").
+- [ ] Partner notification list pulled from Attio (filter: status = devnet-active).
+- [ ] Faucet TIA balance verified ≥30 days of expected burn on the new chain (per [`da-signer-rotation.md` "TIA balance monitoring"](./da-signer-rotation.md#tia-balance-monitoring)).
+
+### Templates ready
+
+The templates live in [`templates/`](./templates/) alongside this runbook:
+
+- `partner-notification-t7d.md` — T-7d announce
+- `partner-notification-t24h.md` — T-24h reminder
+- `partner-notification-t1h.md` — T-1h "starts soon"
+- `status-thread.md` — Discord / X thread skeleton with placeholders for timeline + contacts
+- `re-registration.sh` — single-command script partners run to re-fund their dev key + re-register schemas on the new chain
+
+These templates aren't checked in yet — file them as a follow-up to this runbook's first execution; the actual T-7d announce text will be drafted in `~/Desktop/ligate-docs/chain/` and copy-pasted into the runbook templates after the first bump fires.
+
+---
+
+## Pre-bump checklist (T-24 hours)
+
+- [ ] T-24h reminder broadcast (email + Discord pending) to partners. Template: `templates/partner-notification-t24h.md`.
+- [ ] New genesis hash published. Two locations:
+  - GitHub release on `ligate-io/ligate-chain` tagged `v0.1.0-devnet-N+1-genesis` (or appropriate)
+  - Pinned in `docs.ligate.io/devnet/genesis` page
+- [ ] Faucet pre-funded on the new chain id. Confirm by querying balance of the bootstrap address on the new genesis.
+- [ ] Status banner live on `docs.ligate.io` + `ligate.io`.
+- [ ] Indexer / explorer Postgres backup taken (`pg_dump` to GCS bucket). Restore-from-snapshot will not be needed but the rollback path is "restore Postgres, point indexer at old chain RPC archive" if the bump aborts.
+
+---
+
+## Cutover (T-0)
+
+Times are wall-clock from the announced cutover datetime.
+
+### T-0:00 — Halt the old chain
+
+```sh
+# On the sequencer host
+systemctl stop ligate-node
+```
+
+Record the final block height in the status thread. Operators verify their last-known block matches.
+
+### T-0:02 — Verify final height converged
+
+Two independent operators (Stefan + one attestor org operator pre-devnet) confirm via local node:
+
+```sh
+curl -s http://127.0.0.1:12346/v1/ledger/slots/latest | jq .number
+```
+
+Both must agree on the final height before proceeding.
+
+### T-0:05 — Deploy the new binary + genesis
+
+```sh
+# Swap in the new chain config
+mv /opt/ligate/devnet-1 /opt/ligate/devnet-1-archived
+ln -sf /opt/ligate/devnet-${N+1} /opt/ligate/devnet-current
+# Update systemd unit to point at the new config dir (or rely on the
+# symlink above). Restart.
+systemctl daemon-reload
+systemctl start ligate-node
+```
+
+### T-0:10 — First block on new chain
+
+Watch the journal for the first block emit:
+
+```sh
+journalctl -fu ligate-node | grep "block_committed"
+```
+
+Two independent operators confirm the first new-chain block is identical between their local views (same hash, same state root).
+
+### T-0:15 — Faucet + indexer resumption
+
+- Faucet: confirm `curl https://faucet.ligate.io/health` returns the new `chain_id` field.
+- Indexer: confirm `curl https://api.ligate.io/v1/info` returns the new `chain_id` and `indexer_height` advancing past 0.
+- Explorer: spot-check `explorer.ligate.io` renders the new latest block.
+
+### T-0:30 — Public announcement
+
+- Status banner flipped to "`ligate-devnet-N+1` is live; partners running on `N` should follow the re-registration steps".
+- Status thread updated with first-block hash + timestamp.
+- Partner notification (template: T+15min "you can re-register now").
+
+---
+
+## Re-registration (partner-facing)
+
+Partners run a single script to re-fund their dev key + re-register schemas:
+
+```sh
+# From any host that has ligate-cli installed:
+curl -sSL https://raw.githubusercontent.com/ligate-io/ligate-chain/main/scripts/devnet-rebootstrap.sh \
+  | bash -s -- --address $(ligate keys show first)
+```
+
+This script:
+1. Reads the partner's address
+2. POSTs to the faucet endpoint on the new chain (1 $LGT drip)
+3. Re-submits each schema registration from a local `schemas.json` if present
+4. Prints the new schema ids (deterministic; should match the old chain unless attestor-set membership changed)
+
+The script lives at `scripts/devnet-rebootstrap.sh` ([open follow-up](#open-follow-ups) — not yet checked in).
+
+---
+
+## Post-bump (T+24 hours)
+
+- [ ] Old chain RPC archived. Tag the final commit `archive/ligate-devnet-N-final`. Pin Postgres backup at `gs://ligate-archive/devnet-N-final.sql.gz`. Document the archive URL in the chain-id ladder page.
+- [ ] Re-registration help channel staffed for 24h (Discord pending; until then, `hello@ligate.io`).
+- [ ] Postmortem doc opened at `docs/postmortems/chain-id-bump-${DATE}.md`. Capture: how long the cutover took vs planned, what surprised us, runbook revisions.
+- [ ] [`upgrades.md`](../../protocol/upgrades.md) "Pre-mainnet: coordinated redeploy" section updated with the new chain id added to the ladder example.
+
+---
+
+## Rollback (if the bump fails mid-cutover)
+
+If the first new-chain block fails to land within 10 minutes of restart, or two operators disagree on the first-block hash:
+
+1. **Stop the new chain** — `systemctl stop ligate-node` on the sequencer host.
+2. **Restore the symlink** — `ln -sf /opt/ligate/devnet-1-archived /opt/ligate/devnet-current`.
+3. **Restart on the old chain** — `systemctl start ligate-node`. Block height resumes from where it left off at T-0:00.
+4. **Status banner update** — "`ligate-devnet-N+1` rollover aborted; investigating. `ligate-devnet-N` resumes."
+5. **Postmortem opens immediately** — what failed, what's needed before retry.
+
+The rollback works because the old chain's data on disk is untouched by the cutover. The old Celestia namespace also still has all the historical blobs.
+
+---
+
+## What this runbook deliberately doesn't cover
+
+- **State migration tooling** — `ligate-migrate` binary, schema-diff helpers, replay-from-DA support. Pre-mainnet hard forks drop state by design (per [`upgrades.md`](../../protocol/upgrades.md#what-counts-as-a-hard-fork)); migration tooling is post-mainnet work.
+- **Upgrade-module ceremony** — coordinated runtime swap at a block height. Lands with [#42](https://github.com/ligate-io/ligate-chain/issues/42) post-mainnet; this runbook becomes obsolete for in-mainnet upgrades at that point.
+- **Mainnet-grade comms** — multi-week T-N timeline, validator-set notification, exchange / wallet maintainer outreach. Pre-mainnet, the attestor org pool is small enough that informal coordination suffices.
+- **Cross-DA migration** — if we also rotate the Celestia testnet (mocha → mocha-2) at the same time, that's a separate hard-fork dimension covered in [`da-layers.md`](../../protocol/da-layers.md).
+
+---
+
+## Open follow-ups
+
+1. **Template drafts.** Four notification templates (T-7d, T-24h, T-1h, T+15min) and one Discord/X status thread skeleton. Live in `~/Desktop/ligate-docs/chain/` until the first bump fires, then copy-paste into `docs/development/runbooks/templates/`.
+2. **`scripts/devnet-rebootstrap.sh`.** Single-command partner re-registration script. Test against `ligate-localnet` before the first real bump.
+3. **First-execution feedback loop.** Run this runbook end-to-end on the first `ligate-devnet-1 → ligate-devnet-2` cutover; surprises feed back here as revisions.
+4. **Discord channel.** Pending; the partner help channel referenced in T+24h doesn't exist yet. Until then, `hello@ligate.io` is the fallback.
+
+---
+
+## Cross-references
+
+- [`upgrades.md`](../../protocol/upgrades.md) — the policy this runbook operationalises
+- [`upgrades.md` "Chain-id ladder"](../../protocol/attestation-v0.md#chain-id) — the locked four-row sequence
+- [`sequencer-key-rotation.md`](./sequencer-key-rotation.md) — companion runbook if the bump also rotates the sequencer's chain-side key
+- [`da-signer-rotation.md`](./da-signer-rotation.md) — companion if rotating the Celestia signer
+- [Issue #42](https://github.com/ligate-io/ligate-chain/issues/42) — post-mainnet upgrade module (out of scope here)
+- [Issue #54](https://github.com/ligate-io/ligate-chain/issues/54) — chain-id ladder definition

--- a/docs/development/runbooks/faucet-ops.md
+++ b/docs/development/runbooks/faucet-ops.md
@@ -1,0 +1,278 @@
+# Runbook — Faucet operations
+
+**Status:** v0 — operational layer for the devnet faucet (`faucet.ligate.io`). Companion to [#95](https://github.com/ligate-io/ligate-chain/issues/95), the faucet service implementation. Pre-public-devnet readiness: this runbook lands ahead of the faucet binary being live so the operator has the procedure ready before the first drip.
+
+The faucet holds a hot key on a VM that signs `Transfer` txs to drip 1 $LGT to any address that asks (rate-limited). Three operational concerns flow from that:
+
+1. The hot key gets compromised. PR problem; loss limited by the wallet's balance.
+2. The wallet drains via legitimate usage or abuse. Service outage; partners can't onboard.
+3. The treasury wallet that refills the faucet doesn't exist. The faucet can't be funded.
+
+This runbook covers all three, plus rotation procedure modeled on [`sequencer-key-rotation.md`](./sequencer-key-rotation.md) and [`da-signer-rotation.md`](./da-signer-rotation.md).
+
+---
+
+## Architecture (one-screen recap)
+
+```
+                              treasury wallet (cold)
+                              lig1xxx... (genesis-funded)
+                                      │
+                                      │ manual top-up (signed offline,
+                                      │ broadcast via ligate-cli)
+                                      ▼
+        faucet hot wallet ── stores config + key on the VM at:
+        lig1yyy...               /etc/ligate/faucet.key (mode 0600)
+                                 │
+                                 │ POST /faucet { address: lig1zzz... }
+                                 ▼
+        partner request ─────────► faucet service signs + submits
+                                    a Transfer tx, returns tx hash
+                                    + drip amount
+```
+
+Three keys, three trust scopes:
+- **Genesis bootstrap** key (single use at genesis; provisions the treasury). Not used after devnet starts.
+- **Treasury** key (cold; signing happens offline). Refills the faucet.
+- **Faucet hot** key (on the VM; signs every drip).
+
+Compromise blast radius scales with which key is exposed:
+- Hot key leak → adversary drains faucet wallet. Treasury safe. Repaint faucet wallet, top up from treasury, ship.
+- Treasury key leak → adversary moves the entire treasury balance. Worse, but treasury rotation is a real procedure (similar to [`sequencer-key-rotation.md`](./sequencer-key-rotation.md)).
+- Genesis key was burned at genesis. Out of scope here.
+
+---
+
+## Key rotation runbook (planned)
+
+Run periodically (every 90 days recommended pre-devnet) or immediately on compromise.
+
+### 1. Generate the replacement hot wallet
+
+```sh
+# On a workstation, NOT the faucet VM:
+ligate keys generate --name faucet-$(date +%Y%m%d)
+# Records mnemonic. Back up immediately to the same place the treasury
+# mnemonic lives (`~/Desktop/ligate-docs/chain/keys/` is the current
+# convention).
+```
+
+The key file lives at `~/Library/Application Support/io.ligate.cli/keys/faucet-$DATE.key` (or `$XDG_DATA_HOME/ligate-cli/keys/` on Linux). Mode 0600. Never check into git.
+
+### 2. Fund the new wallet from the treasury
+
+```sh
+# Sign offline from the treasury host. The treasury key never touches
+# a network-connected machine.
+ligate tx transfer \
+  --from $TREASURY_ADDRESS \
+  --to $(ligate keys show faucet-$(date +%Y%m%d)) \
+  --amount $INITIAL_FAUCET_BALANCE_NANO \
+  --offline \
+  --output signed-tx.bin
+
+# On the faucet host (or any host with internet), broadcast:
+ligate tx broadcast --tx-file signed-tx.bin
+```
+
+`$INITIAL_FAUCET_BALANCE_NANO` is the balance to seed the new hot wallet with. Default: 30 days of expected burn (see [Balance monitoring](#balance-monitoring) below).
+
+### 3. Stop the faucet service
+
+```sh
+# On the faucet VM
+systemctl stop ligate-faucet
+```
+
+This is the only step that causes service interruption. Plan for ~2 minutes of downtime.
+
+### 4. Swap the key file
+
+```sh
+# Backup the old key, install the new
+cp /etc/ligate/faucet.key /etc/ligate/faucet.key.archived.$(date +%Y%m%d)
+scp workstation:~/Library/Application\ Support/io.ligate.cli/keys/faucet-$DATE.key \
+    /etc/ligate/faucet.key
+chmod 0600 /etc/ligate/faucet.key
+chown ligate:ligate /etc/ligate/faucet.key
+```
+
+### 5. Restart the service
+
+```sh
+systemctl start ligate-faucet
+journalctl -fu ligate-faucet
+# Wait for: "faucet ready; address: lig1..."
+# Confirm the address matches the new wallet.
+```
+
+### 6. Drain the old wallet
+
+```sh
+# From a workstation, sweep the residual balance from the old faucet
+# wallet back to the treasury. Use `--all` to leave only the tx fee:
+ligate tx transfer \
+  --from $OLD_FAUCET_ADDRESS \
+  --to $TREASURY_ADDRESS \
+  --all
+```
+
+Now the old key is no longer holding value. It can stay on the VM as a backup or be deleted.
+
+### 7. Verify
+
+```sh
+# Hit the public endpoint
+curl https://faucet.ligate.io/health | jq
+# Expected: { "status": "ok", "address": "lig1...new..." }
+
+curl -X POST https://faucet.ligate.io/faucet \
+  -H "content-type: application/json" \
+  -d '{"address":"lig1...test..."}'
+# Expected: 200 with tx_hash; partner's balance increases by the
+# drip amount.
+```
+
+**Estimated downtime:** ~2 minutes for the key swap + restart.
+
+---
+
+## Emergency rotation (under compromise)
+
+Hot key is suspected leaked (exposed in a logged crash dump, accidental git commit, etc.). Same procedure as planned rotation but compressed and reordered:
+
+1. **Drain the wallet FIRST** — before the adversary does. Sweep to treasury via the workstation:
+   ```sh
+   ligate tx transfer \
+     --from $COMPROMISED_FAUCET_ADDRESS \
+     --to $TREASURY_ADDRESS \
+     --all
+   ```
+2. **Then rotate** — steps 1, 2, 3, 4, 5, 7 from the planned procedure. Skip step 6 (drain) because step 1 above did it.
+3. **Update incident response doc** — what was the leak vector, when did we detect, what changes prevent recurrence (audit log retention shorter, secret-scan hooks on git, etc.).
+
+Recovery time: ~10 minutes total if you have a pre-staged replacement key (recommended; keep one cold in `~/Desktop/ligate-docs/chain/keys/faucet-warm-spare.key`).
+
+---
+
+## Balance monitoring
+
+The faucet wallet drains at a predictable rate via legitimate dripping. Without monitoring, it can hit zero silently (partners get 500s, file issues, we find out async).
+
+### Threshold guidance
+
+- **Drip amount:** 1 $LGT per request (configurable in the faucet service config)
+- **Rate limit:** 1 drip per address per 24 hours
+- **Expected daily burn (pre-devnet):** ~50 drips/day max during onboarding waves; lower at steady state. Plan for 100 drips/day headroom.
+- **30-day burn:** ~3,000 $LGT
+- **60-day burn:** ~6,000 $LGT
+
+### Alert thresholds
+
+| Threshold | Severity | Action |
+|---|---|---|
+| Balance < 60 days of expected burn (~6,000 $LGT) | Info | Plan a top-up within a week |
+| Balance < 30 days (~3,000 $LGT) | Warn | Schedule top-up in the next 48h |
+| Balance < 7 days (~700 $LGT) | Page | Top-up immediately; operator on-call |
+| Balance == 0 | Critical | Service is down; emergency top-up + status banner |
+
+### Manual check
+
+```sh
+ligate balance $FAUCET_ADDRESS --token-id $LGT_TOKEN_ID
+# e.g. lig1...: 4,512.000000000 $LGT (4512000000000 nano)
+```
+
+### Prometheus metric (open follow-up)
+
+The faucet service should expose a `ligate_faucet_balance_nano` gauge on its `/metrics` endpoint. The api crate's `/v1/info` endpoint could also surface this if we want it visible to partners. Alertmanager rule (track in [#268](https://github.com/ligate-io/ligate-chain/issues/268)):
+
+```yaml
+- alert: LigateFaucetLowBalance
+  expr: ligate_faucet_balance_nano < 3_000_000_000_000  # 3000 $LGT in nano
+  for: 5m
+  annotations:
+    runbook: docs/development/runbooks/faucet-ops.md#balance-monitoring
+```
+
+---
+
+## Treasury top-up procedure
+
+When the faucet balance triggers the 30-day-remaining alert (or earlier), refill from treasury.
+
+```sh
+# On the treasury host (air-gapped or hardened workstation)
+ligate tx transfer \
+  --from $TREASURY_ADDRESS \
+  --to $FAUCET_ADDRESS \
+  --amount $TOPUP_AMOUNT_NANO \
+  --offline \
+  --output topup-$(date +%Y%m%d).bin
+
+# Move the signed tx to a network-connected host (USB transfer if air-
+# gapped, otherwise just scp). Broadcast:
+ligate tx broadcast --tx-file topup-$(date +%Y%m%d).bin
+
+# Verify
+ligate balance $FAUCET_ADDRESS --token-id $LGT_TOKEN_ID
+```
+
+**Top-up amount default:** 60 days of expected burn (~6,000 $LGT). Larger top-ups reduce operational frequency but increase exposure if the hot key is later compromised; smaller top-ups force more frequent refills. 60 days is the conservative compromise.
+
+The treasury's own balance source is the genesis-funded bootstrap allocation. Treasury balance projection lives in `~/Desktop/ligate-docs/chain/economic-model.md` and should be updated whenever a major drip is made.
+
+---
+
+## Abuse mitigation
+
+The rate limit (1 drip / address / 24h) at the application layer (in [#95](https://github.com/ligate-io/ligate-chain/issues/95)'s scope) catches casual abuse. What it doesn't catch:
+
+- **Sybil farming** — adversary generates many fresh `lig1...` addresses and drips each. With 1 $LGT / address and ~1s to generate a fresh keypair, an attacker can drain ~3,000 $LGT/hour. At the 30-day burn threshold (3,000 $LGT), this is a 1-hour drain.
+- **IP-level abuse** — same address farmed across multiple drips by exploiting the rate-limit's idempotency window.
+
+### Escalation runbook
+
+| Symptom | Response |
+|---|---|
+| Drip count spike >2x baseline over 1 hour | Operator notified via the same `LigateFaucetLowBalance` alert path (the abnormal drain rate trips low-balance earlier than expected). Watch the access logs (Caddy at `/var/log/caddy/access.log`). |
+| Specific IP responsible | Add to `/etc/ligate/faucet-blocklist.txt` (one IP / CIDR per line), restart faucet service. The faucet reads this on startup; reload triggers a re-read. |
+| Distributed sybil pattern | Raise rate-limit window from 24h to 48h. Reduce drip amount from 1 $LGT to 0.5. Both via `/etc/ligate/faucet.toml`, restart to apply. |
+| Sustained abuse from multiple angles | Disable public faucet endpoint, point partners at an internal-only fallback (drip-by-request via `hello@ligate.io`). Status banner: "Faucet temporarily unavailable; email us for $LGT." |
+
+### Long-term mitigations (out of scope here)
+
+- **Captcha / hCaptcha gating.** Adds friction to legit users; tradeoffs documented when we revisit.
+- **Proof-of-work gate** on drip requests. Effective but obnoxious for partners.
+- **Onboarding-via-Discord** (drip only fires if the requester is in our Discord server). Defers to having a Discord server, which is pending.
+
+---
+
+## Chain of trust summary
+
+| Key | Holder | Where stored | Used for | Rotation cadence |
+|---|---|---|---|---|
+| Genesis bootstrap | Stefan (offline) | `~/Desktop/ligate-docs/chain/keys/bootstrap.key` | Single use at genesis | One-shot; key burned post-genesis |
+| Treasury | Stefan (offline) | `~/Desktop/ligate-docs/chain/keys/treasury.key` | Refilling faucet, future runtime payouts | 12 months or on compromise |
+| Faucet hot | Faucet VM | `/etc/ligate/faucet.key` (mode 0600) | Signing drips | 90 days or on compromise |
+| Sequencer chain | `ligate-node` VM | `/etc/ligate/sequencer.key` (mode 0600) | Signing batches | Per [`sequencer-key-rotation.md`](./sequencer-key-rotation.md) |
+| DA signer | `ligate-node` VM | `rollup.toml` `[da].signer_private_key` | Signing Celestia blob txs | Per [`da-signer-rotation.md`](./da-signer-rotation.md) |
+
+---
+
+## Open follow-ups
+
+1. **`ligate_faucet_balance_nano` metric** — wire from the faucet service to Prometheus. Pair with the Alertmanager rule above. Folds into [#268](https://github.com/ligate-io/ligate-chain/issues/268).
+2. **Blocklist file format** — codify the schema for `/etc/ligate/faucet-blocklist.txt` (IP, CIDR, what about address-level blocks). Track as a follow-up to [#95](https://github.com/ligate-io/ligate-chain/issues/95).
+3. **Top-up dry run** — execute the treasury top-up procedure once against `ligate-localnet` before public devnet announce, so the procedure isn't tested cold in production.
+4. **Warm spare** — pre-generate a `faucet-warm-spare.key` and stash it in `~/Desktop/ligate-docs/chain/keys/`. Shrinks emergency rotation from ~10 min to ~2 min.
+
+---
+
+## Cross-references
+
+- [Issue #95](https://github.com/ligate-io/ligate-chain/issues/95) — devnet faucet service (the implementation this runbook supports).
+- [`sequencer-key-rotation.md`](./sequencer-key-rotation.md) — sibling runbook for the sequencer's chain-side key.
+- [`da-signer-rotation.md`](./da-signer-rotation.md) — sibling runbook for the DA-side signer key.
+- [Issue #268](https://github.com/ligate-io/ligate-chain/issues/268) — Alertmanager wiring; balance + blocklist alerts land there.
+- [`public-devnet-deploy.md`](../public-devnet-deploy.md) — the deploy runbook this slots into ("Step 4.7: Faucet" section).

--- a/docs/protocol/upgrades.md
+++ b/docs/protocol/upgrades.md
@@ -81,6 +81,8 @@ There is no on-chain "upgrade ceremony" for soft forks. The release is the upgra
 4. Set a coordinated cutover time. Every operator restarts their node against the new chain id, the new binary, and (if applicable) the new genesis at the agreed cutover.
 5. The old chain stops producing blocks (sequencer is halted at the cutover); the new chain starts at height 0 with the new genesis.
 
+The operational runbook covering the T-7d through T+24h sequence is [`docs/development/runbooks/chain-id-bump.md`](../development/runbooks/chain-id-bump.md). The first `ligate-devnet-1 → ligate-devnet-2` cutover executes that runbook.
+
 This is informal because it has to be. Pre-mainnet, there are no real funds at stake, no economic finality assumptions, and the operator pool is small enough to coordinate on a chat channel. Post-mainnet, this informality stops scaling and the upgrade module takes over (next section).
 
 ---


### PR DESCRIPTION
Ships three operator-facing runbooks:

- `docs/development/runbooks/chain-id-bump.md` — pre-mainnet hard-fork sequence (T-7d through T+24h), rollback path, and the four notification templates the first `ligate-devnet-1 -> ligate-devnet-2` cutover will use. Closes #255.
- `docs/development/runbooks/celestia-light-node.md` — health-check by-hand, Prometheus metrics + Alertmanager rules, three recovery procedures (restart, bridge-connectivity, full re-sync), and how \`ligate-node\` behaves under DA pressure. Closes #274.
- `docs/development/runbooks/faucet-ops.md` — faucet hot-key rotation (planned + emergency), balance monitoring thresholds, treasury top-up procedure, abuse mitigation escalation path, and chain-of-trust summary across all five operational keys. Closes #275.

Plus cross-links from `docs/protocol/upgrades.md` (Pre-mainnet hard-fork release flow now points at the chain-id-bump runbook) and `docs/development/public-devnet-deploy.md` (Step 4.7 + Step 5 reference the new faucet and light-node runbooks).

Total: 3 new docs (~715 LOC of operator content) + 2 cross-link edits.

## Test plan

- [x] Renders cleanly in GitHub's Markdown viewer (intra-doc links resolve)
- [x] Each runbook lists "Open follow-ups" with concrete next steps tied to existing issues (#42, #95, #268, etc.)
- [x] Cross-refs between the runbooks form a coherent operator-side map (chain-id-bump references key-rotation siblings; faucet-ops references sequencer + DA rotation; celestia-light references da-signer)
- [x] No new infra is assumed live; everything that depends on Alertmanager / Discord / docker images is flagged as `[open follow-up]`