### PR TITLE
ops: Mocha smoke gate procedure + optional nightly CI

### DIFF
--- a/.github/workflows/mocha-smoke.yml
+++ b/.github/workflows/mocha-smoke.yml
@@ -1,0 +1,180 @@
+name: Mocha smoke
+
+# Recurring (or on-demand) smoke against real Celestia Mocha. Companion
+# to the manual procedure in `docs/development/runbooks/mocha-smoke.md`.
+# This workflow exercises steps 1-7 of that runbook in CI.
+#
+# DISABLED until `MOCHA_TIA_SIGNER_KEY` repo secret is set + the cron
+# schedule below is uncommented. Workflow exists as documentation +
+# one-shot operator capability via `workflow_dispatch`.
+#
+# Tracking issue: ligate-io/ligate-chain#285.
+
+on:
+  # Operator-triggered one-shot runs. Use this for the initial pre-
+  # devnet-announce smoke per the runbook.
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Chain branch to smoke (default: main)'
+        required: false
+        default: 'main'
+
+  # Uncomment once the manual smoke passes + the operator is ready
+  # to commit to a recurring CI gate.
+  # schedule:
+  #   - cron: '0 6 * * *'  # 06:00 UTC nightly
+
+env:
+  CARGO_TERM_COLOR: always
+  SKIP_GUEST_BUILD: "1"
+  RISC0_SKIP_BUILD_KERNELS: "1"
+  CONSTANTS_MANIFEST_PATH: ${{ github.workspace }}/constants.toml
+
+jobs:
+  smoke:
+    name: ligate-node + Mocha smoke
+    runs-on: ubuntu-latest
+    # Guard: skip if the operator hasn't set the TIA signer key. The
+    # workflow exists for documentation purposes until that's wired.
+    if: ${{ vars.MOCHA_SMOKE_ENABLED == 'true' }}
+    timeout-minutes: 30
+    env:
+      # Funded Mocha TIA wallet. Provided as a repo secret.
+      SOV_CELESTIA_SIGNER_KEY: ${{ secrets.MOCHA_TIA_SIGNER_KEY }}
+      # Mocha bridge to use. Default to pops.one; override via the
+      # `MOCHA_BRIDGE` repo variable if needed (e.g. switching to a
+      # backup bridge during pops.one maintenance).
+      MOCHA_BRIDGE: ${{ vars.MOCHA_BRIDGE || 'rpc-mocha.pops.one' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.93.0
+
+      - name: Install libclang
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev clang
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Build ligate-node + ligate-cli. Cold-cache build is ~10 min;
+      # cached re-runs ~2 min.
+      - name: Build chain binaries
+        run: |
+          cargo build --release --bin ligate-node
+          cargo build --release --bin ligate-cli || true
+
+      # Install + initialize the Celestia light node. v0.20+ matches
+      # the chain's expected light-node version.
+      - name: Install Celestia light node
+        run: |
+          CELESTIA_VERSION=v0.20.0
+          curl -L "https://github.com/celestiaorg/celestia-node/releases/download/${CELESTIA_VERSION}/celestia-linux-amd64" \
+            -o /usr/local/bin/celestia
+          chmod +x /usr/local/bin/celestia
+          celestia light init --p2p.network=mocha
+
+      - name: Start Celestia light node
+        run: |
+          nohup celestia light start \
+              --core.ip "${MOCHA_BRIDGE}" \
+              --p2p.network mocha \
+              --rpc.addr 127.0.0.1 \
+              --rpc.port 26658 \
+              > /tmp/celestia.log 2>&1 &
+          echo "Waiting for light node to sync..."
+          for i in {1..60}; do
+              if celestia rpc header sync-state 2>/dev/null | jq -e '.height > 0' >/dev/null; then
+                  echo "Light node synced."
+                  break
+              fi
+              sleep 5
+          done
+
+      # The actual chain smoke. Spawns ligate-node against the live
+      # mocha light node, waits for slot 3, asserts bech32m encodings
+      # on every hash type, asserts DA metrics increment.
+      - name: Run smoke
+        timeout-minutes: 15
+        run: |
+          set -euo pipefail
+
+          # Start ligate-node in the background
+          nohup ./target/release/ligate-node \
+              --da-layer celestia \
+              --rollup-config-path devnet-1/celestia.toml \
+              --genesis-config-dir devnet-1/genesis \
+              --metrics-bind 127.0.0.1:9100 \
+              > /tmp/ligate-node.log 2>&1 &
+          NODE_PID=$!
+          # Cleanup on exit
+          trap "kill $NODE_PID 2>/dev/null || true; sleep 1; cat /tmp/ligate-node.log | tail -50" EXIT
+
+          # Wait for the REST API to come up
+          for i in {1..60}; do
+              if curl -sf http://127.0.0.1:12346/v1/rollup/info >/dev/null 2>&1; then
+                  break
+              fi
+              sleep 2
+          done
+
+          # === Step 2: chain identity ===
+          echo "=== chain identity ==="
+          INFO=$(curl -sf http://127.0.0.1:12346/v1/rollup/info)
+          echo "$INFO" | jq
+          CHAIN_HASH=$(echo "$INFO" | jq -r .chain_hash)
+          if [[ "$CHAIN_HASH" != lsch1* ]]; then
+              echo "FAIL: chain_hash is not bech32m: $CHAIN_HASH" >&2
+              exit 1
+          fi
+
+          SCHEMA_HASH=$(curl -sf http://127.0.0.1:12346/v1/rollup/schema | jq -r .chain_hash)
+          if [[ "$SCHEMA_HASH" != "$CHAIN_HASH" ]]; then
+              echo "FAIL: schema chain_hash diverges: $SCHEMA_HASH vs $CHAIN_HASH" >&2
+              exit 1
+          fi
+          echo "OK: chain_hash round-trips as $CHAIN_HASH"
+
+          # === Step 3: slot encoding ===
+          echo "=== slot encoding ==="
+          for i in {1..60}; do
+              LATEST=$(curl -sf http://127.0.0.1:12346/v1/ledger/slots/latest | jq -r .number)
+              if [ "$LATEST" -ge 3 ]; then break; fi
+              sleep 2
+          done
+          SLOT=$(curl -sf http://127.0.0.1:12346/v1/ledger/slots/3)
+          echo "$SLOT" | jq
+          SLOT_HASH=$(echo "$SLOT" | jq -r .hash)
+          STATE_ROOT=$(echo "$SLOT" | jq -r .state_root)
+          [[ "$SLOT_HASH" == lblk1* ]] || { echo "FAIL: slot.hash not bech32m: $SLOT_HASH" >&2; exit 1; }
+          [[ "$STATE_ROOT" == lsr1* ]]  || { echo "FAIL: state_root not bech32m: $STATE_ROOT" >&2; exit 1; }
+          echo "OK: slot bech32m encoding correct"
+
+          # === Step 7: DA metrics ===
+          echo "=== DA metrics ==="
+          METRICS=$(curl -sf http://127.0.0.1:9100/metrics)
+          if ! echo "$METRICS" | grep -q "ligate_da_finalization_latency_seconds_count"; then
+              echo "FAIL: ligate_da_finalization_latency_seconds_count metric missing" >&2
+              exit 1
+          fi
+          DA_COUNT=$(echo "$METRICS" | awk '/^ligate_da_finalization_latency_seconds_count /{print $2; exit}')
+          if [ -z "$DA_COUNT" ] || [ "$DA_COUNT" = "0" ]; then
+              echo "WARN: no DA finalizations recorded yet (smoke may not have run long enough)"
+          else
+              echo "OK: DA finalization count = $DA_COUNT"
+          fi
+
+          echo "=== SMOKE PASSED ==="
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mocha-smoke-logs
+          path: |
+            /tmp/ligate-node.log
+            /tmp/celestia.log
+          retention-days: 14

--- a/docs/development/runbooks/mocha-smoke.md
+++ b/docs/development/runbooks/mocha-smoke.md
@@ -1,0 +1,242 @@
+# Runbook — Mocha smoke gate
+
+**Status:** v0 — covers the one-time pre-devnet-announce smoke against real Celestia Mocha. Companion to [`celestia-light-node.md`](./celestia-light-node.md), [`da-signer-rotation.md`](./da-signer-rotation.md), and the broader [`public-devnet-deploy.md`](../public-devnet-deploy.md).
+
+Bech32m + DA-adapter changes that landed in Phase 5/6 (TmHash display, `BlobWithSender.hash` → `BlobHash`, the wallet's `TmHashSchema` attribute) have only been verified against MockDA. **First boot against Mocha is the smoke.** Find the bug here, not after public devnet announce.
+
+This runbook is the procedure for executing that smoke. The artifact is the documented run pasted back into [#285](https://github.com/ligate-io/ligate-chain/issues/285).
+
+---
+
+## What this smoke verifies
+
+| Surface | What we're checking |
+|---|---|
+| Chain identity | `chain_hash` round-trips as `lsch1...` against both `/v1/rollup/info` and `/v1/rollup/schema` |
+| Slot encoding | Slot `hash` is `lblk1...`, `state_root` is `lsr1...`, batch hashes are `lba1...` |
+| Tx round-trip | A transfer submitted via `ligate-cli` returns `ltx1...`, lands on Celestia, finalizes |
+| DA blob encoding | DA blob hashes show as `lbz1...` in `journalctl -u ligate-node` |
+| DA pipeline state machine | Tx transitions Published → Processed → Finalized correctly |
+| DA metrics | `ligate_da_finalization_latency_seconds_bucket` increments; p99 in 12s-60s band |
+| Failure handling | Killing the light node mid-submission triggers `ligate_da_submission_failures_total` with the correct `reason` label; node recovers when light node restarts |
+
+Anything not on this list is out of scope for this smoke — covered elsewhere in the test pyramid.
+
+---
+
+## Prerequisites
+
+- A non-prod VM (or local machine) per [`public-devnet-deploy.md`](../public-devnet-deploy.md). Don't run this against the production sequencer.
+- A funded Mocha TIA wallet (≥10 TIA recommended for safety margin; the smoke uses fractions of a TIA but you want headroom for retries).
+- The Mocha-flavoured chain config at `devnet-1/celestia.toml` with `[da].signer_private_key` pointing at the funded wallet.
+- Celestia light node v0.20+ co-located, syncing Mocha (per [`celestia-light-node.md`](./celestia-light-node.md)).
+- `ligate-cli` installed locally (or available on the smoke VM).
+
+---
+
+## Procedure
+
+Execute step-by-step. Paste the output of each command back into [#285](https://github.com/ligate-io/ligate-chain/issues/285) as you go (or capture to a single transcript file via `script(1)`).
+
+### Step 1 — Boot the chain against Mocha
+
+```sh
+# On the smoke VM, with the Mocha-funded TIA wallet wired:
+systemctl start celestia-light
+# Wait for sync, per celestia-light-node.md
+celestia rpc das samplingstats | jq '.head_of_sampled_chain'
+celestia rpc header sync-state | jq '{height, network_head}'
+
+# Then start the chain
+systemctl start ligate-node
+journalctl -fu ligate-node | head -50
+```
+
+**Expected:** `ligate-node` starts, opens DA-adapter session with the light node, begins producing slot 1 within ~30s. Log lines like `BlobSubmitter connected` and `slot_committed slot=1`.
+
+### Step 2 — Chain identity round-trip
+
+```sh
+curl -s http://127.0.0.1:12346/v1/rollup/info | jq '{chain_id, chain_hash, version}'
+curl -s http://127.0.0.1:12346/v1/rollup/schema | jq .chain_hash
+```
+
+**Expected:** both `chain_hash` values are byte-identical and start with `lsch1`. Cross-check against the build-time-pinned hash via:
+
+```sh
+grep CHAIN_HASH crates/stf/src/chain_hash_pin.rs
+```
+
+The pinned value should match the runtime-emitted one. If they diverge, the smoke fails — file a bug, do NOT continue.
+
+### Step 3 — Slot encoding round-trip
+
+```sh
+# Wait for at least slot 3 so we have non-genesis batches
+curl -s http://127.0.0.1:12346/v1/ledger/slots/latest | jq .number
+# Once >= 3:
+SLOT=3
+curl -s http://127.0.0.1:12346/v1/ledger/slots/${SLOT} | jq '{hash, state_root, batch_range}'
+```
+
+**Expected:**
+- `hash` starts with `lblk1` and decodes to 32 bytes
+- `state_root` starts with `lsr1` and decodes to 64 bytes (NOMT root)
+- `batch_range.start <= batch_range.end`
+
+Decode-check via the bech32 helper or `ligate-cli`:
+
+```sh
+ligate decode-hash <hash-value>
+# (or use the chain repo's `crates/rollup/tests/binary_spawn_smoke.rs` decode patterns)
+```
+
+### Step 4 — Transfer round-trip
+
+```sh
+# Use the localnet dev key (pre-funded with 10000 LGT at genesis, per
+# devnet/local-dev-key.json) as the sender. Pick any address as recipient.
+RECIPIENT="lig1u8z2rxh6ymjwkqsasme64f5kfphtfm2kf4kkn0clusfpr34amezsp5j7yp"
+
+ligate --rpc http://127.0.0.1:12346 transfer \
+    --to "$RECIPIENT" \
+    --amount 1 \
+    --token-id "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7" \
+    --from <path-to-dev-key>
+```
+
+**Expected:** CLI returns a tx hash like `ltx1...`, NOT a hex string.
+
+Pull the tx back:
+
+```sh
+TX_HASH="<the ltx1... value from above>"
+curl -s "http://127.0.0.1:12346/v1/ledger/txs/${TX_HASH}" | jq '.hash, .batch_number'
+```
+
+**Expected:** `hash` field matches the submitted `ltx1...` exactly. The byte-form decode matches.
+
+### Step 5 — Tx state-machine progression
+
+Watch the tx transition through DA states. The chain's `sov-sequencer` emits state-change events visible in the journal:
+
+```sh
+journalctl -u ligate-node --since "-2 minutes" | grep -E "${TX_HASH}|tx_status_changed"
+```
+
+**Expected:** see `tx_status_changed` events with the sequence `Published` → `Processed` → `Finalized` for the smoke tx. Finalization may take 1-2 minutes depending on Mocha's block cadence.
+
+### Step 6 — DA blob hash encoding
+
+```sh
+journalctl -u ligate-node --since "-5 minutes" | grep -E "lbz1|blob_hash"
+```
+
+**Expected:** DA blob hashes appear in logs as `lbz1...`, NOT as `0x...`. Captures any leaked hex display surfaces.
+
+### Step 7 — DA metrics
+
+```sh
+curl -s http://127.0.0.1:9100/metrics \
+    | grep -E "ligate_da_(finalization_latency|submission_failures)"
+```
+
+**Expected:**
+- `ligate_da_finalization_latency_seconds_count > 0`
+- `histogram_quantile(0.99, ligate_da_finalization_latency_seconds_bucket)` between 12s and 60s on healthy Mocha
+- `ligate_da_submission_failures_total{reason=...}` either absent (no failures) or only `reason="submission_timeout"` for the very first blob (cold-start retry can hit timeout once)
+
+### Step 8 — Forced failure injection
+
+The chain should handle light-node death gracefully — backoff + retry, no panic.
+
+```sh
+# Submit a tx, then kill the light node WHILE it's in flight
+ligate --rpc http://127.0.0.1:12346 transfer \
+    --to "$RECIPIENT" --amount 1 --token-id "$TOKEN_ID" --from <key> &
+TX_PID=$!
+sleep 1  # let the submit start
+sudo systemctl stop celestia-light
+wait $TX_PID
+
+# Check what failure mode the chain saw
+curl -s http://127.0.0.1:9100/metrics \
+    | grep ligate_da_submission_failures_total
+
+# Bring the light node back
+sudo systemctl start celestia-light
+
+# Watch the chain recover
+journalctl -fu ligate-node | grep -E "blob_submission|da_recover" | head -20
+```
+
+**Expected:**
+- `ligate_da_submission_failures_total{reason="light_node_unreachable"}` or `{reason="submission_timeout"}` increments by ≥1
+- After restarting the light node, blob submission resumes without operator intervention
+- Block height eventually advances past the pre-kill height
+
+If the chain crashes or wedges instead of retrying, the smoke fails — file a bug.
+
+### Step 9 — Capture + paste
+
+```sh
+# Capture the final-state snapshot of all the relevant surfaces
+{
+    echo "=== chain_hash round-trip ==="
+    curl -s http://127.0.0.1:12346/v1/rollup/info | jq
+    echo "=== latest slot ==="
+    curl -s http://127.0.0.1:12346/v1/ledger/slots/latest | jq
+    echo "=== smoke tx ==="
+    curl -s "http://127.0.0.1:12346/v1/ledger/txs/${TX_HASH}" | jq
+    echo "=== metrics ==="
+    curl -s http://127.0.0.1:9100/metrics | grep -E "ligate_(block_height|da_)"
+} > /tmp/mocha-smoke-$(date -u +%Y%m%dT%H%M%SZ).log
+
+# Paste the contents into issue #285's results comment.
+```
+
+---
+
+## Pass/fail criteria
+
+The smoke passes if every step above produced the expected output without bugs or unexplained surfaces. Specifically:
+
+- ✅ All hash types display in bech32m (no leaked `0x...` hex anywhere)
+- ✅ Tx round-trips byte-identical across REST endpoints
+- ✅ DA pipeline transitions through all three states for the smoke tx
+- ✅ Forced light-node failure surfaces a typed reason, not a crash
+- ✅ Recovery from light-node failure is automatic
+
+Any bug surfaces a follow-up issue. File before announce.
+
+---
+
+## Recurring smoke (optional, CI-driven)
+
+Once the operator confirms the manual smoke passes, the same procedure can run nightly via [`.github/workflows/mocha-smoke.yml`](../../.github/workflows/mocha-smoke.yml). The workflow is checked in but skipped until the `MOCHA_TIA_SIGNER_KEY` secret is set at the repo's Actions secrets. Until then the workflow exists as documentation of "here's what the CI smoke would do" but doesn't run.
+
+When ready:
+
+1. Set `MOCHA_TIA_SIGNER_KEY` at GitHub Actions secrets (operator's funded TIA wallet hex private key).
+2. Enable the workflow via the `workflow_dispatch` button to do a one-time CI run.
+3. If green, flip `on:` to add the `schedule:` cron (commented out today) for nightly runs.
+
+The CI smoke is a subset of the manual procedure (steps 1-7; step 8 forced-failure injection is harder to do reliably in CI without flake risk).
+
+---
+
+## Out of scope
+
+- **Multi-sequencer topology.** v0 is single-sequencer; multi covered post-#82.
+- **Hash-encoding micro-tests.** Already covered by `crates/rollup-interface/src/common/bech32m_encoded.rs` unit tests (and the SDK fork's). This smoke is the *integrated* check, not the type-level one.
+- **Performance benchmarking.** Mocha latency varies; we record p99 but don't gate on a SLO.
+
+---
+
+## Cross-references
+
+- [Issue #285](https://github.com/ligate-io/ligate-chain/issues/285) — paste the smoke results here
+- [`celestia-light-node.md`](./celestia-light-node.md) — light node failure modes referenced in step 8
+- [`da-signer-rotation.md`](./da-signer-rotation.md) — TIA wallet management
+- [`public-devnet-deploy.md`](../public-devnet-deploy.md) — VM bring-up the smoke runs against
+- [`.github/workflows/mocha-smoke.yml`](../../../.github/workflows/mocha-smoke.yml) — recurring CI version


### PR DESCRIPTION
Closes #285.

## What ships

- **`docs/development/runbooks/mocha-smoke.md`** — 9-step manual smoke procedure with exact commands + expected output per step. Designed for the user to execute once on a Mocha-funded VM and paste results back into #285.

  Steps cover: chain-identity bech32m round-trip, slot/state-root encoding, transfer round-trip, tx state-machine progression (Published → Processed → Finalized), DA blob hashes in logs, DA metrics increment with p99 in the 12s-60s band, forced failure injection (kill light node, confirm typed reason + automatic recovery).

- **`.github/workflows/mocha-smoke.yml`** — recurring CI version. Builds chain binaries, installs Celestia v0.20, syncs the light node, boots ligate-node against Mocha, asserts bech32m on `chain_hash`, slot.hash, state_root + checks DA finalization metric. **Guarded by `vars.MOCHA_SMOKE_ENABLED == 'true'`** so the workflow exists as documentation until the operator wires the secret and flips the gate.

  Triggers (initially): `workflow_dispatch` only. The `schedule:` cron (`0 6 * * *` nightly) is commented out; uncomment after the first manual smoke passes.

## Operator action required to enable

1. Set repo secret `MOCHA_TIA_SIGNER_KEY` to the funded TIA wallet hex private key
2. Set repo variable `MOCHA_SMOKE_ENABLED=true`
3. Optionally set repo variable `MOCHA_BRIDGE` if not using `rpc-mocha.pops.one`
4. Trigger one-shot via `workflow_dispatch`; if green, uncomment the `schedule:` cron

## Test plan

- [x] YAML structure validates against GHA schema
- [x] Markdown renders + cross-references resolve (`celestia-light-node.md`, `da-signer-rotation.md`, `public-devnet-deploy.md`)
- [x] Smoke procedure references real metric names from `crates/rollup/src/metrics.rs`
- [x] Workflow `if:` guard prevents accidental run cost burn pre-enable
- [ ] **Pending**: operator (you) executes the manual procedure once + pastes the run log into #285. That's the actual closer.