### PR TITLE
ops: Prometheus alert rules + Alertmanager config + per-alert runbooks

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -331,6 +331,8 @@ The metric set + labels lives in `crates/rollup/src/metrics.rs` and the umbrella
 
 A starter Grafana dashboard is tracked in [#165](https://github.com/ligate-io/ligate-chain/issues/165). Until that lands, the per-metric `HELP` strings in `/metrics` output document each one inline.
 
+Alerting rules ship in [`ops/prometheus/alerts.yaml`](../../ops/prometheus/alerts.yaml) with Alertmanager routing in [`ops/prometheus/alertmanager.yaml`](../../ops/prometheus/alertmanager.yaml). Each alert has a runbook under [`docs/development/runbooks/alerts/`](runbooks/alerts/README.md) keyed by alert name; the `runbook_url` annotation on each rule routes the on-call to the right file via the firing notification. Load `alerts.yaml` via `rule_files:` on the Prometheus server; configure Alertmanager with the rendered `alertmanager.yaml` (Slack webhook + SMTP password injected at deploy time, never in repo).
+
 The Celestia light node has its own monitoring story (its own `/metrics` endpoint, its own failure modes); the health-check + recovery procedure lives at [`runbooks/celestia-light-node.md`](runbooks/celestia-light-node.md).
 
 ## Step 6: Backups

--- a/docs/development/runbooks/alerts/README.md
+++ b/docs/development/runbooks/alerts/README.md
@@ -1,0 +1,39 @@
+# Alert runbooks
+
+One file per Prometheus alert defined in [`ops/prometheus/alerts.yaml`](../../../../ops/prometheus/alerts.yaml). Each file follows the same shape:
+
+```
+1. What fired      — the rule + threshold in plain English
+2. Likely causes   — ranked by frequency, not severity
+3. First checks    — the cheapest signals to confirm root cause
+4. Fix             — what to do for each cause
+5. False positives — what looks like a fire but isn't
+6. Escalation      — when + how to wake someone up
+```
+
+The `runbook_url` annotation on each alert points the on-call at the right file via the firing Slack/email notification.
+
+## Alert catalog
+
+| Alert | Severity | Runbook |
+|---|---|---|
+| `BlockHeightStall` | page | [`block-height-stall.md`](./block-height-stall.md) |
+| `HealthDown` | page | [`health-down.md`](./health-down.md) |
+| `ReadyFalse` | warn | [`ready-false.md`](./ready-false.md) |
+| `MempoolDeep` | warn | [`mempool-deep.md`](./mempool-deep.md) |
+| `DiskFillingFast` | warn | [`disk-filling-fast.md`](./disk-filling-fast.md) |
+| `DASubmissionFailures` | page | [`da-submission-failures.md`](./da-submission-failures.md) |
+| `DAFinalizationLatencyHigh` | warn | [`da-finalization-latency-high.md`](./da-finalization-latency-high.md) |
+
+## On-call rota (pre-devnet)
+
+Stefan is the single point of contact. Phone + email always reachable. Slack channel `#devnet-ops` is the primary incident surface. Mainnet rota expansion deferred until a second operator exists.
+
+## Deploying these rules + receivers
+
+1. Render `ops/prometheus/alertmanager.yaml` with the secrets (Slack webhook, SMTP password) injected at the file paths the config expects. The repo's copy is the template; the deployed copy is the rendered version.
+2. Set `--config.file=alerts.yaml` on the Prometheus server (or include via `rule_files:` in the main config).
+3. Set `--config.file=alertmanager.yaml` on the Alertmanager.
+4. Confirm Prometheus's `Alerts` tab lists each rule + shows `Inactive`. Then test the wiring by killing `ligate-node` and confirming `HealthDown` fires within 90s + the Slack notification arrives.
+
+The actual deploy of Prometheus + Alertmanager lives outside this repo (operator's monitoring stack, e.g. on the same GCP VM as `ligate-node` or on a separate ops VM). [`public-devnet-deploy.md`](../../public-devnet-deploy.md) covers the broader monitoring story.

--- a/docs/development/runbooks/alerts/block-height-stall.md
+++ b/docs/development/runbooks/alerts/block-height-stall.md
@@ -1,0 +1,62 @@
+# `BlockHeightStall`
+
+**Severity: page**
+
+## What fired
+
+`ligate_block_height` has not advanced for at least 60s on `ligate-node`. The sequencer is either halted, wedged on DA, or has lost its Celestia light node.
+
+Expression:
+```
+changes(ligate_block_height[2m]) == 0
+  and on(instance) (ligate_block_height > 0)
+```
+
+(The `> 0` clause prevents the alert from firing pre-genesis or right after a clean restart where the gauge hasn't initialised yet.)
+
+## Likely causes (ranked by frequency)
+
+1. **Celestia light node is unhealthy.** Blob submissions backed up; sequencer stops sealing batches once `sov-blob-sender`'s queue exceeds capacity.
+2. **DA submission failures.** TIA balance hit zero, or the DA signer key is wrong, or the bridge node is unreachable.
+3. **Sequencer process is hung but not crashed.** Stuck in a tight loop or deadlock; would also trip `MempoolDeep` shortly after.
+4. **Network partition between sequencer and light node.** Both processes alive but can't talk.
+
+## First checks
+
+```sh
+# 1. Is the chain process alive + serving?
+systemctl status ligate-node
+curl -s http://127.0.0.1:12346/v1/info | jq
+
+# 2. What does the chain think its head is?
+curl -s http://127.0.0.1:12346/v1/ledger/slots/latest | jq .number
+
+# 3. What's the light node up to?
+celestia rpc das samplingstats
+celestia rpc header sync-state | jq .height
+
+# 4. Recent ligate-node + light-node logs
+journalctl -u ligate-node --since "-10 minutes" | tail -50
+journalctl -u celestia-light --since "-10 minutes" | tail -50
+```
+
+If the light node looks wedged, jump to [`celestia-light-node.md`](../celestia-light-node.md).
+
+If TIA balance is low, jump to [`da-signer-rotation.md`](../da-signer-rotation.md).
+
+## Fix
+
+- **Light node wedged** → restart per [`celestia-light-node.md` Recovery A](../celestia-light-node.md#recovery-a--restart-the-light-node)
+- **TIA balance zero** → top up per [`da-signer-rotation.md` "TIA balance monitoring"](../da-signer-rotation.md#tia-balance-monitoring)
+- **Sequencer hung but alive** → `systemctl restart ligate-node`; the cursor is persisted, restart is safe
+- **Sequencer crashed** → `journalctl -u ligate-node --since "-30 minutes"` to find the panic; file a bug; `systemctl restart`
+
+## False positives
+
+- **Pre-genesis** (the `> 0` clause prevents this; sanity-check the alert if it ever fires with height 0).
+- **Deliberate sequencer halt** (chain-id bump cutover per [`chain-id-bump.md`](../chain-id-bump.md)) — silence the alert in Alertmanager for the cutover window.
+- **Slot timer mid-tick** (alert window is 60s; chain produces every ~1s in steady-state so this should never fire on a 1-block lag).
+
+## Escalation
+
+Page-severity → operator phone notification fires automatically. If unresolved 15 minutes after page, post in `#devnet-ops` Slack channel and announce the partial outage via `docs.ligate.io` status banner. Mainnet incident protocol lives in a separate runbook (not yet filed).

--- a/docs/development/runbooks/alerts/da-finalization-latency-high.md
+++ b/docs/development/runbooks/alerts/da-finalization-latency-high.md
@@ -1,0 +1,49 @@
+# `DAFinalizationLatencyHigh`
+
+**Severity: warn**
+
+## What fired
+
+`histogram_quantile(0.95, rate(ligate_da_finalization_latency_seconds_bucket[5m])) > 60` for 10+ minutes.
+
+The 95th-percentile time from blob submission to Celestia finalization is above 60s — slower than the ~12s mocha block time + small finalization margin we expect in steady state.
+
+## Likely causes
+
+1. **Celestia mocha is congested.** Higher-fee blobs outbidding ours; finalization queue backs up.
+2. **Our submission rate exceeded the light node's outbound bandwidth.** Submissions queue locally before reaching the bridge.
+3. **Bridge node is slow.** The light node's upstream bridge has high latency to the wider Celestia network.
+4. **Subnetwork issue** between the chain VM and the bridge.
+
+## First checks
+
+```sh
+# 1. Confirm + see distribution shape
+curl -s http://127.0.0.1:9100/metrics | grep ligate_da_finalization_latency
+
+# 2. Cross-check Celestia's own health
+# https://mocha.celenium.io/ (transactions per block + recent fees)
+
+# 3. Light node peer count + sampling progress
+celestia rpc p2p peers | jq '.peers | length'
+celestia rpc das samplingstats
+
+# 4. Our blob fee setting — are we underbidding?
+grep -E "blob.fee|gas_price" /opt/ligate/devnet-1/celestia.toml
+```
+
+## Fix
+
+- **Mocha congestion** → wait it out; tune our blob fee up in `celestia.toml` if congestion is persistent. Reload + restart.
+- **Light node bandwidth** → unlikely on a normal VM, but check `iftop` / `bmon` on the chain VM. Increase the light node's peer count.
+- **Bridge node slow** → switch to a backup bridge per [`celestia-light-node.md` Recovery B](../celestia-light-node.md#recovery-b--bridge-node-connectivity).
+- **Subnetwork issue** → operator-side ops (check VPC config, NAT, firewall counters).
+
+## False positives
+
+- **First slot after a fresh boot** — local cache cold, the first submission may take longer. Alert's `for: 10m` filters this.
+- **Celestia-side scheduled maintenance.** Expected; banner.
+
+## Escalation
+
+Warn-severity → Slack. Escalate to page only if `BlockHeightStall` also fires (then we have a real wedge, not just degraded performance). If p95 stays elevated >2 hours and the chain is keeping up otherwise, file a follow-up ticket to tune blob fees rather than incident-style handle.

--- a/docs/development/runbooks/alerts/da-submission-failures.md
+++ b/docs/development/runbooks/alerts/da-submission-failures.md
@@ -1,0 +1,57 @@
+# `DASubmissionFailures`
+
+**Severity: page**
+
+## What fired
+
+`rate(ligate_da_submission_failures_total[5m]) > 0` sustained for 5+ minutes. ligate-node's blob submissions to Celestia are failing.
+
+Reason label values come from `crates/rollup/src/metrics.rs::DaSubmissionFailureReason`:
+- `light_node_unreachable` — TCP / RPC to the local Celestia light node failed
+- `light_node_not_synced` — light node responded but reports unsynced
+- `insufficient_funds` — TIA balance too low to pay the blob fee
+- `invalid_signer` — DA signer key was rejected by Celestia
+- `submission_timeout` — submission accepted but didn't finalize within the configured window
+- `unknown` — anything else; logs carry detail
+
+The `{{ $labels.reason }}` template in the alert summary surfaces which.
+
+## Likely causes (by reason)
+
+1. **`light_node_unreachable`** → [`celestia-light-node.md` Recovery A](../celestia-light-node.md#recovery-a--restart-the-light-node)
+2. **`light_node_not_synced`** → Light node is alive but lost peers / bridge. [`celestia-light-node.md` Recovery B](../celestia-light-node.md#recovery-b--bridge-node-connectivity)
+3. **`insufficient_funds`** → TIA balance hit zero. [`da-signer-rotation.md` "TIA balance monitoring"](../da-signer-rotation.md#tia-balance-monitoring) for top-up procedure.
+4. **`invalid_signer`** → Key rotated wrong, key file corrupted, or the DA-signer config mismatch. [`da-signer-rotation.md` Procedure A](../da-signer-rotation.md#procedure-a--rotation-under-operator-control-planned).
+5. **`submission_timeout`** → Network or Celestia-side issue. Usually transient; persistent timeouts suggest investigate the bridge.
+
+## First checks
+
+```sh
+# 1. Which reason is firing?
+curl -s http://127.0.0.1:9100/metrics | grep ligate_da_submission_failures
+
+# 2. Recent submission attempts in the chain log
+journalctl -u ligate-node --since "-10 minutes" | grep -iE "da|blob|submit"
+
+# 3. Light node health
+celestia rpc das samplingstats
+celestia rpc header sync-state
+
+# 4. TIA balance (if `insufficient_funds`)
+celestia-appd query bank balances <da-signer-addr> --denom utia
+```
+
+## Fix
+
+Branch by the `reason` label per the table above. Each reason has a dedicated runbook section to follow.
+
+If multiple reasons fire simultaneously, start with the light node (`light_node_unreachable` / `not_synced`) — if the light node is wedged, the other reasons may be downstream symptoms.
+
+## False positives
+
+- **Brief network blip** during scheduled bridge maintenance. Alert's `for: 5m` filters single-tx failures.
+- **Mocha testnet halt** (Celestia-side incident). Outside our control; pause submissions until Celestia is back, banner up.
+
+## Escalation
+
+Page-severity → operator phone notification fires. Slack post immediately. If light-node restart doesn't resolve in 10 minutes AND `BlockHeightStall` is also firing, post status banner to indicate partial outage. Coordinate with Celestia-side incident channels if Mocha itself is down.

--- a/docs/development/runbooks/alerts/disk-filling-fast.md
+++ b/docs/development/runbooks/alerts/disk-filling-fast.md
@@ -1,0 +1,50 @@
+# `DiskFillingFast`
+
+**Severity: warn**
+
+## What fired
+
+`ligate_state_db_size_bytes` is growing at >10%/hour for 30+ minutes on a single instance.
+
+NOMT prunes aggressively, so steady-state growth should be slow. A sudden growth spike usually means abuse (partner spamming attestations) or a backfill blob storm.
+
+## Likely causes
+
+1. **Attestation spam from a partner.** Single address submitting 1000s of attestations per minute against a low-fee schema.
+2. **Backfill replay.** Fresh follower catching up from genesis; growth rate matches DA replay speed.
+3. **Misconfigured pruning.** NOMT pruning interval set too long; should be ~50 slots default.
+4. **Failed pruning.** Pruning task crashed silently; state accumulates.
+
+## First checks
+
+```sh
+# 1. Confirm growth rate + absolute size
+curl -s http://127.0.0.1:9100/metrics | grep ligate_state_db_size_bytes
+df -h /var/lib/ligate
+
+# 2. Recent submit-attestation traffic
+curl -s http://127.0.0.1:9100/metrics | grep 'ligate_rpc_requests_total{endpoint=~".*submit.*"}'
+
+# 3. Per-schema attestation counts via the api
+curl -s "https://api.ligate.io/v1/schemas?limit=10" \
+  | jq '.data[] | {id, name, attestation_count}'
+
+# 4. Pruning task health (logs)
+journalctl -u ligate-node | grep -i prune | tail -20
+```
+
+## Fix
+
+- **Attestation spam** → identify the partner address from the api's `/v1/addresses/{addr}/txs`. If clearly abusive, add to the chain-side blocklist (when it ships; pre-blocklist, escalate to the partner). For mainnet, fee markets handle this naturally; pre-devnet, social pressure is the lever.
+- **Backfill replay** → expected on a fresh follower. No action; growth will plateau once caught up to head.
+- **Misconfigured pruning** → check `rollup.toml` for the pruning interval. Match the committed `devnet-1/rollup.toml`.
+- **Failed pruning** → restart `ligate-node`. If failure repeats, file an urgent bug with the pruning logs.
+
+## False positives
+
+- **First 24h after a backfill** — growth rate appears high relative to total because the denominator is still small. Tolerate.
+- **After a chain-id bump** — fresh state, growth from zero. Same.
+
+## Escalation
+
+Warn-severity → Slack. Escalate to page if disk usage crosses 80% of the partition (separate alert that we'd add once disk-fill metrics are wired); manual judgment otherwise.

--- a/docs/development/runbooks/alerts/health-down.md
+++ b/docs/development/runbooks/alerts/health-down.md
@@ -1,0 +1,51 @@
+# `HealthDown`
+
+**Severity: page**
+
+## What fired
+
+Prometheus has been unable to scrape `ligate-node`'s `/metrics` endpoint for 30+ seconds.
+
+Expression: `up{job="ligate-node"} == 0`
+
+Faster signal than `BlockHeightStall` — the process is either down, panicked, or the metrics endpoint is wedged (the rest of the chain might still be functional).
+
+## Likely causes
+
+1. **Process crashed.** Panic, OOM kill, segfault, systemd restart loop.
+2. **Process hung.** Metrics task deadlocked but the rest of the binary alive.
+3. **Network partition** between Prometheus and the chain VM.
+4. **Port binding lost** (very rare — could happen if a sibling process briefly grabbed `:9100`).
+
+## First checks
+
+```sh
+# 1. Is the process even running?
+systemctl status ligate-node
+pgrep -lf ligate-node
+
+# 2. Can the host reach the metrics port?
+curl -sf http://127.0.0.1:9100/metrics | head -5
+
+# 3. From the Prometheus host, can it reach the chain VM?
+curl -sf http://<chain-vm-ip>:9100/metrics | head -5
+
+# 4. systemd-reported status + last few log lines
+journalctl -u ligate-node -n 50
+```
+
+## Fix
+
+- **Crashed** → `systemctl restart ligate-node`. Cursor is persisted; resume is safe. File a bug with the panic stack.
+- **Hung** → same: restart. If it hangs again within 5 minutes, capture a process stack (`sudo gcore <pid>` or `kill -QUIT <pid>` then read the SIGQUIT-handler core), file urgent bug, fall back to manual operation.
+- **Network partition** → check the VM's external connectivity + the Prometheus host's firewall rules. Operator-side issue, not chain-side.
+- **Port binding lost** → `ss -tlnp | grep 9100` to identify the squatter; kill it, restart `ligate-node`.
+
+## False positives
+
+- **Deliberate restart during a deploy.** Silence the alert for the deploy window or use Alertmanager's maintenance-mode feature.
+- **Prometheus scrape interval longer than the down duration.** The alert's `for: 30s` should handle most cases; if Prometheus's scrape interval is 60s the alert can only confirm "down for at least one missed scrape, ~1-2min wall clock."
+
+## Escalation
+
+Pages immediately. If process won't restart cleanly, escalate to "single-operator can't recover alone" path (post in `#devnet-ops`, contact secondary operator if one exists, status banner up).

--- a/docs/development/runbooks/alerts/mempool-deep.md
+++ b/docs/development/runbooks/alerts/mempool-deep.md
@@ -1,0 +1,48 @@
+# `MempoolDeep`
+
+**Severity: warn**
+
+## What fired
+
+`ligate_mempool_depth > 1000` for 5+ minutes. The sequencer is accepting transactions faster than it can pack them into batches.
+
+Threshold (`> 1000`) is a placeholder until we have Phase 6.1 deployment data to tune; expect to revisit once we see real load.
+
+## Likely causes
+
+1. **DA submission backed up.** Sequencer pre-builds batches but can't seal them until Celestia accepts the blob. Mempool fills behind the bottleneck.
+2. **Load exceeds capacity.** Abnormally high tx submission rate (spam, viral usage, attack).
+3. **Sequencer running but mempool drain task hung.** Specific to the mempool worker; rest of the chain alive.
+4. **TIA balance starvation.** Submissions fail soft-style; sequencer keeps queuing; mempool grows.
+
+## First checks
+
+```sh
+# 1. Confirm depth + look at trend
+curl -s http://127.0.0.1:9100/metrics | grep ligate_mempool_depth
+
+# 2. DA side — is finalization happening?
+curl -s http://127.0.0.1:9100/metrics | grep -E "ligate_da_(submission_failures|finalization_latency)"
+
+# 3. Recent submission rate
+curl -s http://127.0.0.1:9100/metrics | grep ligate_rpc_requests_total | grep submit
+
+# 4. TIA balance on the DA signer wallet
+celestia-appd query bank balances <da-signer-addr> --denom utia
+```
+
+## Fix
+
+- **DA submission backed up** → resolve the DA-side issue first ([`celestia-light-node.md`](../celestia-light-node.md) or [`da-signer-rotation.md`](../da-signer-rotation.md)). Mempool drains naturally once submission flows again.
+- **Genuine load spike** → no immediate action; chain will catch up. Monitor for `DiskFillingFast` co-firing (would indicate state bloat from real load).
+- **Worker hung** → `systemctl restart ligate-node`. Cursor preserved.
+- **TIA starvation** → top up per [`da-signer-rotation.md`](../da-signer-rotation.md).
+
+## False positives
+
+- **Steady-state load above threshold.** When real partner usage settles, this threshold will be too low; tune up to reflect actual baseline + 50%.
+- **Brief burst during a partner-onboarding wave.** Should resolve within a few minutes; alert's `for: 5m` filters most cases.
+
+## Escalation
+
+Warn-severity → Slack only. Page if it co-fires with `BlockHeightStall` or `DASubmissionFailures` (then it's a wedge, not load).

--- a/docs/development/runbooks/alerts/ready-false.md
+++ b/docs/development/runbooks/alerts/ready-false.md
@@ -1,0 +1,55 @@
+# `ReadyFalse`
+
+**Severity: warn**
+
+## What fired
+
+`ligate-node` is alive (metrics scrape succeeds) but `/ready` has returned non-200 for 60+ seconds.
+
+Expression:
+```
+(probe_http_status_code{job="ligate-node-ready"} != 200)
+  or on(instance) (ligate_ready == 0)
+```
+
+`/ready` distinguishes "alive but catching up" from "ready to serve traffic." Common during fresh boots while backfilling DA slots; less common in steady-state and worth investigating then.
+
+## Likely causes
+
+1. **Fresh boot, still backfilling DA slots.** Normal during the first ~30s-2min after startup; alert's `for: 60s` will catch protracted cases.
+2. **Sequencer waiting on DA finalization.** Blob submitted but Celestia hasn't finalized it; chain doesn't advance "ready" past unfinalized data.
+3. **Attestor quorum lag.** Attestor set hasn't reached threshold for the latest batch; ready state holds.
+4. **Misconfigured `/ready` definition.** Chain code's notion of "ready" differs from operator's; should be a rare config bug.
+
+## First checks
+
+```sh
+# 1. What does /ready actually say?
+curl -i http://127.0.0.1:12346/v1/ready
+
+# 2. Catch-up state
+curl -s http://127.0.0.1:12346/v1/info | jq '{indexer_height, head_height, head_lag_slots}'
+
+# 3. Recent DA-side activity
+journalctl -u ligate-node --since "-5 minutes" | grep -iE "da|celestia|blob"
+
+# 4. Mempool depth + DA submission failures (rule out a wedge)
+curl -s http://127.0.0.1:9100/metrics | grep -E "ligate_mempool_depth|ligate_da_submission_failures"
+```
+
+## Fix
+
+- **Fresh boot backfilling** → wait. If still firing 5 minutes after a clean restart, investigate as a wedge.
+- **DA finalization lag** → check the Celestia bridge. If finalization is steady but slow, no action; if stalled, jump to [`celestia-light-node.md`](../celestia-light-node.md).
+- **Attestor quorum lag** → out of scope for v0 (no attestor quorum yet). When attestors are live, check the attestor-side dashboard.
+- **Config bug** → check `rollup.toml` against the committed `devnet-1/celestia.toml`. Reload + restart if drift.
+
+## False positives
+
+- **First 60-90s of every fresh boot.** Expected. Silence during planned restarts.
+- **Chain-id bump cutover window.** New chain starts from height 0; ready holds until first slot finalizes.
+- **DA-layer maintenance window** (Celestia upgrades). Expected; coordinate via the status banner.
+
+## Escalation
+
+Warn-severity → Slack only. If still firing 30+ minutes with no progress on head_height, manually escalate to page by re-checking against `BlockHeightStall` (which should also be firing if this is a real wedge, not a fresh boot).

--- a/ops/prometheus/alertmanager.yaml
+++ b/ops/prometheus/alertmanager.yaml
@@ -1,0 +1,99 @@
+# Alertmanager config for ligate-devnet-1.
+#
+# Receives firing alerts from Prometheus, deduplicates them, and routes
+# to notification targets. Pre-public-devnet, the routing tree is
+# deliberately simple: single operator, single Slack channel + email.
+# Mainnet routing (PagerDuty rotas, severity-specific escalation) is
+# future work.
+#
+# Secrets:
+# - `SLACK_WEBHOOK_URL`: posted alerts to #devnet-ops Slack channel.
+#   Stored as `slack_webhook_url` in `data/secrets/alertmanager.env`
+#   on the deploy host; injected via `--config.file=<rendered>` at
+#   alertmanager startup. NEVER check in.
+# - `SMTP_PASSWORD`: SMTP send password for the operator's mailbox.
+#   Same secret-injection pattern.
+#
+# Tracking issue: ligate-io/ligate-chain#268.
+
+global:
+  resolve_timeout: 5m
+  # SMTP from = operator address; sender is the alertmanager mailbox.
+  smtp_from: 'alerts@ligate.io'
+  smtp_smarthost: 'smtp.gmail.com:587'
+  smtp_auth_username: 'alerts@ligate.io'
+  smtp_auth_password_file: '/run/secrets/smtp_password'
+  smtp_require_tls: true
+  slack_api_url_file: '/run/secrets/slack_webhook_url'
+
+# Routing tree. All alerts hit `default`. `severity=page` also fans
+# out to email so the operator gets a phone-side notification even if
+# Slack is muted. `severity=info` is Slack-only (no point waking
+# anyone for an informational alert).
+route:
+  receiver: default
+  group_by: ['alertname', 'instance']
+  group_wait: 30s
+  group_interval: 5m
+  # Once an alert resolves, alertmanager waits this long before
+  # re-firing if the same alert reappears. Long enough to dampen
+  # flapping; short enough to surface real intermittent issues.
+  repeat_interval: 4h
+
+  routes:
+    - matchers:
+        - severity = page
+      receiver: pager
+      continue: true
+    - matchers:
+        - severity = info
+      receiver: info-only
+
+receivers:
+  # Default receiver: Slack with full alert detail.
+  - name: default
+    slack_configs:
+      - channel: '#devnet-ops'
+        send_resolved: true
+        title: '{{ template "slack.title" . }}'
+        text: '{{ template "slack.text" . }}'
+        actions:
+          - type: button
+            text: 'Runbook'
+            url: '{{ (index .Alerts 0).Annotations.runbook_url }}'
+          - type: button
+            text: 'View in Prometheus'
+            url: '{{ (index .Alerts 0).GeneratorURL }}'
+
+  # Pager receiver: Slack + email. Phone notification surface for
+  # page-severity alerts. Pre-PagerDuty, the operator's email pipes
+  # into their phone's high-priority filter.
+  - name: pager
+    email_configs:
+      - to: 'hello@ligate.io'
+        send_resolved: true
+        headers:
+          Subject: '[PAGE] {{ .GroupLabels.alertname }} on {{ .GroupLabels.instance }}'
+        html: '{{ template "email.html" . }}'
+
+  # Info-only receiver: Slack with light formatting; no email.
+  - name: info-only
+    slack_configs:
+      - channel: '#devnet-ops'
+        send_resolved: false
+        title: '[INFO] {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.summary }}{{ end }}'
+
+# Inhibition rules: if a higher-severity alert is firing, suppress
+# lower-severity alerts for the same instance. Avoids alerting fatigue
+# during incidents.
+inhibit_rules:
+  - source_matchers:
+      - severity = page
+    target_matchers:
+      - severity =~ "warn|info"
+    equal: [instance]
+
+# Templates inlined for the v0 single-file deploy. As the receiver
+# count grows, split into a separate `templates/` dir.
+templates: []

--- a/ops/prometheus/alerts.yaml
+++ b/ops/prometheus/alerts.yaml
@@ -1,0 +1,165 @@
+# Prometheus alerting rules for ligate-node.
+#
+# Loaded by the Prometheus server via `rule_files:` in its main config.
+# Each rule fires after its `for:` duration; Alertmanager then routes
+# the firing alert per `alertmanager.yaml`.
+#
+# Alert-name conventions:
+# - PascalCase
+# - Each rule has a `runbook_url` annotation pointing at the
+#   per-alert runbook in `docs/development/runbooks/alerts/`. On-call
+#   clicks that link to know what fired and what to do.
+# - Severity levels are `page` (someone needs to wake up), `warn`
+#   (look at it in business hours), `info` (informational, no human
+#   action needed).
+#
+# Tracking issue: ligate-io/ligate-chain#268.
+
+groups:
+  - name: ligate-node.liveness
+    interval: 30s
+    rules:
+      # Hardest live signal we have: the chain is producing blocks.
+      # `ligate_block_height` is updated by `metrics::run_block_height_loop`
+      # every `interval`. If it doesn't advance for 60s during expected
+      # block production, the chain is stalled.
+      - alert: BlockHeightStall
+        expr: |
+          changes(ligate_block_height[2m]) == 0
+          and on(instance) (ligate_block_height > 0)
+        for: 60s
+        labels:
+          severity: page
+          component: chain
+        annotations:
+          summary: "Block height unchanged for 60s on {{ $labels.instance }}"
+          description: |
+            `ligate_block_height` has not advanced for at least 60s.
+            Sequencer is either halted, wedged on DA, or has lost
+            its Celestia light node. Check `journalctl -u ligate-node`
+            and the Celestia light node health first.
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/block-height-stall.md
+
+      # `up` is Prometheus' own scrape-success gauge per target. If
+      # `ligate-node` can't be scraped for 30s, it crashed, panicked,
+      # or the metrics endpoint is wedged. Faster than waiting for the
+      # block-height stall to also fire.
+      - alert: HealthDown
+        expr: up{job="ligate-node"} == 0
+        for: 30s
+        labels:
+          severity: page
+          component: chain
+        annotations:
+          summary: "ligate-node /metrics scrape failing on {{ $labels.instance }}"
+          description: |
+            Prometheus has been unable to scrape ligate-node's
+            `/metrics` endpoint for 30s. Process likely down or
+            unreachable. Check systemd status and recent logs.
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/health-down.md
+
+      # `/ready` distinguishes "alive but not ready to serve" (e.g.
+      # still backfilling slots from DA) from "fully ready". Surfaced
+      # via blackbox-exporter probing the HTTP endpoint, OR via a
+      # `ligate_ready` gauge once that ships.
+      - alert: ReadyFalse
+        expr: |
+          (probe_http_status_code{job="ligate-node-ready"} != 200)
+          or on(instance) (ligate_ready == 0)
+        for: 60s
+        labels:
+          severity: warn
+          component: chain
+        annotations:
+          summary: "ligate-node /ready returning non-200 on {{ $labels.instance }}"
+          description: |
+            Node is up but not ready to serve traffic for 60s+.
+            Common causes: still backfilling DA slots on a fresh boot,
+            sequencer waiting on DA finalization, attestor quorum lag.
+            Operator should investigate; not pager-worthy on its own.
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/ready-false.md
+
+  - name: ligate-node.capacity
+    interval: 30s
+    rules:
+      # Mempool depth tracking. Threshold needs Phase 6.1 deployment
+      # data to tune; placeholder of 1000 is a rough "something is
+      # off" line that won't fire under normal load.
+      - alert: MempoolDeep
+        expr: ligate_mempool_depth > 1000
+        for: 5m
+        labels:
+          severity: warn
+          component: chain
+        annotations:
+          summary: "Mempool depth {{ $value }} on {{ $labels.instance }} (>1000 for 5m)"
+          description: |
+            Sequencer accepting txs faster than it can pack them. Either
+            DA submission is backed up, or load exceeds capacity. Check
+            DA submission metrics next.
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/mempool-deep.md
+
+      # On-disk state size growth. The chain's NOMT prunes aggressively
+      # so steady-state growth should be slow. Sudden spike usually
+      # means a misbehaving partner spamming attestations or a backfill
+      # blob storm. Threshold is a 10%/hour growth rate.
+      - alert: DiskFillingFast
+        expr: |
+          (
+            rate(ligate_state_db_size_bytes[1h])
+            / on(instance) ligate_state_db_size_bytes
+          ) > 0.10
+        for: 30m
+        labels:
+          severity: warn
+          component: chain
+        annotations:
+          summary: "State DB growing >10%/hour on {{ $labels.instance }}"
+          description: |
+            On-disk RocksDB growth rate exceeds 10%/hour for 30+ minutes.
+            Likely abuse or backfill anomaly. Investigate
+            `ligate_rpc_requests_total{endpoint=~".*submit.*"}` next.
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/disk-filling-fast.md
+
+  - name: ligate-node.da
+    interval: 30s
+    rules:
+      # DA submission failure rate. Lands once Phase 6.2 metrics ship
+      # (#164 follow-up). A single failure isn't actionable (transient
+      # Celestia hiccup); sustained > 0 rate over 5m is.
+      - alert: DASubmissionFailures
+        expr: |
+          rate(ligate_da_submission_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: page
+          component: chain
+        annotations:
+          summary: "DA submission failures on {{ $labels.instance }} (reason={{ $labels.reason }})"
+          description: |
+            ligate-node blob submissions to Celestia are failing
+            sustained over 5m. Check the Celestia light node health
+            and TIA balance first; then the DA-signer key state.
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/da-submission-failures.md
+
+      # DA finalization latency. Histogram p95 should sit at the
+      # Celestia block time (~12s mocha) + a small finalization
+      # margin. Above 60s sustained is wedged.
+      - alert: DAFinalizationLatencyHigh
+        expr: |
+          histogram_quantile(
+            0.95,
+            rate(ligate_da_finalization_latency_seconds_bucket[5m])
+          ) > 60
+        for: 10m
+        labels:
+          severity: warn
+          component: chain
+        annotations:
+          summary: "DA finalization p95 >60s on {{ $labels.instance }}"
+          description: |
+            95th-percentile time from blob submission to Celestia
+            finalization is above 60s for 10m+. Either Celestia is
+            congested or our submission path is buffering. Investigate
+            via the Celestia explorer + the local light node.
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/da-finalization-latency-high.md


### PR DESCRIPTION
Closes #268.

## What ships

- **`ops/prometheus/alerts.yaml`** — 7 alert rules across 3 groups (liveness / capacity / DA), referencing the real metric names from `crates/rollup/src/metrics.rs`:
  - `BlockHeightStall` (page) — block_height unchanged for 60s+
  - `HealthDown` (page) — `/metrics` scrape failing 30s+
  - `ReadyFalse` (warn) — `/ready` non-200 for 60s+
  - `MempoolDeep` (warn) — depth > 1000 for 5m+
  - `DiskFillingFast` (warn) — state DB growth >10%/hour for 30m+
  - `DASubmissionFailures` (page) — failure rate > 0 for 5m+
  - `DAFinalizationLatencyHigh` (warn) — p95 > 60s for 10m+
- **`ops/prometheus/alertmanager.yaml`** — single-operator routing (Slack + email for page-severity; Slack-only for warn/info); inhibition rules so a page suppresses sibling warns; secrets via file-mounts (`/run/secrets/slack_webhook_url`, `/run/secrets/smtp_password`). Never in repo.
- **`docs/development/runbooks/alerts/`** — one runbook per alert. Each follows the same shape: what fired / likely causes ranked by frequency / first checks / fix / false positives / escalation.
- Cross-link from `public-devnet-deploy.md` Step 5 (monitoring) so the runbook surfaces inline with the deploy guide.

## Test plan

- [x] YAML structure validated against Prometheus / Alertmanager v2 schemas (rendered locally; no syntax errors)
- [x] Each `runbook_url` annotation resolves to an actual file path post-merge
- [x] Markdown renders cleanly in GitHub preview
- [x] Cross-references between alert runbooks and existing operator runbooks (`celestia-light-node.md`, `da-signer-rotation.md`) are bidirectional
- [ ] **Operator action required to put this into effect**: deploy Prometheus + Alertmanager, render `alertmanager.yaml` with secrets injected, point Prometheus at `alerts.yaml` via `rule_files:`. Then exercise the wiring by killing `ligate-node` and confirming `HealthDown` fires within 90s.

## Open follow-ups noted in the rules

- `MempoolDeep` threshold (1000) is a placeholder; tune from real Phase 6.1 load.
- `DASubmissionFailures` depends on Phase 6.2 metrics (`ligate_da_submission_failures_total` lands with #164).
- A `ligate_ready` gauge would let us drop the blackbox-exporter dependency for `ReadyFalse`. Filed as a follow-up to #110.