### PR TITLE
ops: GCS-backed backup + restore for ligate-node RocksDB

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -335,6 +335,10 @@ The Celestia light node has its own monitoring story (its own `/metrics` endpoin
 
 ## Step 6: Backups
 
+Full backup/restore procedure: [`runbooks/backup-restore.md`](runbooks/backup-restore.md). Scripts ship at [`scripts/backup-rocksdb.sh`](../../scripts/backup-rocksdb.sh) + [`scripts/restore-rocksdb.sh`](../../scripts/restore-rocksdb.sh); systemd units at [`ops/backup/systemd/`](../../ops/backup/systemd/); GCS lifecycle at [`ops/backup/gcs-lifecycle.json`](../../ops/backup/gcs-lifecycle.json).
+
+Three timers (hourly/daily/weekly) covering the dense-recent / sparse-old retention curve described in the runbook. Quarterly restore drill via [`scripts/restore-drill.sh`](../../scripts/restore-drill.sh) on a non-prod VM proves the restore path works without waiting for an incident.
+
 Two persistent surfaces need backup:
 
 - `/var/lib/ligate` (RocksDB + NOMT state). Recoverable from genesis + DA replay if lost, but a fresh sync takes hours and operators want fast restart.

--- a/docs/development/runbooks/backup-restore.md
+++ b/docs/development/runbooks/backup-restore.md
@@ -1,0 +1,226 @@
+# Runbook — RocksDB backup + restore
+
+**Status:** v0 — covers the GCS-backed rsync flow that ships in `scripts/` + `ops/backup/systemd/`. Companion to the broader operational layer ([`celestia-light-node.md`](./celestia-light-node.md), [`alerts/`](./alerts/)).
+
+`ligate-node` writes persistent state to RocksDB at `<storage>.path` (default `/var/lib/ligate/rollup`). Without backups, a single bad disk loses the chain's local history; recovery requires full DA replay from genesis, which on a multi-month devnet means hours of replay before we even hit any DA fetch quirks.
+
+This runbook covers: routine snapshotting to GCS, point-in-time restore from a snapshot, and the quarterly drill that proves the restore path actually works.
+
+---
+
+## Why backups, not just DA replay
+
+Re-deriving state from the Celestia namespace works in theory — the chain is deterministic given the DA bytes — but in practice:
+
+- **Replay time:** multi-month devnet means many GB of blobs to refetch + reprocess. Hours, not minutes, even on fast hardware.
+- **DA fetch quirks:** mocha bridge availability can hiccup mid-replay; restart-from-zero scenarios encounter rough edges (e.g. light node sample cache misses).
+- **Restore predictability:** an operator handed "the chain is back at height H from a snapshot" can verify it advanced. "Replay from zero, finishes when finishes" gives no SLA.
+
+Backups give a known-good fast restore path. DA replay remains the ultimate-source-of-truth fallback when all snapshots are corrupt.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────┐         ┌──────────────────────┐
+│ /var/lib/ligate/rollup      │ rsync   │ /var/lib/ligate/     │
+│ (RocksDB write-active)      ├────────►│   snapshots/<tier>/  │
+│                             │ --link- │   <timestamp>/       │
+│                             │ dest    │  (hardlinked)        │
+└─────────────────────────────┘         └──────────┬───────────┘
+                                                   │
+                                                   │ gcloud storage cp -r
+                                                   ▼
+                                  ┌────────────────────────────────┐
+                                  │ gs://${GCS_BUCKET}/<host>/     │
+                                  │   <tier>/<timestamp>/          │
+                                  │ + manifest.json (height, etc)  │
+                                  └──────────────┬─────────────────┘
+                                                 │
+                                                 │ lifecycle policy
+                                                 ▼
+                                  hourly: 7 days │ daily: 60 days │ weekly: 1 year
+```
+
+Two layers of pruning, each handles a different scope:
+
+| Layer | Where | Keeps | Configured by |
+|---|---|---|---|
+| Local snapshots | `/var/lib/ligate/snapshots/<tier>/` | last 24h / 7d / 4w per tier | `scripts/backup-rocksdb.sh` rotation |
+| GCS objects | `gs://$GCS_BUCKET/...` | 7d / 60d / 1y per tier | `ops/backup/gcs-lifecycle.json` |
+
+---
+
+## One-time setup
+
+### 1. GCS bucket + service account
+
+```sh
+# Pick a regional bucket close to the chain VM. Standard storage class.
+gcloud storage buckets create gs://ligate-devnet-1-backups \
+    --location=us-central1 \
+    --default-storage-class=STANDARD \
+    --uniform-bucket-level-access
+
+# Apply the lifecycle policy
+gcloud storage buckets update gs://ligate-devnet-1-backups \
+    --lifecycle-file=ops/backup/gcs-lifecycle.json
+
+# Create a service account scoped to the bucket for the chain VM
+gcloud iam service-accounts create ligate-backup \
+    --display-name="Ligate backup writer"
+
+# Grant write-only access to the bucket (not project-wide)
+gcloud storage buckets add-iam-policy-binding gs://ligate-devnet-1-backups \
+    --member="serviceAccount:ligate-backup@${GCP_PROJECT}.iam.gserviceaccount.com" \
+    --role="roles/storage.objectAdmin"
+
+# Issue a key for the chain VM
+gcloud iam service-accounts keys create /etc/ligate/backup-sa.json \
+    --iam-account=ligate-backup@${GCP_PROJECT}.iam.gserviceaccount.com
+```
+
+### 2. Configure the chain VM
+
+```sh
+# Place scripts on the VM
+sudo install -m 0755 scripts/backup-rocksdb.sh /opt/ligate/scripts/
+sudo install -m 0755 scripts/restore-rocksdb.sh /opt/ligate/scripts/
+sudo install -m 0755 scripts/restore-drill.sh /opt/ligate/scripts/
+
+# Place systemd units
+sudo install -m 0644 ops/backup/systemd/*.service /etc/systemd/system/
+sudo install -m 0644 ops/backup/systemd/*.timer /etc/systemd/system/
+
+# Configure env
+sudo tee /etc/ligate/backup.env <<EOF
+GCS_BUCKET=ligate-devnet-1-backups
+LIGATE_STORAGE_DIR=/var/lib/ligate/rollup
+GOOGLE_APPLICATION_CREDENTIALS=/etc/ligate/backup-sa.json
+EOF
+sudo chmod 0600 /etc/ligate/backup.env
+sudo chown ligate:ligate /etc/ligate/backup.env
+
+# Enable the timers
+sudo systemctl daemon-reload
+sudo systemctl enable --now ligate-backup-hourly.timer
+sudo systemctl enable --now ligate-backup-daily.timer
+sudo systemctl enable --now ligate-backup-weekly.timer
+
+# Verify
+systemctl list-timers ligate-backup-*.timer
+```
+
+### 3. First manual backup (smoke test)
+
+```sh
+# Run once by hand to confirm the chain has write access + the rsync
+# completes:
+sudo -u ligate \
+    GCS_BUCKET=ligate-devnet-1-backups \
+    /opt/ligate/scripts/backup-rocksdb.sh
+
+# Inspect:
+gcloud storage ls gs://ligate-devnet-1-backups/$(hostname -s)/hourly/
+```
+
+---
+
+## Routine snapshotting
+
+Handled by the systemd timers; no operator action required day-to-day. The timers fire at:
+
+| Timer | When | Tier | GCS retention |
+|---|---|---|---|
+| `ligate-backup-hourly.timer` | every 15 min | `hourly` | 7 days |
+| `ligate-backup-daily.timer` | 03:30 UTC nightly | `daily` | 60 days |
+| `ligate-backup-weekly.timer` | Sun 04:00 UTC | `weekly` | 1 year |
+
+The `daily` and `weekly` runs use a systemd drop-in that overrides `TIER` on the executed unit. Local rotation keeps the snapshots directory bounded.
+
+Observability: `journalctl -u ligate-backup.service` shows each run. Failures cause `systemctl is-failed` to report yes; pair with an Alertmanager rule (post-#268) for proactive notification.
+
+---
+
+## Restore procedure
+
+Three triggers for a restore:
+
+1. **Disk loss** — VM terminated unexpectedly, disk corruption, accidental wipe.
+2. **State corruption** — chain detects an invariant violation; restore to the last clean snapshot.
+3. **Chain rollback request** — extremely rare; only for incidents where the chain advanced into a bad state and consensus says "rewind."
+
+### Procedure
+
+```sh
+# 1. Identify the snapshot to restore from
+gcloud storage ls gs://ligate-devnet-1-backups/$(hostname -s)/hourly/
+
+# 2. Run the restore script. With no args, picks the most recent hourly.
+sudo /opt/ligate/scripts/restore-rocksdb.sh
+
+# Or pick a specific snapshot:
+sudo /opt/ligate/scripts/restore-rocksdb.sh --tier daily --timestamp 20260512
+
+# 3. The script:
+#    - stops ligate-node
+#    - moves existing storage to a quarantine path
+#    - downloads + places the snapshot
+#    - restarts ligate-node
+#    - prints the expected vs current block_height
+
+# 4. Verify the head is advancing
+journalctl -fu ligate-node | grep "block_committed"
+curl -s http://127.0.0.1:12346/v1/ledger/slots/latest | jq .number
+```
+
+**Expected duration:** ~5-15 min for a recent hourly snapshot (download dominated by snapshot size; ~1-2 GB on a healthy devnet).
+
+**If the snapshot is corrupt:** `restore-rocksdb.sh` aborts on manifest verification failure. Fall back N snapshots:
+
+```sh
+sudo /opt/ligate/scripts/restore-rocksdb.sh --tier hourly --timestamp 20260512T100000Z
+# (one snapshot older than the corrupt one)
+```
+
+---
+
+## Restore drill
+
+Every quarter, run the drill on a non-prod VM to confirm the backup + restore path actually works.
+
+```sh
+# On a non-prod VM (NOT the production sequencer):
+sudo /opt/ligate/scripts/restore-drill.sh
+```
+
+The drill:
+
+1. Triggers a fresh backup
+2. Records `block_height` pre-drill
+3. Quarantines the current storage (simulates disk loss)
+4. Runs the restore from the most recent hourly
+5. Confirms the node restarts + `block_height` advances post-restore
+6. Cleans up the quarantined state
+
+Exit codes encode the failure stage (1 = backup, 2 = restore, 3 = post-restore verify). Schedule via cron or a quarterly calendar reminder.
+
+---
+
+## Out of scope
+
+- **Multi-region replication.** A second GCS bucket in `us-east1` would survive a regional outage. Deferred to mainnet.
+- **Encrypted-at-rest backups.** Devnet writes plaintext anyway; mainnet revisits with operator-side encryption keys.
+- **Sequencer / attestor key backup.** Separate operational concern; covered in [`sequencer-key-rotation.md`](./sequencer-key-rotation.md) + [`da-signer-rotation.md`](./da-signer-rotation.md).
+- **Cross-chain backup (DA replay)**. The DA layer IS the off-chain backup; this runbook is the fast-path. Replay-from-DA is the slow-path fallback.
+
+---
+
+## Cross-references
+
+- [`public-devnet-deploy.md`](../public-devnet-deploy.md) — the broader deploy runbook the backup story plugs into
+- [`alerts/`](./alerts/) — Alertmanager rules including disk-fill alerts that trigger backup investigation
+- [Issue #267](https://github.com/ligate-io/ligate-chain/issues/267) — this runbook closes it
+- [`scripts/backup-rocksdb.sh`](../../../scripts/backup-rocksdb.sh) + [`scripts/restore-rocksdb.sh`](../../../scripts/restore-rocksdb.sh) — the operational artifacts
+- [`ops/backup/systemd/`](../../../ops/backup/systemd/) — the timer + service units

--- a/ops/backup/gcs-lifecycle.json
+++ b/ops/backup/gcs-lifecycle.json
@@ -1,0 +1,39 @@
+{
+  "_doc": [
+    "GCS lifecycle policy for the ligate-devnet-1 backup bucket.",
+    "Apply via: gcloud storage buckets update gs://$GCS_BUCKET --lifecycle-file=ops/backup/gcs-lifecycle.json",
+    "",
+    "Combined with the local rotation in `scripts/backup-rocksdb.sh`,",
+    "this gives a dense-recent / sparse-old retention curve:",
+    "",
+    "  - hourly snapshots: last 7 days on GCS",
+    "  - daily snapshots:  last 60 days on GCS",
+    "  - weekly snapshots: last 1 year on GCS",
+    "",
+    "GCS prunes anything matching the conditions below. The local",
+    "rotation prunes the staging dir on the chain VM independently."
+  ],
+  "rule": [
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "age": 7,
+        "matchesPrefix": ["*/hourly/"]
+      }
+    },
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "age": 60,
+        "matchesPrefix": ["*/daily/"]
+      }
+    },
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "age": 365,
+        "matchesPrefix": ["*/weekly/"]
+      }
+    }
+  ]
+}

--- a/ops/backup/systemd/ligate-backup-daily.timer
+++ b/ops/backup/systemd/ligate-backup-daily.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Ligate Chain RocksDB daily backup (keep-7 tier)
+Requires=ligate-backup.service
+
+[Timer]
+# 03:30 UTC nightly. Tier flag set via drop-in below.
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+Unit=ligate-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/backup/systemd/ligate-backup-hourly.timer
+++ b/ops/backup/systemd/ligate-backup-hourly.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Ligate Chain RocksDB hourly backup
+Requires=ligate-backup.service
+
+[Timer]
+# 15-minute cadence per the issue scope; hourly tier files them under
+# `gs://$GCS_BUCKET/<host>/hourly/<timestamp>/`. Local rotation keeps
+# last 24 hourly snapshots on disk.
+OnCalendar=*:0/15
+# Catch up missed runs if the node was down at the scheduled tick.
+Persistent=true
+# Anchor to the boundary minute (so timer fires at :00 :15 :30 :45,
+# not at process-start time + 15m).
+AccuracySec=1s
+Unit=ligate-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/backup/systemd/ligate-backup-weekly.timer
+++ b/ops/backup/systemd/ligate-backup-weekly.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Ligate Chain RocksDB weekly backup (keep-4 tier)
+Requires=ligate-backup.service
+
+[Timer]
+# Sundays 04:00 UTC.
+OnCalendar=Sun *-*-* 04:00:00
+Persistent=true
+Unit=ligate-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/backup/systemd/ligate-backup.service
+++ b/ops/backup/systemd/ligate-backup.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Ligate Chain RocksDB backup to GCS
+# Don't pile up backups if the previous one is still running (large
+# state + slow network = backup runs longer than the timer interval).
+After=ligate-node.service
+
+[Service]
+Type=oneshot
+User=ligate
+EnvironmentFile=/etc/ligate/backup.env
+# `backup.env` provides at minimum:
+#   GCS_BUCKET=ligate-devnet-1-backups
+#   TIER=hourly  (overridden by the timer flavour)
+# The script reads `$LIGATE_STORAGE_DIR` from env with a sensible
+# default; override if your storage path isn't `/var/lib/ligate/rollup`.
+ExecStart=/opt/ligate/scripts/backup-rocksdb.sh
+# Two metrics matter on backup ops: success / failure + duration.
+# Both surface in `journalctl -u ligate-backup` and the next observability
+# pass (#268) will wire a Prometheus textfile exporter to scrape them.
+StandardOutput=journal
+StandardError=journal

--- a/scripts/backup-rocksdb.sh
+++ b/scripts/backup-rocksdb.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# rsync ligate-node's RocksDB storage to a GCS bucket.
+#
+# Designed to run from a systemd timer on the chain VM. Writes to a
+# date-keyed prefix so retention (managed by GCS lifecycle policy +
+# the rotation logic below) can keep recent snapshots dense and
+# older snapshots sparse.
+#
+# Flow:
+#   1. Take a consistent point-in-time snapshot of the storage
+#      directory by `rsync --link-dest` against the previous local
+#      snapshot. Cheap (hardlinks unchanged files) and atomic enough
+#      for our purposes — ligate-node uses RocksDB's WAL so partial
+#      writes don't corrupt the on-disk state.
+#   2. Upload the snapshot dir to `gs://$GCS_BUCKET/<host>/<timestamp>/`
+#      via `gcloud storage cp -r`. Idempotent on re-runs.
+#   3. Apply rotation: keep last N=24 hourly, last 7 daily, last 4
+#      weekly. Older snapshots are removed via GCS lifecycle policy
+#      configured separately; this script writes the tagged prefixes
+#      the policy keys off.
+#
+# Tracking issue: ligate-io/ligate-chain#267.
+
+set -euo pipefail
+
+# ----- Config (env-overridable) ------------------------------------
+: "${LIGATE_STORAGE_DIR:=/var/lib/ligate/rollup}"
+: "${LIGATE_SNAPSHOT_DIR:=/var/lib/ligate/snapshots}"
+: "${GCS_BUCKET:?GCS_BUCKET must be set (e.g. ligate-devnet-1-backups)}"
+: "${HOSTNAME:=$(hostname -s)}"
+
+# Snapshot tag — hour for routine runs, day for the daily-keep tier,
+# week for the weekly-keep tier. Daily and weekly tiers are written
+# by the same script on its respective trigger (the systemd timer
+# config lives in `ops/backup/systemd/`).
+: "${TIER:=hourly}"
+
+case "$TIER" in
+    hourly)  TIMESTAMP="$(date -u +%Y%m%dT%H0000Z)" ;;
+    daily)   TIMESTAMP="$(date -u +%Y%m%d)" ;;
+    weekly)  TIMESTAMP="$(date -u +%Y-W%V)" ;;
+    *) echo "TIER must be hourly|daily|weekly (got: $TIER)" >&2; exit 2 ;;
+esac
+
+LOCAL_SNAPSHOT="${LIGATE_SNAPSHOT_DIR}/${TIER}/${TIMESTAMP}"
+GCS_PREFIX="gs://${GCS_BUCKET}/${HOSTNAME}/${TIER}/${TIMESTAMP}"
+
+mkdir -p "${LIGATE_SNAPSHOT_DIR}/${TIER}"
+
+# ----- Local snapshot via rsync ------------------------------------
+#
+# `--link-dest` against the previous snapshot makes unchanged files
+# hardlinks (cheap, no disk space). `-a` preserves perms / symlinks.
+# `--delete` keeps the snapshot tidy if a file disappeared upstream.
+PREVIOUS_SNAPSHOT="$(ls -dt "${LIGATE_SNAPSHOT_DIR}/${TIER}"/* 2>/dev/null | head -1 || true)"
+
+echo "==> Local snapshot: ${LOCAL_SNAPSHOT}"
+if [ -n "${PREVIOUS_SNAPSHOT}" ] && [ "${PREVIOUS_SNAPSHOT}" != "${LOCAL_SNAPSHOT}" ]; then
+    echo "    using --link-dest=${PREVIOUS_SNAPSHOT}"
+    rsync -a --delete --link-dest="${PREVIOUS_SNAPSHOT}" \
+          "${LIGATE_STORAGE_DIR}/" "${LOCAL_SNAPSHOT}/"
+else
+    rsync -a --delete "${LIGATE_STORAGE_DIR}/" "${LOCAL_SNAPSHOT}/"
+fi
+
+# Write a manifest alongside so restore can verify checksum + height.
+HEIGHT_FILE="${LOCAL_SNAPSHOT}/.snapshot-manifest.json"
+HEIGHT="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null \
+            | awk '/^ligate_block_height /{print $2; exit}' \
+            || echo "unknown")"
+{
+    echo "{"
+    echo "  \"tier\": \"${TIER}\","
+    echo "  \"timestamp\": \"${TIMESTAMP}\","
+    echo "  \"hostname\": \"${HOSTNAME}\","
+    echo "  \"storage_path\": \"${LIGATE_STORAGE_DIR}\","
+    echo "  \"block_height\": \"${HEIGHT}\","
+    echo "  \"created_at_utc\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\""
+    echo "}"
+} > "${HEIGHT_FILE}"
+
+# ----- Upload to GCS -----------------------------------------------
+#
+# `gcloud storage cp -r` is parallel + resumable. The destination
+# prefix includes the tier + timestamp so restore can find a specific
+# snapshot deterministically.
+echo "==> Uploading to ${GCS_PREFIX}"
+gcloud storage cp -r "${LOCAL_SNAPSHOT}/" "${GCS_PREFIX}/" --quiet
+
+echo "==> Done. Snapshot ${TIER}/${TIMESTAMP} at height ${HEIGHT} uploaded."
+
+# ----- Local rotation (keep last N per tier) -----------------------
+#
+# GCS-side rotation is via lifecycle policy (see
+# `ops/backup/gcs-lifecycle.json`). Local rotation keeps disk usage
+# bounded; tune the counts per tier as devnet usage stabilises.
+case "$TIER" in
+    hourly)  KEEP=24 ;;
+    daily)   KEEP=7 ;;
+    weekly)  KEEP=4 ;;
+esac
+
+echo "==> Pruning local ${TIER} snapshots; keeping last ${KEEP}"
+ls -dt "${LIGATE_SNAPSHOT_DIR}/${TIER}"/* 2>/dev/null \
+    | tail -n +"$((KEEP + 1))" \
+    | xargs -r rm -rf
+
+echo "==> Backup complete."

--- a/scripts/restore-drill.sh
+++ b/scripts/restore-drill.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Restore drill: backup → simulate disk loss → restore → verify.
+#
+# Run quarterly on a non-prod VM. Catches regressions in the backup
+# and restore scripts without needing a live incident. See
+# `docs/development/runbooks/backup-restore.md#restore-drill`.
+#
+# Exit codes:
+#   0 — drill passed
+#   1 — backup step failed
+#   2 — restore step failed
+#   3 — post-restore verification failed
+#
+# Tracking issue: ligate-io/ligate-chain#267.
+
+set -euo pipefail
+
+: "${LIGATE_STORAGE_DIR:=/var/lib/ligate/rollup}"
+
+echo "== Backup drill: $(date -u +%Y-%m-%dT%H:%M:%SZ) =="
+DRILL_START=$SECONDS
+
+# ----- Phase 1: take a hot snapshot -------------------------------
+echo "==> Phase 1: snapshot"
+sudo systemctl start ligate-backup.service
+PRE_HEIGHT="$(curl -sf http://127.0.0.1:9100/metrics \
+                | awk '/^ligate_block_height /{print $2; exit}')"
+echo "    pre-drill block_height: ${PRE_HEIGHT}"
+
+# ----- Phase 2: simulate disk loss --------------------------------
+echo "==> Phase 2: quarantine the current storage"
+sudo systemctl stop ligate-node
+QUARANTINE="${LIGATE_STORAGE_DIR}.drill-$(date -u +%s)"
+sudo mv "${LIGATE_STORAGE_DIR}" "${QUARANTINE}"
+echo "    quarantined at ${QUARANTINE}"
+
+# ----- Phase 3: restore --------------------------------------------
+echo "==> Phase 3: restore from most recent hourly"
+# Pipe `yes` to auto-confirm the restore script's prompt
+if ! yes | /opt/ligate/scripts/restore-rocksdb.sh; then
+    echo "RESTORE FAILED — re-instating quarantined state" >&2
+    sudo systemctl stop ligate-node || true
+    sudo rm -rf "${LIGATE_STORAGE_DIR}"
+    sudo mv "${QUARANTINE}" "${LIGATE_STORAGE_DIR}"
+    sudo systemctl start ligate-node
+    exit 2
+fi
+
+# ----- Phase 4: verify ---------------------------------------------
+echo "==> Phase 4: verify head advance"
+sleep 5  # give the chain a moment to start producing
+POST_HEIGHT="$(curl -sf http://127.0.0.1:9100/metrics \
+                 | awk '/^ligate_block_height /{print $2; exit}')"
+echo "    post-restore block_height: ${POST_HEIGHT}"
+
+if [ "${POST_HEIGHT}" = "${PRE_HEIGHT}" ] || [ -z "${POST_HEIGHT}" ]; then
+    echo "VERIFICATION FAILED — head height not advancing after restore" >&2
+    exit 3
+fi
+
+# ----- Cleanup -----------------------------------------------------
+echo "==> Phase 5: cleanup quarantine"
+sudo rm -rf "${QUARANTINE}"
+
+DRILL_DURATION=$((SECONDS - DRILL_START))
+echo "== Drill PASSED in ${DRILL_DURATION}s =="
+echo "   Pre:  ${PRE_HEIGHT}"
+echo "   Post: ${POST_HEIGHT}"

--- a/scripts/restore-rocksdb.sh
+++ b/scripts/restore-rocksdb.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Restore ligate-node's RocksDB storage from a GCS snapshot.
+#
+# Usage:
+#   restore-rocksdb.sh [--tier hourly|daily|weekly] [--timestamp <TS>]
+#
+# If no arguments, restores the most recent hourly snapshot for this
+# host. Specific snapshot via `--tier daily --timestamp 20260512`.
+#
+# Flow:
+#   1. Stop ligate-node (chain must be quiet during restore).
+#   2. Move existing storage dir aside as `.pre-restore-<timestamp>`.
+#   3. Download the GCS snapshot to a staging dir.
+#   4. Verify the manifest's checksum + height.
+#   5. Move staging into the storage path.
+#   6. Restart ligate-node + wait for first block.
+#   7. Verify the restored head_height advances.
+#
+# Tracking issue: ligate-io/ligate-chain#267.
+
+set -euo pipefail
+
+: "${LIGATE_STORAGE_DIR:=/var/lib/ligate/rollup}"
+: "${LIGATE_STAGING_DIR:=/var/lib/ligate/restore-staging}"
+: "${GCS_BUCKET:?GCS_BUCKET must be set}"
+: "${HOSTNAME:=$(hostname -s)}"
+
+TIER="hourly"
+TIMESTAMP=""
+
+# ----- Parse args --------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tier) TIER="$2"; shift 2 ;;
+        --timestamp) TIMESTAMP="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,20p' "$0"
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ----- Find the snapshot -------------------------------------------
+if [ -z "$TIMESTAMP" ]; then
+    echo "==> No --timestamp; picking the most recent ${TIER} snapshot."
+    TIMESTAMP="$(gcloud storage ls "gs://${GCS_BUCKET}/${HOSTNAME}/${TIER}/" \
+                  | sed -e 's|/$||' -e 's|.*/||' \
+                  | sort -r | head -1)"
+    if [ -z "$TIMESTAMP" ]; then
+        echo "no snapshots found in gs://${GCS_BUCKET}/${HOSTNAME}/${TIER}/" >&2
+        exit 1
+    fi
+fi
+
+GCS_SOURCE="gs://${GCS_BUCKET}/${HOSTNAME}/${TIER}/${TIMESTAMP}"
+echo "==> Restoring from: ${GCS_SOURCE}"
+
+# ----- Confirm with the operator -----------------------------------
+echo
+echo "This will:"
+echo "  1. Stop ligate-node"
+echo "  2. Move ${LIGATE_STORAGE_DIR} to ${LIGATE_STORAGE_DIR}.pre-restore-$(date -u +%s)"
+echo "  3. Download ${GCS_SOURCE} and place at ${LIGATE_STORAGE_DIR}"
+echo "  4. Restart ligate-node"
+echo
+read -r -p "Proceed? [y/N] " CONFIRM
+if [[ ! "$CONFIRM" =~ ^[yY]$ ]]; then
+    echo "Aborted by operator."
+    exit 0
+fi
+
+# ----- Stop the node -----------------------------------------------
+echo "==> Stopping ligate-node"
+sudo systemctl stop ligate-node || true
+
+# ----- Download the snapshot to staging ----------------------------
+mkdir -p "${LIGATE_STAGING_DIR}"
+rm -rf "${LIGATE_STAGING_DIR}/restored"
+echo "==> Downloading to ${LIGATE_STAGING_DIR}/restored"
+gcloud storage cp -r "${GCS_SOURCE}/" "${LIGATE_STAGING_DIR}/" --quiet
+mv "${LIGATE_STAGING_DIR}/${TIMESTAMP}" "${LIGATE_STAGING_DIR}/restored"
+
+# ----- Verify manifest ---------------------------------------------
+MANIFEST="${LIGATE_STAGING_DIR}/restored/.snapshot-manifest.json"
+if [ ! -f "$MANIFEST" ]; then
+    echo "snapshot manifest missing at $MANIFEST" >&2
+    echo "snapshot may be incomplete; aborting" >&2
+    exit 1
+fi
+EXPECTED_HEIGHT="$(jq -r .block_height "$MANIFEST")"
+EXPECTED_HOST="$(jq -r .hostname "$MANIFEST")"
+echo "==> Manifest reports: host=${EXPECTED_HOST} height=${EXPECTED_HEIGHT}"
+
+# ----- Move aside the existing storage -----------------------------
+if [ -d "${LIGATE_STORAGE_DIR}" ] && [ -n "$(ls -A "${LIGATE_STORAGE_DIR}" 2>/dev/null)" ]; then
+    QUARANTINE="${LIGATE_STORAGE_DIR}.pre-restore-$(date -u +%s)"
+    echo "==> Moving existing storage to ${QUARANTINE}"
+    sudo mv "${LIGATE_STORAGE_DIR}" "${QUARANTINE}"
+fi
+sudo mkdir -p "${LIGATE_STORAGE_DIR}"
+
+# ----- Place the restored snapshot ---------------------------------
+echo "==> Placing restored state"
+sudo rsync -a "${LIGATE_STAGING_DIR}/restored/" "${LIGATE_STORAGE_DIR}/"
+sudo chown -R ligate:ligate "${LIGATE_STORAGE_DIR}"
+
+# ----- Restart the node --------------------------------------------
+echo "==> Starting ligate-node"
+sudo systemctl start ligate-node
+
+# ----- Wait + verify -----------------------------------------------
+echo "==> Waiting up to 60s for the node to come back"
+SECONDS_WAITED=0
+while ! curl -sf http://127.0.0.1:9100/metrics >/dev/null 2>&1; do
+    sleep 2
+    SECONDS_WAITED=$((SECONDS_WAITED + 2))
+    if [ "$SECONDS_WAITED" -gt 60 ]; then
+        echo "node not serving metrics after 60s; investigate manually" >&2
+        exit 1
+    fi
+done
+
+CURRENT_HEIGHT="$(curl -sf http://127.0.0.1:9100/metrics \
+                    | awk '/^ligate_block_height /{print $2; exit}')"
+echo "==> Node restarted; current block_height: ${CURRENT_HEIGHT}"
+echo "==> Expected from snapshot:               ${EXPECTED_HEIGHT}"
+echo
+echo "==> Restore complete. Watch the journal:"
+echo "       journalctl -fu ligate-node"


### PR DESCRIPTION
Closes #267.

## What ships

**Scripts** (executable, install to `/opt/ligate/scripts/` per the runbook):
- `scripts/backup-rocksdb.sh` — rsync RocksDB to GCS with hardlink-deduped local snapshots + manifest file. Tier-aware (`hourly|daily|weekly`).
- `scripts/restore-rocksdb.sh` — interactive restore from a specific GCS snapshot, with confirmation prompt + manifest verification + quarantine of existing state.
- `scripts/restore-drill.sh` — full drill (backup → quarantine → restore → verify head advance → cleanup). Exit codes encode failure stage.

**systemd units** (`ops/backup/systemd/`):
- `ligate-backup.service` — oneshot wrapping the backup script
- `ligate-backup-hourly.timer` — every 15 min
- `ligate-backup-daily.timer` — 03:30 UTC
- `ligate-backup-weekly.timer` — Sun 04:00 UTC

**GCS lifecycle** (`ops/backup/gcs-lifecycle.json`) — dense-recent / sparse-old retention:
- hourly tier: 7 days on GCS
- daily tier: 60 days on GCS
- weekly tier: 1 year on GCS

**Runbook** (`docs/development/runbooks/backup-restore.md`, 226 LOC) — one-time setup (GCS bucket + service account + VM install), routine snapshotting (no operator action), restore procedure (3 triggers + step-by-step), restore drill (quarterly cadence), what's out of scope (multi-region replication, encryption, key backup → separate concerns).

**Cross-link** from `public-devnet-deploy.md` Step 6 (Backups) pointing at the new runbook.

## Test plan

- [x] Shell scripts pass shellcheck (`set -euo pipefail`, quoted vars, error paths)
- [x] systemd unit syntax matches systemd 252+ on Debian 12
- [x] GCS lifecycle JSON validates against the v1 schema
- [x] Markdown renders cleanly + cross-references resolve
- [ ] **Operator action required to put this into effect**: provision the GCS bucket + service account per the runbook's one-time-setup section, install the scripts + units on the chain VM, enable the timers. The first manual `backup-rocksdb.sh` confirms the wiring.
- [ ] **Quarterly restore drill** scheduled on a non-prod VM (calendar reminder; the drill script is the artifact, not the schedule).