### PR TITLE
chore(cla): allowlist sstefdev (org member)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,4 +29,4 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/ligate-io/ligate-chain/blob/main/CLA.md'
           branch: 'cla/signatures'
-          allowlist: 'dependabot[bot],*[bot]'
+          allowlist: 'sstefdev,dependabot[bot],*[bot]'


### PR DESCRIPTION
Add `sstefdev` to the CLA Assistant allowlist so org-owner pushes do not gate behind a CLA signature. The bot still enforces CLA for external contributors. Mirrors the same one-line patch across all four public repos.

Tracks ligate-io/ligate-chain#257.