### PR TITLE
ci: cross-OS genesis determinism matrix

### DIFF
--- a/.github/workflows/genesis-determinism.yml
+++ b/.github/workflows/genesis-determinism.yml
@@ -1,0 +1,161 @@
+name: Genesis determinism
+
+# Cross-OS reproducibility check for `ligate-genesis-tool generate`.
+#
+# Runs the tool with the same inputs on Linux and macOS, sha256s each
+# output file, and asserts the hashes match across the two runners.
+# Divergence is detected as a hard error.
+#
+# Triggers narrowly: only when genesis-tool, genesis fixture, or this
+# workflow itself changes. The cross-OS build is expensive (~5-10 min
+# cold cache); skipping it on unrelated PRs keeps the cost contained.
+#
+# Tracking issue: ligate-io/ligate-chain#278.
+
+on:
+  pull_request:
+    paths:
+      - 'crates/genesis-tool/**'
+      - 'devnet-1/genesis/**'
+      - 'ops/genesis-determinism/**'
+      - '.github/workflows/genesis-determinism.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/genesis-tool/**'
+      - 'devnet-1/genesis/**'
+      - 'ops/genesis-determinism/**'
+      - '.github/workflows/genesis-determinism.yml'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  SKIP_GUEST_BUILD: "1"
+  RISC0_SKIP_BUILD_KERNELS: "1"
+  CONSTANTS_MANIFEST_PATH: ${{ github.workspace }}/constants.toml
+
+jobs:
+  generate:
+    name: generate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch_label: linux-amd64
+          - os: macos-14
+            arch_label: darwin-arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.93.0
+
+      - name: Install libclang (linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev clang
+
+      - name: Install libclang (macos)
+        if: runner.os == 'macOS'
+        run: |
+          brew install llvm
+          echo "LIBCLANG_PATH=/opt/homebrew/opt/llvm/lib" >> $GITHUB_ENV
+          echo "DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.arch_label }}
+
+      - name: Build ligate-genesis-tool
+        run: cargo build --release -p ligate-genesis-tool
+
+      - name: Generate from devnet-1 template
+        run: |
+          mkdir -p genesis-out
+          ./target/release/ligate-genesis-tool generate \
+            --template devnet-1/genesis \
+            --substitutions ops/genesis-determinism/substitutions.toml \
+            --output genesis-out
+
+      - name: Hash output files
+        run: |
+          # Sort by filename for stable comparison. Each file gets a
+          # `<sha256>  <relpath>` line. The relpath is identical across
+          # runners (same input filenames); only the hash should match.
+          if [ "${{ runner.os }}" = "macOS" ]; then
+              HASHER="shasum -a 256"
+          else
+              HASHER="sha256sum"
+          fi
+          find genesis-out -type f | sort | while read f; do
+              $HASHER "$f"
+          done > hashes-${{ matrix.arch_label }}.txt
+          echo "===== hashes (${{ matrix.arch_label }}) ====="
+          cat hashes-${{ matrix.arch_label }}.txt
+
+      - name: Upload hashes
+        uses: actions/upload-artifact@v4
+        with:
+          name: hashes-${{ matrix.arch_label }}
+          path: hashes-${{ matrix.arch_label }}.txt
+          retention-days: 7
+
+      - name: Upload output (for diff-on-failure)
+        uses: actions/upload-artifact@v4
+        with:
+          name: genesis-out-${{ matrix.arch_label }}
+          path: genesis-out/
+          retention-days: 7
+
+  compare:
+    name: compare hashes
+    needs: generate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download linux hashes
+        uses: actions/download-artifact@v4
+        with:
+          name: hashes-linux-amd64
+          path: linux/
+
+      - name: Download macOS hashes
+        uses: actions/download-artifact@v4
+        with:
+          name: hashes-darwin-arm64
+          path: darwin/
+
+      - name: Diff
+        run: |
+          # Normalise the relpath column (which differs only in the
+          # ./genesis-out prefix on each runner) before diffing the
+          # hashes themselves.
+          # First column is the sha256; second column is the file path.
+          # We compare ONLY the sha256s, keyed by filename, so runner-
+          # local working directory differences don't masquerade as
+          # non-determinism.
+          awk '{
+              # Extract just the basename of the file column for keying
+              n = split($2, p, "/")
+              key = p[n]
+              print key, $1
+          }' linux/hashes-linux-amd64.txt | sort > /tmp/linux.txt
+
+          awk '{
+              n = split($2, p, "/")
+              key = p[n]
+              print key, $1
+          }' darwin/hashes-darwin-arm64.txt | sort > /tmp/darwin.txt
+
+          echo "===== linux ====="
+          cat /tmp/linux.txt
+          echo "===== darwin ====="
+          cat /tmp/darwin.txt
+
+          if ! diff -u /tmp/linux.txt /tmp/darwin.txt; then
+              echo "::error::genesis-tool output diverges between linux and macOS"
+              echo "::error::See uploaded artifacts genesis-out-linux-amd64 + genesis-out-darwin-arm64 to inspect the diff"
+              exit 1
+          fi
+          echo "OK: cross-OS sha256s identical."

--- a/docs/development/genesis-determinism.md
+++ b/docs/development/genesis-determinism.md
@@ -1,0 +1,89 @@
+# Genesis determinism
+
+`ligate-genesis-tool generate` reads a template directory + a substitutions TOML, writes a new genesis bundle. Two operators on different machines (different Rust versions, different OSes, different filesystems) running the tool against the same inputs must produce a **byte-identical** output. Otherwise multi-operator validation is silently broken: two operators compute different `CHAIN_HASH` values from the same input and never realize.
+
+CI verifies this via `.github/workflows/genesis-determinism.yml`: cross-OS matrix (Linux + macOS) running the tool with a fixture substitution, sha256-comparing each output file. The job fires on any PR that touches `crates/genesis-tool/`, `devnet-1/genesis/`, or the workflow itself.
+
+---
+
+## Sources of non-determinism we mitigate (or proved absent)
+
+| Source | Affects | Mitigation in tool |
+|---|---|---|
+| HashMap iteration order | JSON object field order | Tool uses `serde_json::to_writer_pretty` against `BTreeMap`-backed structs (sorted by key) wherever the input is structurally a map. The 8 genesis-config structs are `#[derive(Serialize)]` over named fields, which serde emits in declaration order — deterministic. |
+| Timestamp injection | Any field carrying creation-time | Tool does NOT timestamp the output; every output field comes from the template or substitutions input. |
+| Locale-dependent JSON formatting | Number / decimal formatting | `serde_json` emits ASCII-only JSON; locale is irrelevant. |
+| Floating-point representation | Currency fields | All amounts are `u128`-backed decimal strings (per RFC 0002); no f64 anywhere. |
+| Filesystem-order directory traversal | Order of files written | Tool iterates a fixed `GENESIS_FILES` array, not a directory listing. Deterministic across filesystems. |
+| Trailing newline / line-ending | EOF byte sequences | `to_writer_pretty` appends a single `\n`; no platform-dependent CRLF. |
+| Hash of derived state | `CHAIN_HASH` build-time derive | `CHAIN_HASH` is computed via `Schema`'s deterministic-hasher path with pinned spec parameters (`MockDaSpec + MockZkvm + MultiAddressEvm`) regardless of the binary's runtime DA/ZkVM choice. See [`crates/stf/build.rs`](../../crates/stf/build.rs). |
+
+Each row above is what the *tool* mitigates. The cross-OS CI test catches anything we didn't think of — that's its job.
+
+---
+
+## When the CI test fires
+
+A divergence between `linux-amd64` and `darwin-arm64` output means a new non-determinism source slipped in. Common culprits:
+
+- **Added a `HashMap<K, V>` to a serialised struct.** Swap for `BTreeMap` or sort before serialise. Serde's `Serialize` uses HashMap iteration order which differs across platforms.
+- **Added an integer field formatted with `Display`** where the integer comes from a chrono-time / random / process-id source. Make the field input-derived only.
+- **Introduced a new `serde_json::Value` round-trip** that lost field ordering. Use typed structs instead.
+- **Added a custom `Hasher` somewhere that depends on platform-default random state.** Wire a deterministic hasher (e.g. `seahash` with a fixed seed) explicitly.
+
+The CI job's failure message points at the diverged files; the uploaded `genesis-out-*` artifacts let you `diff -r` to find the exact field.
+
+---
+
+## How to reproduce a CI failure locally
+
+```sh
+# Build the tool
+cargo build --release -p ligate-genesis-tool
+
+# Generate twice with the same inputs; sha256 each file
+mkdir -p /tmp/run-a /tmp/run-b
+./target/release/ligate-genesis-tool generate \
+    --template devnet-1/genesis \
+    --substitutions ops/genesis-determinism/substitutions.toml \
+    --output /tmp/run-a
+
+./target/release/ligate-genesis-tool generate \
+    --template devnet-1/genesis \
+    --substitutions ops/genesis-determinism/substitutions.toml \
+    --output /tmp/run-b
+
+# Compare
+find /tmp/run-a -type f -exec shasum -a 256 {} \; | sort > /tmp/a.sha
+find /tmp/run-b -type f -exec shasum -a 256 {} \; | sort > /tmp/b.sha
+diff -u /tmp/a.sha /tmp/b.sha
+```
+
+Same-machine non-determinism (different output between two consecutive runs on one host) catches HashMap-iteration-order regressions before they even reach CI.
+
+For cross-OS reproduction without GitHub Actions: a Linux VM (via Multipass / Lima / a Docker container with the matching toolchain) running the above and uploading its `/tmp/a.sha` for comparison against the same on macOS.
+
+---
+
+## Trust model
+
+This is operational determinism, not cryptographic determinism. The tool's output is reproducible because the *implementation* doesn't introduce variation, not because the output is signed or attested. If a non-determinism source slips in despite our checks, the failure mode is "two operators see different state" — caught downstream by the chain's `CHAIN_HASH` mismatch at first transaction signing. The CI test moves that catch from "first signed tx fails on a partner-operator's node, hours later" to "PR doesn't merge."
+
+---
+
+## Out of scope
+
+- **Cross-Rust-version determinism.** Pinned to 1.93.0 via `rust-toolchain.toml`. A future Rust upgrade is its own deliberate PR with the same determinism test re-run.
+- **Cross-architecture (CPU) endianness.** All chain encodings use little-endian Borsh; no platform-conditional code paths in genesis-tool today.
+- **Tamper-evidence of the output.** Operator signs the genesis bundle separately if they want a tamper-evident artifact (covered by [`chain-id-bump.md`](runbooks/chain-id-bump.md)'s pre-bump checklist, "Snapshot any state that should carry over").
+
+---
+
+## Cross-references
+
+- [Issue #278](https://github.com/ligate-io/ligate-chain/issues/278) — this work closes it
+- [`crates/genesis-tool/src/main.rs`](../../crates/genesis-tool/src/main.rs) — the tool
+- [`.github/workflows/genesis-determinism.yml`](../../.github/workflows/genesis-determinism.yml) — the CI matrix
+- [`ops/genesis-determinism/substitutions.toml`](../../ops/genesis-determinism/substitutions.toml) — the fixture
+- [`crates/stf/build.rs`](../../crates/stf/build.rs) — `CHAIN_HASH` derivation (related determinism layer)
+- [`upgrades.md`](../protocol/upgrades.md#the-chain_hash-guard) — the `CHAIN_HASH` guard story

--- a/ops/genesis-determinism/substitutions.toml
+++ b/ops/genesis-determinism/substitutions.toml
@@ -1,0 +1,22 @@
+# Substitution fixture for the genesis-determinism CI matrix.
+#
+# Identity substitution: maps each placeholder address in
+# `devnet-1/genesis/` to itself. The test only cares that
+# `ligate-genesis-tool generate` produces byte-identical output across
+# machines, not that the substitution does anything semantic. With an
+# identity map, every machine running `generate` should produce a
+# bundle identical to the input — and identical to every other
+# machine's output.
+#
+# When the cross-OS test surfaces a non-determinism source (HashMap
+# iteration order, locale-dependent JSON ordering, etc.), the diff
+# in the artifact comparison will point at the offending field. The
+# `docs/development/genesis-determinism.md` doc catalogs the sources
+# we mitigated (or proved aren't present) as the test expands.
+#
+# Tracking issue: ligate-io/ligate-chain#278.
+
+[addresses]
+"lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8" = "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
+"lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544" = "lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544"
+"lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz" = "lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz"


### PR DESCRIPTION
Closes #278.

## What ships

- **`.github/workflows/genesis-determinism.yml`** — Linux (ubuntu-24.04) + macOS (macos-14) matrix runs \`ligate-genesis-tool generate\` against an identity substitution fixture. Each leg sha256s every output file; a downstream \`compare\` job diffs the hashes by filename and fails the workflow on divergence. Output artifacts uploaded for 7 days so on-failure you can \`diff -r\` to find the exact field.
- **`ops/genesis-determinism/substitutions.toml`** — identity-map fixture (placeholder addresses substituted to themselves). The test only cares whether generate is deterministic; identity substitution gives us \`output == input\` so any divergence is non-determinism leakage.
- **`docs/development/genesis-determinism.md`** — sources of non-determinism cataloged (HashMap iteration, timestamp injection, locale-dependent JSON, FP repr, filesystem traversal order, line endings, hash-of-derived-state) with the mitigation each tool layer applies. Reproduction recipe for local debugging. Trust model + scope-limitations.

## Triggers narrowly

CI fires only on PRs / pushes touching \`crates/genesis-tool/\`, \`devnet-1/genesis/\`, or the workflow / fixture itself. Cross-OS Rust build is expensive (~5-10 min cold); paths-filter keeps cost contained.

## Test plan

- [x] Same-machine determinism verified locally: two consecutive runs produce byte-identical output (see PR validation transcript)
- [x] Workflow YAML structure validates against GHA schema
- [x] Identity fixture sha256s match \`devnet-1/genesis/\` post-generate (the tool reads + re-emits each module config unchanged when substitutions are identity)
- [ ] CI's first run is the cross-OS matrix itself — Linux + macOS produce identical hashes for every file, OR the failure surfaces a non-determinism source we'd want to know about