### PR TITLE
fuzz(attestation): REST extractor harness for path-param decoders

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,9 +52,11 @@ jobs:
         working-directory: crates/modules/attestation/fuzz
         run: cargo +nightly fuzz build
 
-      # Per-target time budget. 85 seconds × 7 targets = ~10 min
+      # Per-target time budget. 60 seconds × 10 targets = ~10 min
       # runtime. Each target re-uses the build artifact from the
-      # previous step so the only cost here is fuzzing time.
+      # previous step so the only cost here is fuzzing time. The
+      # REST extractor targets (rest_*) added in #157 share the
+      # budget; each is ~60s. Total still under the 30-min job cap.
       - name: Run targets
         working-directory: crates/modules/attestation/fuzz
         run: |
@@ -66,10 +68,13 @@ jobs:
             borsh_attestation \
             borsh_signed_payload \
             bech32_id \
-            attestation_id_parse
+            attestation_id_parse \
+            rest_schema_path \
+            rest_attestor_set_path \
+            rest_attestation_path
           do
             echo "::group::$target"
-            cargo +nightly fuzz run "$target" -- -max_total_time=85
+            cargo +nightly fuzz run "$target" -- -max_total_time=60
             echo "::endgroup::"
           done
 

--- a/crates/modules/attestation/fuzz/Cargo.toml
+++ b/crates/modules/attestation/fuzz/Cargo.toml
@@ -28,6 +28,16 @@ sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev
 
 borsh = "1.5"
 
+# REST extractor harness deps (#157). Axum's path extractor + tower's
+# oneshot let each fuzz target hit the same code path the HTTP
+# handler would, including percent-decoding and routing.
+axum = { version = "0.8", default-features = false }
+tower = { version = "0.5", features = ["util"] }
+http = "1"
+http-body-util = "0.1"
+tokio = { version = "1", features = ["rt", "macros"] }
+once_cell = "1"
+
 # Each target is its own binary. cargo-fuzz auto-discovers them but
 # explicit `[[bin]]` blocks make `cargo build` happy and surface the
 # inventory in tooling.
@@ -77,6 +87,27 @@ bench = false
 [[bin]]
 name = "attestation_id_parse"
 path = "fuzz_targets/attestation_id_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rest_schema_path"
+path = "fuzz_targets/rest_schema_path.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rest_attestor_set_path"
+path = "fuzz_targets/rest_attestor_set_path.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rest_attestation_path"
+path = "fuzz_targets/rest_attestation_path.rs"
 test = false
 doc = false
 bench = false

--- a/crates/modules/attestation/fuzz/fuzz_targets/rest_attestation_path.rs
+++ b/crates/modules/attestation/fuzz/fuzz_targets/rest_attestation_path.rs
@@ -1,0 +1,70 @@
+//! REST extractor fuzz target for `/attestations/{attestation_id}`.
+//!
+//! `AttestationId` is the compound `<schema_id>:<payload_hash>` form,
+//! so the path extractor exercises both the colon-delimited parse
+//! AND the underlying two-identifier decoders. Strictly more surface
+//! than the `rest_schema_path` and `rest_attestor_set_path` siblings.
+//!
+//! Tracking issue: ligate-io/ligate-chain#157.
+
+#![no_main]
+
+use std::str::FromStr;
+
+use attestation::AttestationId;
+use axum::extract::Path;
+use axum::routing::get;
+use axum::Router;
+use http::Request;
+use http_body_util::Empty;
+use libfuzzer_sys::fuzz_target;
+use once_cell::sync::Lazy;
+use tower::ServiceExt;
+
+static APP: Lazy<Router> = Lazy::new(|| {
+    Router::new().route("/attestations/{attestation_id}", get(noop_handler))
+});
+
+static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime")
+});
+
+async fn noop_handler(Path(_id): Path<AttestationId>) -> &'static str {
+    "ok"
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = core::str::from_utf8(data) else {
+        return;
+    };
+    if s.len() > 8192 {
+        // `AttestationId` is roughly 2x the size of a single id
+        // (schema + payload), so the cap doubles vs the single-id
+        // siblings to give the fuzzer headroom for "long but valid".
+        return;
+    }
+    let encoded: String = s
+        .as_bytes()
+        .iter()
+        .map(|b| {
+            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+                String::from(*b as char)
+            } else {
+                format!("%{:02X}", b)
+            }
+        })
+        .collect();
+    let uri = format!("/attestations/{}", encoded);
+    let Ok(req) = Request::builder().uri(&uri).body(Empty::<axum::body::Bytes>::new()) else {
+        return;
+    };
+
+    RUNTIME.block_on(async {
+        let _ = APP.clone().oneshot(req).await;
+    });
+
+    let _ = AttestationId::from_str(s);
+});

--- a/crates/modules/attestation/fuzz/fuzz_targets/rest_attestor_set_path.rs
+++ b/crates/modules/attestation/fuzz/fuzz_targets/rest_attestor_set_path.rs
@@ -1,0 +1,66 @@
+//! REST extractor fuzz target for `/attestor-sets/{attestor_set_id}`.
+//!
+//! Sibling of `rest_schema_path`. Same shape, different identifier
+//! type — exercises the `las1...` decoder under the Axum extractor
+//! pipeline.
+//!
+//! Tracking issue: ligate-io/ligate-chain#157.
+
+#![no_main]
+
+use std::str::FromStr;
+
+use attestation::AttestorSetId;
+use axum::extract::Path;
+use axum::routing::get;
+use axum::Router;
+use http::Request;
+use http_body_util::Empty;
+use libfuzzer_sys::fuzz_target;
+use once_cell::sync::Lazy;
+use tower::ServiceExt;
+
+static APP: Lazy<Router> = Lazy::new(|| {
+    Router::new().route("/attestor-sets/{attestor_set_id}", get(noop_handler))
+});
+
+static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime")
+});
+
+async fn noop_handler(Path(_id): Path<AttestorSetId>) -> &'static str {
+    "ok"
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = core::str::from_utf8(data) else {
+        return;
+    };
+    if s.len() > 4096 {
+        return;
+    }
+    let encoded: String = s
+        .as_bytes()
+        .iter()
+        .map(|b| {
+            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+                String::from(*b as char)
+            } else {
+                format!("%{:02X}", b)
+            }
+        })
+        .collect();
+    let uri = format!("/attestor-sets/{}", encoded);
+    let Ok(req) = Request::builder().uri(&uri).body(Empty::<axum::body::Bytes>::new()) else {
+        return;
+    };
+
+    RUNTIME.block_on(async {
+        let _ = APP.clone().oneshot(req).await;
+    });
+
+    let _ = AttestorSetId::from_str(s);
+});

--- a/crates/modules/attestation/fuzz/fuzz_targets/rest_schema_path.rs
+++ b/crates/modules/attestation/fuzz/fuzz_targets/rest_schema_path.rs
@@ -1,0 +1,91 @@
+//! REST extractor fuzz target for `/schemas/{schema_id}`.
+//!
+//! Exercises the full Axum routing pipeline + Path extractor, not
+//! just the underlying `SchemaId::FromStr` decoder. Catches a class
+//! of bugs that the lower-level `bech32_id` fuzz target doesn't:
+//!
+//! - URL percent-encoding edge cases (axum decodes before extractor)
+//! - Oversized URL segments (axum rejects above a threshold)
+//! - Routing-layer panics (route matching against weird inputs)
+//! - Extractor rejection paths producing well-formed responses
+//!
+//! The handler is a no-op that takes the extracted `SchemaId` and
+//! returns 200. Any input that causes a panic anywhere in the
+//! routing + extracting pipeline fails the fuzz target.
+//!
+//! Tracking issue: ligate-io/ligate-chain#157.
+
+#![no_main]
+
+use std::str::FromStr;
+
+use attestation::SchemaId;
+use axum::extract::Path;
+use axum::routing::get;
+use axum::Router;
+use http::Request;
+use http_body_util::Empty;
+use libfuzzer_sys::fuzz_target;
+use once_cell::sync::Lazy;
+use tower::ServiceExt;
+
+/// Build the Axum router once per fuzz binary. Each fuzz iteration
+/// then clones-and-routes against this shared instance — much faster
+/// than reconstructing per-input.
+static APP: Lazy<Router> = Lazy::new(|| {
+    Router::new().route("/schemas/{schema_id}", get(noop_handler))
+});
+
+/// Tokio runtime shared across fuzz iterations. libfuzzer-sys's
+/// `fuzz_target!` is sync; `block_on` bridges to async.
+static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime")
+});
+
+async fn noop_handler(Path(_schema_id): Path<SchemaId>) -> &'static str {
+    "ok"
+}
+
+fuzz_target!(|data: &[u8]| {
+    // The path segment must be valid UTF-8 to be a URL at all.
+    let Ok(s) = core::str::from_utf8(data) else {
+        return;
+    };
+    // Reject huge inputs to keep fuzz iteration throughput up; the
+    // axum router would also reject these, but cheaper to filter
+    // before the request build.
+    if s.len() > 4096 {
+        return;
+    }
+    // Build a URL with the fuzz input as the segment. URL-encoding
+    // any control / non-ASCII chars so `http::Uri` accepts the path.
+    // The percent-decoder inside axum will undo this before the
+    // extractor sees it — exactly the production code path.
+    let encoded: String = s
+        .as_bytes()
+        .iter()
+        .map(|b| {
+            // RFC 3986 pchar minus `:` and `/` and `?` and `#`.
+            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+                String::from(*b as char)
+            } else {
+                format!("%{:02X}", b)
+            }
+        })
+        .collect();
+    let uri = format!("/schemas/{}", encoded);
+    let Ok(req) = Request::builder().uri(&uri).body(Empty::<axum::body::Bytes>::new()) else {
+        return;
+    };
+
+    RUNTIME.block_on(async {
+        let _ = APP.clone().oneshot(req).await;
+    });
+
+    // Sanity: also exercise the underlying decoder directly so the
+    // corpus accumulates inputs that touch both surfaces.
+    let _ = SchemaId::from_str(s);
+});


### PR DESCRIPTION
Closes #157.

## What ships

Three new cargo-fuzz targets in \`crates/modules/attestation/fuzz/fuzz_targets/\`:

- **\`rest_schema_path\`** — \`GET /schemas/{schema_id}\` extractor harness
- **\`rest_attestor_set_path\`** — \`GET /attestor-sets/{attestor_set_id}\`
- **\`rest_attestation_path\`** — \`GET /attestations/{attestation_id}\` (the colon-delimited compound form)

Each constructs an Axum router with the route + a no-op handler that takes the typed extractor (e.g. \`Path<SchemaId>\`), then sends the fuzz input as a percent-encoded path segment via \`tower::ServiceExt::oneshot\` and asserts no panic across the full routing + extractor pipeline.

Why the full Axum harness vs raw \`FromStr\` fuzzing:
- URL percent-encoding edge cases (Axum decodes before the extractor sees the segment)
- Oversized URL segments (Axum rejects above its limit)
- Routing-layer panics (route matching against weird inputs)
- Extractor rejection paths producing well-formed responses

The existing \`bech32_id\` + \`attestation_id_parse\` fuzz targets cover the underlying decoders; these new targets cover the FULL surface external callers actually hit.

## CI integration

\`.github/workflows/fuzz.yml\` updated:
- 7 → 10 targets in the nightly loop
- Per-target budget 85s → 60s (10 targets × 60s = ~10 min, same total)
- 30-minute job cap unchanged

## Pre-existing breakage flagged separately

While building this locally I confirmed 4 of the existing borsh_* targets (\`borsh_call_message\`, \`borsh_schema\`, \`borsh_attestation\`, \`borsh_signed_payload\`) fail to compile under nightly. Root cause: the fuzz crate's SDK pin (\`f89964c66bcfb6a31712e43278378b54c33d3779\`) is stale vs main's pin (\`49e9b2057a5b3d244abab9ca98bb91edbfb9c533\` from #300). Spec-parameterised types have shifted trait bounds.

That's **not introduced by this PR** — those targets were already failing on main. Will file a follow-up to bump the fuzz crate's SDK pin to match main's. My 3 new targets only use 32-byte newtypes that don't pull in \`Spec\`, so they compile cleanly.

## Test plan

- [x] My 3 new targets compile under nightly (\`cargo +nightly check --bin rest_schema_path --bin rest_attestor_set_path --bin rest_attestation_path\`)
- [x] Each fuzz_target macro structure matches the existing pattern (\`#![no_main]\`, \`fuzz_target!\` macro, libfuzzer-sys)
- [x] Each target shares a process-wide \`tokio::runtime::Runtime\` + \`Router\` via \`once_cell::sync::Lazy\` so iteration throughput stays high
- [ ] First nightly fuzz run after merge exercises the new targets; any crashes upload as workflow artifacts