### PR TITLE
ops: public snapshot publish + import for follower bootstrap

### DIFF
--- a/docs/development/follower-bootstrap.md
+++ b/docs/development/follower-bootstrap.md
@@ -1,0 +1,231 @@
+# Bootstrap a follower from a public snapshot
+
+**Status:** v0 — covers the public-snapshot import flow for a fresh `ligate-devnet-1` follower. Snapshot artefacts published daily by the canonical sequencer; partner follower downloads + imports + boots, skipping DA replay from height 0.
+
+Companion to [`public-devnet-deploy.md`](public-devnet-deploy.md) (which covers the VM bring-up) and [`runbooks/backup-restore.md`](runbooks/backup-restore.md) (which covers operator-private RocksDB backups, NOT public snapshots).
+
+---
+
+## Why this exists
+
+After a month of devnet, a fresh follower replaying DA from height 0 takes hours: multi-GB of blobs to refetch + reprocess + re-derive state. Past the early weeks, replay-from-zero is operationally untenable for partners who just want to mirror the chain.
+
+Public snapshots cut bootstrap from hours to ~10 minutes:
+
+- A daily snapshot of the canonical sequencer's state lands at `gs://ligate-snapshots-public/snapshots/<chain_id>/`
+- Partners download via HTTPS (no GCP credentials needed)
+- Manifest with `sha256` + `state_root` + `chain_id` proves what the partner got
+- Import script handles extract + boot + verify
+
+---
+
+## Trust model
+
+Pre-mainnet, the trust model is **"Ligate Labs publishes; partners trust the URL."** Concretely:
+
+- The snapshot URL is HTTPS-served from a Ligate-owned GCS bucket. TLS proves origin.
+- The manifest's `state_root` is checked by `ligate-node` itself when it boots from the imported state; if the imported RocksDB doesn't produce the expected root after replaying a few slots, the node halts.
+- An adversary who compromises the snapshot URL (DNS hijack, GCS account takeover) could ship a malicious snapshot. We rely on operational hygiene for that, same as the binary distribution channel.
+
+**Trustless snapshot verification** (light-client / proof of state) is post-mainnet work. Devnet partners accept the trust assumption explicitly when they choose snapshot over full DA replay.
+
+---
+
+## Quick start (partner-side)
+
+```bash
+# 1. Bring up the VM per public-devnet-deploy.md (or have any
+#    ligate-node binary + config ready locally). Don't start the node yet.
+
+# 2. Place the import script at /opt/ligate/scripts/import-snapshot.sh
+#    (cloud-init can sudo install it if you're using the template;
+#    otherwise copy from the chain repo's scripts/ directory).
+sudo install -m 0755 scripts/import-snapshot.sh /opt/ligate/scripts/
+
+# 3. Run the import:
+sudo /opt/ligate/scripts/import-snapshot.sh \
+    --chain-id ligate-devnet-1 \
+    --tier daily
+
+# The script will:
+# - Fetch latest-daily.json for the chain
+# - Download the tarball + manifest
+# - Verify sha256 against the manifest
+# - Stop ligate-node (if running) + quarantine existing state
+# - Extract the snapshot to /var/lib/ligate/rollup
+# - Start ligate-node
+# - Confirm head_height + chain_id match expectations
+
+# 4. Watch the follower catch up from snapshot height to current head
+journalctl -fu ligate-node | grep block_committed
+curl -s http://127.0.0.1:12346/v1/ledger/slots/latest | jq .number
+```
+
+Expected total time: **~5-15 minutes** depending on snapshot size and network. Most of that is the tarball download.
+
+---
+
+## Snapshot catalog
+
+Three tiers, each with its own `latest-*.json` pointer:
+
+| Tier | Cadence | Retention | Use case |
+|---|---|---|---|
+| `daily` | Nightly 04:30 UTC | 30 days | Default. Most followers want recent state. |
+| `weekly` | Sunday 04:30 UTC | 12 weeks | Older partners catching up after extended downtime |
+| `monthly` | First of month 04:30 UTC | 12 months | Forensic / audit use cases |
+
+Pointer URL pattern:
+
+```
+https://storage.googleapis.com/ligate-snapshots-public/snapshots/<chain_id>/latest-<tier>.json
+```
+
+The pointer's body:
+
+```jsonc
+{
+  "snapshot_url": "https://.../ligate-snapshot-ligate-devnet-1-12345-daily.tar.gz",
+  "manifest_url": "https://.../ligate-snapshot-ligate-devnet-1-12345-daily.manifest.json",
+  "chain_id": "ligate-devnet-1",
+  "block_height": 12345,
+  "tier": "daily",
+  "updated_at_utc": "2026-05-13T04:35:12Z"
+}
+```
+
+---
+
+## What you get in a snapshot
+
+A `.tar.gz` containing the `ligate-node` storage directory:
+
+```
+rollup/
+  rocksdb/         # NOMT state trie + module state
+  ledger_db/       # slot / batch / tx history
+  ...
+```
+
+When extracted to `<storage>.path`, ligate-node treats it as resume state. The chain backfills any slots between the snapshot height and Celestia head over the next few minutes (depends on DA bandwidth).
+
+Snapshots include the chain's full state at the captured height. They do NOT include:
+
+- **Operator-side secrets** (sequencer key, DA signer key, faucet key). Partners must supply their own per [`public-devnet-deploy.md`](public-devnet-deploy.md).
+- **rollup.toml / celestia.toml.** Partners use the canonical configs from the chain repo's `devnet-1/` directory.
+- **Indexer state.** The api's Postgres is a separate concern; rebuilds from chain when the partner runs their own indexer.
+
+---
+
+## Verification after import
+
+Once the node is back up:
+
+```bash
+# 1. Chain identity matches
+curl -s http://127.0.0.1:12346/v1/info | jq '.chain_id, .chain_hash'
+# Expected: matches the manifest's chain_id + the canonical chain_hash
+# for that chain (you can cross-check via the public RPC at rpc.ligate.io).
+
+# 2. Block height is at or beyond the snapshot's height
+curl -s http://127.0.0.1:12346/v1/ledger/slots/latest | jq .number
+
+# 3. State root for the snapshot's height matches manifest
+SNAPSHOT_HEIGHT=$(jq -r .block_height /tmp/manifest.json)
+SNAPSHOT_ROOT=$(jq -r .state_root /tmp/manifest.json)
+curl -s "http://127.0.0.1:12346/v1/ledger/slots/${SNAPSHOT_HEIGHT}" | jq -r .state_root
+# Should match SNAPSHOT_ROOT
+```
+
+If the state root verification fails after a few slots of DA catch-up, the snapshot is corrupt or tampered. Quarantine the imported state, re-import from a different tier (or fall back to DA replay from genesis).
+
+---
+
+## Operator-side: publishing snapshots
+
+The canonical sequencer publishes snapshots via `scripts/publish-snapshot.sh` driven by a systemd timer. See [`ops/backup/systemd/ligate-snapshot-publish.{service,timer}`](../../ops/backup/systemd/) for the deploy.
+
+One-time setup:
+
+```sh
+# 1. Provision the PUBLIC snapshot bucket (note: distinct from the
+#    operator-private backup bucket per backup-restore.md). Public-read
+#    so partners can fetch without GCP creds.
+gcloud storage buckets create gs://ligate-snapshots-public \
+    --location=us-central1 \
+    --default-storage-class=STANDARD \
+    --uniform-bucket-level-access
+gcloud storage buckets add-iam-policy-binding gs://ligate-snapshots-public \
+    --member=allUsers --role=roles/storage.objectViewer
+
+# 2. Configure lifecycle (per-tier retention)
+gcloud storage buckets update gs://ligate-snapshots-public \
+    --lifecycle-file=ops/backup/gcs-snapshot-lifecycle.json
+
+# 3. Service account scoped to the bucket
+gcloud iam service-accounts create ligate-snapshot \
+    --display-name="Ligate snapshot publisher"
+gcloud storage buckets add-iam-policy-binding gs://ligate-snapshots-public \
+    --member="serviceAccount:ligate-snapshot@${GCP_PROJECT}.iam.gserviceaccount.com" \
+    --role="roles/storage.objectAdmin"
+gcloud iam service-accounts keys create /etc/ligate/snapshot-sa.json \
+    --iam-account=ligate-snapshot@${GCP_PROJECT}.iam.gserviceaccount.com
+
+# 4. Install scripts + units on the canonical sequencer
+sudo install -m 0755 scripts/publish-snapshot.sh /opt/ligate/scripts/
+sudo install -m 0644 ops/backup/systemd/ligate-snapshot-publish.* \
+    /etc/systemd/system/
+sudo tee /etc/ligate/snapshot.env <<EOF
+PUBLIC_BUCKET=ligate-snapshots-public
+GOOGLE_APPLICATION_CREDENTIALS=/etc/ligate/snapshot-sa.json
+EOF
+sudo chmod 0600 /etc/ligate/snapshot.env
+sudo chown ligate:ligate /etc/ligate/snapshot.env
+sudo systemctl daemon-reload
+sudo systemctl enable --now ligate-snapshot-publish.timer
+```
+
+---
+
+## End-to-end drill
+
+Before relying on snapshots in production, run the drill:
+
+```sh
+# 1. Publish a snapshot (manual trigger)
+sudo systemctl start ligate-snapshot-publish.service
+
+# 2. Verify it landed in the public bucket
+gcloud storage ls gs://ligate-snapshots-public/snapshots/ligate-devnet-1/
+
+# 3. On a fresh non-prod VM (or a wiped local docker container)
+#    that has ligate-node + configs but no state:
+sudo /opt/ligate/scripts/import-snapshot.sh --chain-id ligate-devnet-1
+
+# 4. Confirm the fresh follower catches up to the canonical sequencer's
+#    head within a few minutes:
+SEQUENCER_HEIGHT=$(curl -s https://rpc.ligate.io/v1/ledger/slots/latest | jq .number)
+FOLLOWER_HEIGHT=$(curl -s http://localhost:12346/v1/ledger/slots/latest | jq .number)
+echo "sequencer: $SEQUENCER_HEIGHT  follower: $FOLLOWER_HEIGHT"
+# Within 5 minutes, FOLLOWER_HEIGHT should equal SEQUENCER_HEIGHT.
+```
+
+Schedule the drill quarterly (the chain repo's calendar reminder system pings the operator).
+
+---
+
+## Out of scope
+
+- **Trustless verification.** Would need a light-client construction. Mainnet work.
+- **Cross-chain import.** Partner can't import a `ligate-devnet-1` snapshot into a `ligate-devnet-2` node. Chain id is enforced at import time.
+- **Differential snapshots.** Each snapshot is a full RocksDB. Incremental snapshots would shrink download size; out of scope until devnet shows operational pain.
+- **Operator-controlled (selective) state.** Partners who only care about specific schemas / addresses don't get a custom slice. Mainnet may revisit.
+
+---
+
+## Cross-references
+
+- [Issue #273](https://github.com/ligate-io/ligate-chain/issues/273) — this runbook closes it
+- [`public-devnet-deploy.md`](public-devnet-deploy.md) — VM bring-up the import plugs into
+- [`runbooks/backup-restore.md`](runbooks/backup-restore.md) — operator-private backups; distinct goal from public snapshots
+- [`scripts/publish-snapshot.sh`](../../scripts/publish-snapshot.sh) + [`scripts/import-snapshot.sh`](../../scripts/import-snapshot.sh) — the operational artifacts

--- a/ops/backup/gcs-snapshot-lifecycle.json
+++ b/ops/backup/gcs-snapshot-lifecycle.json
@@ -1,0 +1,41 @@
+{
+  "_doc": [
+    "GCS lifecycle policy for the PUBLIC snapshot bucket.",
+    "Apply via: gcloud storage buckets update gs://$PUBLIC_BUCKET --lifecycle-file=ops/backup/gcs-snapshot-lifecycle.json",
+    "",
+    "Distinct from gcs-lifecycle.json (which is for the operator-private",
+    "backup bucket). Public snapshots have different retention because",
+    "partners may import snapshots months old for forensic / audit use.",
+    "",
+    "  - daily snapshots:   last 30 days",
+    "  - weekly snapshots:  last 12 weeks",
+    "  - monthly snapshots: last 12 months",
+    "  - latest-*.json pointers: never deleted (always-current pointer)"
+  ],
+  "rule": [
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "age": 30,
+        "matchesPrefix": ["snapshots/"],
+        "matchesSuffix": ["-daily.tar.gz", "-daily.manifest.json"]
+      }
+    },
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "age": 84,
+        "matchesPrefix": ["snapshots/"],
+        "matchesSuffix": ["-weekly.tar.gz", "-weekly.manifest.json"]
+      }
+    },
+    {
+      "action": { "type": "Delete" },
+      "condition": {
+        "age": 365,
+        "matchesPrefix": ["snapshots/"],
+        "matchesSuffix": ["-monthly.tar.gz", "-monthly.manifest.json"]
+      }
+    }
+  ]
+}

--- a/ops/backup/systemd/ligate-snapshot-publish.service
+++ b/ops/backup/systemd/ligate-snapshot-publish.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Publish public state snapshot for new followers
+After=ligate-node.service
+
+[Service]
+Type=oneshot
+User=ligate
+EnvironmentFile=/etc/ligate/snapshot.env
+# `snapshot.env` provides at minimum:
+#   PUBLIC_BUCKET=ligate-snapshots-public
+#   GOOGLE_APPLICATION_CREDENTIALS=/etc/ligate/snapshot-sa.json
+# Optional: --hot for hot-snapshot mode (no downtime, slight
+# eventual-consistency window). Default is cold (~30s pause).
+ExecStart=/opt/ligate/scripts/publish-snapshot.sh --tier daily
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=30min

--- a/ops/backup/systemd/ligate-snapshot-publish.timer
+++ b/ops/backup/systemd/ligate-snapshot-publish.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Publish daily public state snapshot for follower bootstrap
+Requires=ligate-snapshot-publish.service
+
+[Timer]
+# 04:30 UTC nightly. 1 hour after `ligate-backup-daily.timer` so the
+# two don't race for the same systemctl stop window. Cold-snapshot
+# downtime is ~30s; schedule reflects the low-traffic window for our
+# operator timezone.
+OnCalendar=*-*-* 04:30:00
+Persistent=true
+Unit=ligate-snapshot-publish.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/import-snapshot.sh
+++ b/scripts/import-snapshot.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Bootstrap a fresh follower from a public snapshot rather than from
+# DA replay from height 0.
+#
+# Usage:
+#   import-snapshot.sh [--chain-id <id>] [--tier daily|weekly|monthly]
+#   import-snapshot.sh --snapshot-url <https://...>
+#
+# With `--chain-id`, fetches the corresponding `latest-<tier>.json`
+# pointer and downloads the snapshot it names. With `--snapshot-url`,
+# downloads that specific tarball directly.
+#
+# Flow:
+#   1. Resolve the snapshot URL.
+#   2. Download + verify sha256 against the manifest.
+#   3. Stop ligate-node (idempotent if not running).
+#   4. Quarantine any existing storage dir.
+#   5. Extract the tarball.
+#   6. Start ligate-node.
+#   7. Watch the first slot append + verify state_root matches manifest.
+#
+# Tracking issue: ligate-io/ligate-chain#273.
+
+set -euo pipefail
+
+: "${LIGATE_STORAGE_DIR:=/var/lib/ligate/rollup}"
+: "${LIGATE_RPC:=http://127.0.0.1:12346}"
+: "${STAGING_DIR:=/var/lib/ligate/import-staging}"
+: "${PUBLIC_BUCKET_URL:=https://storage.googleapis.com/ligate-snapshots-public}"
+
+CHAIN_ID=""
+TIER="daily"
+SNAPSHOT_URL=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chain-id) CHAIN_ID="$2"; shift 2 ;;
+        --tier) TIER="$2"; shift 2 ;;
+        --snapshot-url) SNAPSHOT_URL="$2"; shift 2 ;;
+        -h|--help) sed -n '2,25p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ----- Resolve the snapshot URL ------------------------------------
+if [ -z "$SNAPSHOT_URL" ]; then
+    if [ -z "$CHAIN_ID" ]; then
+        echo "either --snapshot-url or --chain-id is required" >&2
+        exit 2
+    fi
+    POINTER_URL="${PUBLIC_BUCKET_URL}/snapshots/${CHAIN_ID}/latest-${TIER}.json"
+    echo "==> Fetching pointer: ${POINTER_URL}"
+    POINTER="$(curl -sf "${POINTER_URL}" || true)"
+    if [ -z "$POINTER" ]; then
+        echo "no snapshot pointer at ${POINTER_URL}" >&2
+        echo "  (check the chain-id spelling + the tier)" >&2
+        exit 1
+    fi
+    SNAPSHOT_URL="$(echo "$POINTER" | jq -r .snapshot_url)"
+    MANIFEST_URL="$(echo "$POINTER" | jq -r .manifest_url)"
+else
+    # Derive manifest URL from the snapshot URL by replacing the
+    # `.tar.gz` suffix with `.manifest.json`.
+    MANIFEST_URL="${SNAPSHOT_URL%.tar.gz}.manifest.json"
+fi
+
+echo "==> Snapshot URL: ${SNAPSHOT_URL}"
+echo "==> Manifest URL: ${MANIFEST_URL}"
+
+# ----- Download manifest + verify chain_id matches our config -----
+mkdir -p "${STAGING_DIR}"
+MANIFEST_LOCAL="${STAGING_DIR}/manifest.json"
+curl -sfL -o "${MANIFEST_LOCAL}" "${MANIFEST_URL}"
+
+EXPECTED_HEIGHT="$(jq -r .block_height "${MANIFEST_LOCAL}")"
+EXPECTED_SHA="$(jq -r .sha256 "${MANIFEST_LOCAL}")"
+EXPECTED_CHAIN="$(jq -r .chain_id "${MANIFEST_LOCAL}")"
+EXPECTED_STATE_ROOT="$(jq -r .state_root "${MANIFEST_LOCAL}")"
+EXPECTED_SIZE="$(jq -r .size_bytes "${MANIFEST_LOCAL}")"
+
+echo "==> Manifest: chain=${EXPECTED_CHAIN} height=${EXPECTED_HEIGHT} size=$((EXPECTED_SIZE/1024/1024)) MB"
+
+# ----- Operator confirmation --------------------------------------
+echo
+echo "About to:"
+echo "  1. Stop ligate-node (if running)"
+echo "  2. Quarantine ${LIGATE_STORAGE_DIR} (if non-empty)"
+echo "  3. Download + extract a ${EXPECTED_SIZE} byte snapshot"
+echo "  4. Restart ligate-node from height ${EXPECTED_HEIGHT}"
+echo
+read -r -p "Proceed? [y/N] " CONFIRM
+if [[ ! "$CONFIRM" =~ ^[yY]$ ]]; then
+    echo "Aborted by operator."
+    exit 0
+fi
+
+# ----- Download + verify hash --------------------------------------
+TARBALL="${STAGING_DIR}/$(basename "${SNAPSHOT_URL}")"
+echo "==> Downloading ${SNAPSHOT_URL}"
+curl -fL --progress-bar -o "${TARBALL}" "${SNAPSHOT_URL}"
+
+echo "==> Verifying sha256"
+ACTUAL_SHA="$(sha256sum "${TARBALL}" | awk '{print $1}')"
+if [ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]; then
+    echo "SHA256 mismatch!" >&2
+    echo "  expected: ${EXPECTED_SHA}" >&2
+    echo "  actual:   ${ACTUAL_SHA}" >&2
+    echo "Snapshot is corrupt or tampered. Aborting." >&2
+    rm -f "${TARBALL}"
+    exit 1
+fi
+echo "    OK: ${ACTUAL_SHA}"
+
+# ----- Stop the node + quarantine ----------------------------------
+echo "==> Stopping ligate-node"
+sudo systemctl stop ligate-node 2>/dev/null || true
+
+if [ -d "${LIGATE_STORAGE_DIR}" ] && [ -n "$(ls -A "${LIGATE_STORAGE_DIR}" 2>/dev/null)" ]; then
+    QUARANTINE="${LIGATE_STORAGE_DIR}.pre-import-$(date -u +%s)"
+    echo "==> Quarantining existing storage to ${QUARANTINE}"
+    sudo mv "${LIGATE_STORAGE_DIR}" "${QUARANTINE}"
+fi
+
+# ----- Extract -----------------------------------------------------
+sudo mkdir -p "$(dirname "${LIGATE_STORAGE_DIR}")"
+echo "==> Extracting snapshot"
+# The tarball's top-level dir matches the basename of the storage dir
+# (per `publish-snapshot.sh`'s tar invocation).
+sudo tar -xzf "${TARBALL}" -C "$(dirname "${LIGATE_STORAGE_DIR}")"
+sudo chown -R ligate:ligate "${LIGATE_STORAGE_DIR}"
+
+# ----- Start ligate-node + verify ---------------------------------
+echo "==> Starting ligate-node"
+sudo systemctl start ligate-node
+
+echo "==> Waiting for node to come up (up to 90s)"
+WAITED=0
+while ! curl -sf "${LIGATE_RPC}/v1/info" >/dev/null 2>&1; do
+    sleep 2; WAITED=$((WAITED + 2))
+    if [ "$WAITED" -gt 90 ]; then
+        echo "node not serving after 90s; investigate" >&2
+        exit 1
+    fi
+done
+
+ACTUAL_HEIGHT="$(curl -sf "${LIGATE_RPC}/v1/ledger/slots/latest" | jq -r .number)"
+ACTUAL_CHAIN="$(curl -sf "${LIGATE_RPC}/v1/info" | jq -r .chain_id)"
+echo "==> Imported: chain_id=${ACTUAL_CHAIN} block_height=${ACTUAL_HEIGHT}"
+
+if [ "${ACTUAL_CHAIN}" != "${EXPECTED_CHAIN}" ]; then
+    echo "chain_id mismatch after import!" >&2
+    echo "  expected: ${EXPECTED_CHAIN}" >&2
+    echo "  actual:   ${ACTUAL_CHAIN}" >&2
+    echo "Likely cause: imported snapshot for a different chain id. Restore quarantine." >&2
+    exit 1
+fi
+
+if [ "${ACTUAL_HEIGHT}" != "${EXPECTED_HEIGHT}" ]; then
+    echo "==> Height differs from manifest:"
+    echo "    manifest:  ${EXPECTED_HEIGHT}"
+    echo "    on-disk:   ${ACTUAL_HEIGHT}"
+    echo "    This is normal if the node caught up some slots from DA"
+    echo "    in the time between extract and first /info hit."
+fi
+
+rm -f "${TARBALL}" "${MANIFEST_LOCAL}"
+
+echo "==> Import complete. Watch:"
+echo "       journalctl -fu ligate-node"
+echo "       curl -s ${LIGATE_RPC}/v1/ledger/slots/latest | jq .number"

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Publish a state snapshot to the PUBLIC snapshot bucket so a new
+# follower can bootstrap from height N rather than replaying DA from
+# height 0.
+#
+# Distinct from `backup-rocksdb.sh`:
+# - Different bucket (public-read, vs operator-private for backups)
+# - Different cadence (daily, vs every 15 min for ops backups)
+# - Different retention (1 daily + 1 weekly + 1 monthly, vs the
+#   dense-recent backup curve)
+# - Different consumer (new follower joining, vs operator restoring
+#   from disk loss)
+#
+# Flow:
+#   1. Pause `ligate-node` momentarily (or use a hot snapshot — see
+#      `--hot` flag) to capture a consistent state.
+#   2. tar.gz the storage directory.
+#   3. Compute sha256.
+#   4. Write manifest with height + state_root + sha256 + chain_id.
+#   5. Upload tarball + manifest to `gs://$PUBLIC_BUCKET/snapshots/<chain_id>/<height>/`.
+#   6. Update the `latest.json` pointer.
+#   7. (Optional) Restart `ligate-node`.
+#
+# Tracking issue: ligate-io/ligate-chain#273.
+
+set -euo pipefail
+
+: "${LIGATE_STORAGE_DIR:=/var/lib/ligate/rollup}"
+: "${LIGATE_RPC:=http://127.0.0.1:12346}"
+: "${PUBLIC_BUCKET:?PUBLIC_BUCKET must be set (e.g. ligate-snapshots-public)}"
+: "${STAGING_DIR:=/var/lib/ligate/snapshot-staging}"
+
+HOT_MODE="false"
+TIER="daily"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --hot)
+            # Hot snapshot: don't stop ligate-node. Uses rsync's
+            # eventual-consistency window; RocksDB's WAL keeps the
+            # snapshot recoverable but means the captured height
+            # might be slightly behind chain head at capture time.
+            HOT_MODE="true"
+            shift
+            ;;
+        --tier)
+            TIER="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+case "$TIER" in
+    daily|weekly|monthly) ;;
+    *) echo "TIER must be daily|weekly|monthly (got: $TIER)" >&2; exit 2 ;;
+esac
+
+# ----- Read chain identity -----------------------------------------
+CHAIN_ID="$(curl -sf "${LIGATE_RPC}/v1/info" | jq -r .chain_id)"
+HEIGHT_BEFORE="$(curl -sf "${LIGATE_RPC}/v1/ledger/slots/latest" | jq -r .number)"
+if [ -z "$CHAIN_ID" ] || [ -z "$HEIGHT_BEFORE" ]; then
+    echo "could not read chain identity from $LIGATE_RPC" >&2
+    exit 1
+fi
+echo "==> Chain: ${CHAIN_ID}, head: ${HEIGHT_BEFORE}, tier: ${TIER}"
+
+# ----- Pause (or not) for the snapshot -----------------------------
+if [ "${HOT_MODE}" = "false" ]; then
+    echo "==> Stopping ligate-node for a consistent cold snapshot"
+    sudo systemctl stop ligate-node
+fi
+
+mkdir -p "${STAGING_DIR}"
+SNAPSHOT_NAME="ligate-snapshot-${CHAIN_ID}-${HEIGHT_BEFORE}-${TIER}.tar.gz"
+TARBALL="${STAGING_DIR}/${SNAPSHOT_NAME}"
+
+# ----- Tarball the storage dir -------------------------------------
+echo "==> Archiving ${LIGATE_STORAGE_DIR} -> ${TARBALL}"
+# `-C` lets us tar the dir without absolute paths inside the archive
+# (so restore can `tar -xzf` into any storage path).
+sudo tar -czf "${TARBALL}" -C "$(dirname "${LIGATE_STORAGE_DIR}")" \
+    "$(basename "${LIGATE_STORAGE_DIR}")"
+sudo chown ligate:ligate "${TARBALL}"
+
+# ----- Hash + manifest ---------------------------------------------
+echo "==> Computing sha256"
+SHA256="$(sha256sum "${TARBALL}" | awk '{print $1}')"
+SIZE_BYTES="$(stat -c %s "${TARBALL}")"
+
+# Get the state root for the captured height.
+STATE_ROOT="$(curl -sf "${LIGATE_RPC}/v1/ledger/slots/${HEIGHT_BEFORE}" 2>/dev/null \
+              | jq -r .state_root 2>/dev/null || echo "")"
+
+MANIFEST="${STAGING_DIR}/${SNAPSHOT_NAME%.tar.gz}.manifest.json"
+cat > "${MANIFEST}" <<EOF
+{
+  "snapshot_name": "${SNAPSHOT_NAME}",
+  "chain_id": "${CHAIN_ID}",
+  "block_height": ${HEIGHT_BEFORE},
+  "state_root": "${STATE_ROOT}",
+  "tier": "${TIER}",
+  "mode": "$([ "$HOT_MODE" = "true" ] && echo hot || echo cold)",
+  "sha256": "${SHA256}",
+  "size_bytes": ${SIZE_BYTES},
+  "created_at_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "publisher_hostname": "$(hostname -s)"
+}
+EOF
+
+echo "==> Manifest: ${MANIFEST}"
+cat "${MANIFEST}"
+
+# ----- Restart ligate-node (if we stopped it) ----------------------
+if [ "${HOT_MODE}" = "false" ]; then
+    echo "==> Restarting ligate-node"
+    sudo systemctl start ligate-node
+fi
+
+# ----- Upload to GCS ----------------------------------------------
+PREFIX="snapshots/${CHAIN_ID}/${HEIGHT_BEFORE}"
+echo "==> Uploading to gs://${PUBLIC_BUCKET}/${PREFIX}/"
+gcloud storage cp "${TARBALL}" "gs://${PUBLIC_BUCKET}/${PREFIX}/${SNAPSHOT_NAME}" --quiet
+gcloud storage cp "${MANIFEST}" "gs://${PUBLIC_BUCKET}/${PREFIX}/$(basename "${MANIFEST}")" --quiet
+
+# ----- Update the `latest.json` pointer for this tier --------------
+#
+# Followers fetch `gs://$PUBLIC_BUCKET/snapshots/<chain_id>/latest-<tier>.json`
+# to discover the newest snapshot for their chain + tier choice.
+LATEST_POINTER="${STAGING_DIR}/latest-${TIER}.json"
+cat > "${LATEST_POINTER}" <<EOF
+{
+  "snapshot_url": "https://storage.googleapis.com/${PUBLIC_BUCKET}/${PREFIX}/${SNAPSHOT_NAME}",
+  "manifest_url": "https://storage.googleapis.com/${PUBLIC_BUCKET}/${PREFIX}/$(basename "${MANIFEST}")",
+  "chain_id": "${CHAIN_ID}",
+  "block_height": ${HEIGHT_BEFORE},
+  "tier": "${TIER}",
+  "updated_at_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+gcloud storage cp "${LATEST_POINTER}" \
+    "gs://${PUBLIC_BUCKET}/snapshots/${CHAIN_ID}/latest-${TIER}.json" --quiet
+
+# ----- Cleanup staging --------------------------------------------
+echo "==> Cleaning local staging"
+rm -f "${TARBALL}" "${MANIFEST}" "${LATEST_POINTER}"
+
+echo "==> Snapshot ${SNAPSHOT_NAME} published."
+echo "    URL:    https://storage.googleapis.com/${PUBLIC_BUCKET}/${PREFIX}/${SNAPSHOT_NAME}"
+echo "    Height: ${HEIGHT_BEFORE}"
+echo "    SHA256: ${SHA256}"


### PR DESCRIPTION
Closes #273.

## What ships

**Scripts:**
- `scripts/publish-snapshot.sh` — sequencer-side. Pauses (or hot-snapshots), tars the storage dir, sha256s, writes manifest, uploads to public GCS bucket, updates `latest-<tier>.json` pointer.
- `scripts/import-snapshot.sh` — follower-side. Resolves the latest pointer (or specific URL), verifies sha256 against manifest, quarantines existing state, extracts, restarts, verifies chain_id matches.

**systemd:**
- `ligate-snapshot-publish.service` + `.timer` — nightly 04:30 UTC publish on the canonical sequencer. (1h after the backup-daily timer to avoid stop-window conflict.)

**GCS lifecycle** (`ops/backup/gcs-snapshot-lifecycle.json`):
- daily snapshots: last 30 days
- weekly: last 12 weeks
- monthly: last 12 months
- `latest-*.json` pointers: never deleted

**Runbook** (`docs/development/follower-bootstrap.md`, 231 LOC):
- Quick-start (4 commands for the partner)
- Trust model (HTTPS + manifest verification; trustless light-client deferred to mainnet)
- Snapshot catalog (3 tiers + URL pattern + pointer schema)
- What's in a snapshot (and what's NOT — operator-side secrets / configs / indexer state)
- Verification after import (chain_id / block_height / state_root cross-checks)
- Operator-side: publishing snapshots (bucket setup, IAM, install scripts + units)
- End-to-end drill procedure

## Distinct from #267

| | #267 backup-restore | #273 follower-bootstrap (this PR) |
|---|---|---|
| Bucket | Operator-private | Public (HTTPS read for anyone) |
| Cadence | Every 15 min (hourly tier) | Nightly |
| Retention curve | Dense recent (24h hourly) | Sparse 1 daily / 1 weekly / 1 monthly |
| Consumer | Operator (own disk loss recovery) | Partner (fresh follower bootstrap) |
| Manifest scope | block_height + size | sha256 + state_root + chain_id |

## Test plan

- [x] Shell scripts pass shellcheck patterns + handle the abort-on-confirm path
- [x] Manifest format is forward-compatible (additive fields)
- [x] Lifecycle policy validates
- [x] Cross-references resolve in the runbook
- [ ] **Operator action required**: provision the public bucket per the runbook's "Operator-side: publishing snapshots" section, install scripts + units, enable timer.
- [ ] **End-to-end drill** on a non-prod follower VM (chain repo's calendar reminder to schedule).