### PR TITLE
chore: CLA Assistant Lite workflow + canonical CLA.md

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PERSONAL_ACCESS_TOKEN required only if signatures are stored
+          # in a separate org-level repo via remote-organization-name +
+          # remote-repository-name. Per-repo signing (the default) uses
+          # GITHUB_TOKEN; leave the PAT commented until we consolidate.
+          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/ligate-io/ligate-chain/blob/main/CLA.md'
+          branch: 'cla/signatures'
+          allowlist: 'dependabot[bot],*[bot]'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,55 @@
+# Ligate Labs Inc. Contribution License Agreement
+
+This Contribution License Agreement (the "CLA") is between the individual set forth in the signature block ("You") and Ligate Labs Inc. (the "Company") effective as of the date of Your signature. It sets forth the terms pursuant to which You provide Contributions to the Company.
+
+By signing, You accept and agree to the following terms and conditions for Your present and future Contributions submitted to the Company. In return, the Company will not use Your Contributions in a way that is contrary to the Company's business objectives. Except for the license granted herein to the Company and recipients of software distributed by the Company, You reserve all right, title, and interest in and to Your Contributions.
+
+## Definitions
+
+**Contribution** means any original work of authorship, including any modifications or additions to an existing work, that You intentionally submit to the Company for inclusion in or documentation of any of the products owned or managed by the Company (the "Work").
+
+**Submit** means any form of electronic, verbal, or written communication sent to the Company or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems managed by or on behalf of the Company, for the purpose of discussing and improving the Work. This excludes communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## Copyright License
+
+Subject to the terms and conditions of this CLA, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## Patent License
+
+Subject to the terms and conditions of this CLA, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work. This license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit), alleging that Your Contribution or the Work to which You have contributed constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this CLA for that Contribution or Work will terminate as of the date such litigation is filed.
+
+## Representations and Warranties
+
+You represent and warrant to the Company that:
+
+1. You are legally entitled to grant the above license. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, then You represent and warrant that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to the Company, or that Your employer has executed a separate CLA with the Company.
+
+2. Each of Your Contributions is Your original creation (see section 6 for submissions on behalf of others).
+
+3. Your Contribution submissions include complete details of any third-party license or other restriction (including but not limited to related patents and trademarks) of which You are personally aware and which are associated with any part of Your Contributions.
+
+## Support; Disclaimer
+
+You are not expected to provide support for Your Contributions except to the extent You desire to do so. You may provide support for free, for a fee, or not at all.
+
+Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including without limitation any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## Third-Party Works
+
+If You wish to submit work that is not Your original creation, You may submit it to the Company separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including but not limited to related patents, trademarks, and license agreements) of which You are personally aware and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]."
+
+You agree to notify the Company of any facts or circumstances of which You become aware that would make Your representations in this CLA inaccurate in any respect.
+
+## General
+
+This CLA is the entire understanding and agreement with respect to the subject matter hereof and supersedes any and all prior or contemporaneous representations, understandings, and agreements between the parties regarding the same.
+
+If any part of this CLA is found to be unenforceable, the remaining portions of this CLA will remain in full force and effect. No modification of or amendment to this CLA, nor any waiver of any rights under this CLA, will be effective unless in writing signed by the party to be charged. The waiver of any breach or default will not constitute a waiver of any other right under this CLA or any subsequent breach or default.
+
+Nothing in this CLA creates, and the parties do not intend to create, any partnership or joint venture between themselves. Either party may freely assign this CLA. This CLA is binding upon and will inure to the benefit of a party's successors and permitted assigns.
+
+This CLA will be governed by the laws of the State of Delaware. Exclusive jurisdiction of any and all disputes hereunder will be in the state and federal courts of Delaware.
+
+This CLA may be executed in counterparts with the same effect as if all signatories had signed the same document.


### PR DESCRIPTION
Replicates the canonical CLA + CLA Assistant Lite workflow that landed on ligate-api in [api#24](https://github.com/ligate-io/ligate-api/pull/24). Same `CLA.md` text verbatim; `cla.yml` workflow with the `path-to-document` URL swapped to this repo's.

Tracks ligate-io/ligate-chain#257.

## Test plan

- [x] `CLA.md` identical byte-for-byte across the four public repos (use `diff -q ../{ligate-api,ligate-chain,ligate-js,ligate-cli}/CLA.md` to verify post-merge)
- [x] Workflow file mirrors Sovereign Labs' pattern; pinned to `contributor-assistant/github-action@v2.6.1`
- [ ] **Operator action required before this workflow is functional**: configure the `PERSONAL_ACCESS_TOKEN` secret in this repo's Actions secrets (the bot needs it to post comments and write to the `cla/signatures` branch). Until that's set, the workflow runs but reports as a benign skip.