### PR TITLE
ops: Grafana cost dashboard + TIA balance alerts + docs

### DIFF
--- a/docs/development/cost-monitoring.md
+++ b/docs/development/cost-monitoring.md
@@ -1,0 +1,127 @@
+# Cost monitoring — Mocha TIA spend + GCP infra spend
+
+**Status:** v0 — Grafana dashboard + Alertmanager rules for cost visibility on `ligate-devnet-1`. Companion to [`da-signer-rotation.md`](runbooks/da-signer-rotation.md) (TIA wallet management), [`alerts/`](runbooks/alerts/) (alert runbooks), and [`public-devnet-deploy.md`](public-devnet-deploy.md) (the deploy this monitors).
+
+Two cost surfaces:
+
+| Surface | What's spending | Source of truth |
+|---|---|---|
+| Mocha TIA | DA signer wallet pays per-blob to Celestia | Celestia light node's `/metrics` endpoint (`celestia_node_da_signer_balance_utia`) |
+| GCP infra | VM-hours, GCS storage, network egress | GCP billing export → BigQuery |
+
+The dashboard at [`monitoring/grafana/ligate-devnet-1-cost.json`](../../monitoring/grafana/ligate-devnet-1-cost.json) puts both on one page so the operator can correlate cost spikes against chain activity.
+
+---
+
+## Mocha TIA cost
+
+### Steady-state expectation
+
+1 blob per slot at ~1000ms slot time × 86,400 slots/day = ~86,400 blobs/day. Average blob fee on Mocha ≈ 0.001 TIA. Daily burn ≈ **0.86 TIA/day** at full utilisation; usually less because not every slot has chain activity.
+
+| Tier | Approximate runway |
+|---|---|
+| 50 TIA (warn threshold) | ~30 days |
+| 12 TIA (page threshold) | ~7 days |
+| 5 TIA/day draw-down (spike alarm) | something's wrong: abuse, backfill, or bug |
+
+### What surfaces in Grafana
+
+Three panels on the dashboard:
+
+- **Current TIA balance** (stat). Red < 10, yellow < 50, green ≥ 50.
+- **TIA balance trend** (timeseries). Plotted over the dashboard's window so the operator can eyeball the slope.
+- **TIA draw-down rate** per `$window` (stat). Negative slope is normal (balance decreasing); positive sign in the panel after the `* -1` makes "TIA burned per day" the readable value.
+
+### Alerting
+
+Three rules in [`ops/prometheus/alerts.yaml`](../../ops/prometheus/alerts.yaml) under the `ligate-node.cost` group:
+
+- `TIABalanceLow` — warn, 30m persistence. Below 50 TIA. Operator schedules a top-up within the next week.
+- `TIABalanceCritical` — page, 5m persistence. Below 12 TIA. Operator tops up immediately or blob submission halts.
+- `TIADrawdownSpike` — warn, 1h persistence. Daily burn rate exceeds 5 TIA/day. Surfaces abnormal activity.
+
+Top-up procedure: [`da-signer-rotation.md` "TIA balance monitoring"](runbooks/da-signer-rotation.md#tia-balance-monitoring).
+
+---
+
+## GCP infra cost
+
+### Steady-state expectation
+
+`ligate-devnet-1`'s baseline:
+
+| Resource | Quantity | $/mo |
+|---|---|---|
+| Sequencer VM (`e2-medium`) | 1 | ~25 USD |
+| Persistent disk (150 GB SSD) | 1 | ~25 USD |
+| Network egress (modest) | 10-50 GB/mo | < 5 USD |
+| GCS storage (backups + snapshots) | 5-20 GB-mo | < 1 USD |
+
+Target envelope: **$30-$50/month**. Anything above $200/mo is the "something's misconfigured" line — RED on the dashboard.
+
+### Setup
+
+GCP billing export to BigQuery is a one-time UI step per project:
+
+1. **GCP Console** → **Billing** → **Billing export** → **BigQuery export**
+2. Select the chain's BigQuery dataset (create one named `ligate_billing` if needed)
+3. Enable "Detailed usage cost data" (the schema the dashboard queries)
+4. Wait ~24h for the first export to land
+
+Once data flows, Grafana's BigQuery datasource queries the export tables for the GCP panels.
+
+### Budget alert
+
+Set a GCP **Budget Alert** at the project level: $100/mo warning, $200/mo critical. Configure via:
+
+```
+GCP Console → Billing → Budgets & alerts → Create budget
+```
+
+Notifications fire on the project owner's email + a Pub/Sub topic (which we can wire into Slack via a Cloud Function if desired; deferred until the alert actually fires).
+
+### Lookerstudio dashboard
+
+Pin a Lookerstudio dashboard to the project for executive-level cost visibility (the Grafana dashboard is operator-facing):
+
+1. Lookerstudio → New report → Connect data → BigQuery
+2. Pick the `ligate_billing.gcp_billing_export_v1_*` table
+3. Panels: monthly cost trend, cost by service, cost by SKU, projected month-end total
+4. Share read-only with the team
+
+This is the "where's my money going?" view; the Grafana dashboard is the "is this normal right now?" view.
+
+---
+
+## Why two cost layers?
+
+TIA and GCP are entirely separate billing systems with entirely separate budgets:
+
+- **TIA** is consumed per-blob from a finite wallet. Running out = chain stalls.
+- **GCP** is consumed per resource-hour from a credit card. Running out = bill grows but service continues.
+
+The risk profile differs:
+- TIA risk is **operational** (chain stops); detect early via the warn alert + top up.
+- GCP risk is **financial** (surprise bill); detect at month-end via the dashboard + budget alert.
+
+Same dashboard, different priorities. The Grafana panels make this explicit by grouping into rows.
+
+---
+
+## What's deliberately NOT here
+
+- **GCP IAM cost-control quotas.** Setting per-resource quotas to hard-cap spend is a separate engineering effort; pre-devnet, the budget alert + visibility is sufficient.
+- **Per-tenant cost attribution.** Once partners deploy follower nodes, we may want to attribute their consumption back to them. Not in scope until that's a real concern.
+- **Predictive cost models.** Forecasting the next month's spend from current trend. Useful but post-mainnet.
+
+---
+
+## Cross-references
+
+- [Issue #277](https://github.com/ligate-io/ligate-chain/issues/277) — this work closes it
+- [`monitoring/grafana/ligate-devnet-1-cost.json`](../../monitoring/grafana/ligate-devnet-1-cost.json) — the dashboard
+- [`ops/prometheus/alerts.yaml`](../../ops/prometheus/alerts.yaml) `ligate-node.cost` group — the alert rules
+- [`runbooks/da-signer-rotation.md`](runbooks/da-signer-rotation.md) — TIA wallet management procedure
+- [`runbooks/alerts/`](runbooks/alerts/) — alert runbooks (Tia* alerts inherit those patterns)
+- [Issue #234](https://github.com/ligate-io/ligate-chain/issues/234) — public Grafana host (where the dashboard ultimately renders)

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -1,0 +1,206 @@
+{
+  "_doc": [
+    "Grafana dashboard for ligate-devnet-1 cost monitoring (#277).",
+    "Two halves: Mocha TIA spend (left) + GCP infra spend (right).",
+    "",
+    "Import via Grafana UI > Dashboards > New > Import > Paste JSON.",
+    "Pin to the 'Ligate Ops' folder once the public Grafana (#234)",
+    "is up.",
+    "",
+    "Data sources:",
+    "- 'Prometheus' for TIA panels (scrapes celestia-light's /metrics).",
+    "- 'GCP-BigQuery' for infra panels (reads billing export tables).",
+    "",
+    "Variables (drop-down at top of dashboard):",
+    "- $instance: which chain VM (sequencer / followers).",
+    "- $window: aggregation window for draw-down rates (1h, 24h, 7d).",
+    "",
+    "Time-range default: Last 7 days, refresh 1m."
+  ],
+  "title": "Ligate devnet-1 — cost monitoring",
+  "uid": "ligate-devnet-1-cost",
+  "tags": ["ligate", "devnet-1", "cost"],
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-7d", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(up{job=\"celestia-light\"}, instance)",
+        "current": { "text": "All", "value": "$__all" },
+        "includeAll": true,
+        "refresh": 2
+      },
+      {
+        "name": "window",
+        "type": "custom",
+        "query": "1h,24h,7d",
+        "current": { "text": "24h", "value": "24h" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Current TIA balance",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 50 }
+            ]
+          }
+        }
+      },
+      "description": "Current TIA balance on the DA signer wallet in whole TIA (utia / 1e6). Source: Celestia light node's /metrics endpoint. Red at <10 TIA (~7 day runway), yellow at <50 TIA, green above."
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "TIA balance trend",
+      "gridPos": { "h": 8, "w": 12, "x": 6, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        }
+      },
+      "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts)."
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "TIA draw-down rate (per $window)",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * -1 * 60 * 60 * 24 / 1e6",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 3
+        }
+      },
+      "description": "TIA burned per day, averaged over $window. Negative draw-down (positive sign here after the *-1) means balance is decreasing. Compare against the alert threshold (50 TIA/30 days = ~1.67 TIA/day baseline; spikes above 5 TIA/day suggest abuse or backfill anomaly)."
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "GCP infra",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 }
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "VM-hours this month",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 9 },
+      "datasource": "GCP-BigQuery",
+      "targets": [
+        {
+          "rawSql": "SELECT SUM(usage.amount) AS vm_hours FROM `${billing_table}` WHERE service.description = 'Compute Engine' AND usage.unit = 'hour' AND DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
+          "format": "table"
+        }
+      ],
+      "description": "Sum of vCPU-hours billed this calendar month. Set the BigQuery dataset name in the dashboard variable `${billing_table}`. Cross-check against expected envelope (1 e2-medium = ~720 hours/month)."
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "GCS storage GB-months",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 9 },
+      "datasource": "GCP-BigQuery",
+      "targets": [
+        {
+          "rawSql": "SELECT SUM(usage.amount_in_pricing_units) AS gb_months FROM `${billing_table}` WHERE service.description = 'Cloud Storage' AND DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
+          "format": "table"
+        }
+      ],
+      "description": "Cloud Storage GB-month consumption. Dominated by the backup + snapshot buckets; surfaces if retention isn't pruning."
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "Network egress GB",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 9 },
+      "datasource": "GCP-BigQuery",
+      "targets": [
+        {
+          "rawSql": "SELECT SUM(usage.amount_in_pricing_units) AS gb FROM `${billing_table}` WHERE service.description = 'Compute Engine' AND sku.description LIKE '%Network Egress%' AND DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
+          "format": "table"
+        }
+      ],
+      "description": "Egress GB this month. RPC + indexer traffic. Spike here means either real partner volume or a backfill abuse pattern."
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Estimated month-to-date $USD",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 9 },
+      "datasource": "GCP-BigQuery",
+      "targets": [
+        {
+          "rawSql": "SELECT SUM(cost) AS month_to_date FROM `${billing_table}` WHERE DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
+          "format": "table"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 200 }
+            ]
+          }
+        }
+      },
+      "description": "Total billed cost this calendar month so far. Yellow at $50, red at $200 — devnet's expected envelope is ~$30-$50/mo. Spike here is the first signal something's misconfigured."
+    }
+  ]
+}

--- a/ops/prometheus/alerts.yaml
+++ b/ops/prometheus/alerts.yaml
@@ -163,3 +163,69 @@ groups:
             congested or our submission path is buffering. Investigate
             via the Celestia explorer + the local light node.
           runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/da-finalization-latency-high.md
+
+  - name: ligate-node.cost
+    interval: 5m
+    rules:
+      # TIA balance warning + page tiers. Sources from the Celestia
+      # light node's own /metrics endpoint (the chain doesn't expose
+      # this directly; the light node is the local authority on its
+      # wallet balance).
+      #
+      # Thresholds calibrated against `da-signer-rotation.md`'s
+      # "TIA balance monitoring" section:
+      # - 50 TIA = ~30 days at our submission cadence (warn-level)
+      # - 12 TIA = ~7 days runway (page-level — operator should
+      #   already be topping up by now)
+      - alert: TIABalanceLow
+        expr: |
+          (celestia_node_da_signer_balance_utia / 1e6) < 50
+        for: 30m
+        labels:
+          severity: warn
+          component: chain
+        annotations:
+          summary: "TIA balance below 50 (~30 days runway) on {{ $labels.instance }}"
+          description: |
+            DA signer wallet has dropped below 50 TIA, roughly 30 days
+            of expected blob-fee burn. Plan a top-up from treasury in
+            the next week. Procedure:
+            docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
+
+      - alert: TIABalanceCritical
+        expr: |
+          (celestia_node_da_signer_balance_utia / 1e6) < 12
+        for: 5m
+        labels:
+          severity: page
+          component: chain
+        annotations:
+          summary: "TIA balance below 12 (~7 days runway) on {{ $labels.instance }}"
+          description: |
+            DA signer wallet has dropped below 12 TIA, roughly 7 days
+            of runway. Top up immediately or blob submission halts.
+            Procedure: docs/development/runbooks/da-signer-rotation.md
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
+
+      # Daily draw-down rate alarm. Steady-state burn is ~1-2 TIA/day
+      # (1 blob per slot at ~1000ms cadence, average blob fee ~0.001
+      # TIA). A 24h-rolling rate above 5 TIA/day suggests abnormal
+      # activity: backfill anomaly, partner abuse, or a bug spiking
+      # blob production.
+      - alert: TIADrawdownSpike
+        expr: |
+          rate(celestia_node_da_signer_balance_utia[24h]) * -1 * 86400 / 1e6 > 5
+        for: 1h
+        labels:
+          severity: warn
+          component: chain
+        annotations:
+          summary: "TIA draw-down >5 TIA/day on {{ $labels.instance }}"
+          description: |
+            24h-rolling burn rate exceeds 5 TIA/day, well above the
+            steady-state baseline (~1-2/day). Investigate next:
+            - Mempool depth spike (partner abuse?)
+            - Backfill replay loop (followers reprocessing)
+            - Bug spiking blob production rate
+          runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/cost-monitoring.md


### PR DESCRIPTION
Closes #277.

## What ships

**Grafana dashboard** (\`monitoring/grafana/ligate-devnet-1-cost.json\`):
- TIA half: current balance stat, balance trend timeseries, draw-down rate stat (per configurable window)
- GCP half: VM-hours / GCS GB-months / network egress / month-to-date USD (queries BigQuery billing export)
- Variables: \`$instance\` (which chain VM), \`$window\` (1h/24h/7d aggregation)

**Alertmanager rules** (3 new entries in the \`ligate-node.cost\` group):
- \`TIABalanceLow\` (warn) — below 50 TIA, ~30 days runway
- \`TIABalanceCritical\` (page) — below 12 TIA, ~7 days runway
- \`TIADrawdownSpike\` (warn) — daily burn > 5 TIA/day, well above the ~1-2 TIA/day baseline

**Docs** (\`docs/development/cost-monitoring.md\`):
- Steady-state expectations + thresholds for both cost layers
- GCP billing export setup procedure (one-time UI step)
- Budget alert configuration
- Lookerstudio companion dashboard hookup
- Risk-profile breakdown (TIA = operational, GCP = financial)

## No chain code

Originally considered adding a \`ligate_da_signer_balance_utia\` gauge to ligate-node. Reviewed: the Celestia light node already exposes its own \`/metrics\` endpoint including the wallet balance (\`celestia_node_da_signer_balance_utia\`). Wrapping that in our own metric would be theatre — Prometheus can scrape both targets and the dashboard / alert can reference the upstream metric directly. Saves real chain code in favour of zero-code reuse of an existing source of truth.

## Operator action required to render

- Provision the Grafana host (#234)
- Enable GCP billing export to BigQuery
- Configure a project-level GCP budget alert at \$100/\$200 thresholds
- Import the dashboard JSON; pin to the \"Ligate Ops\" folder
- Render alertmanager.yaml with the cost-rules group loaded

The dashboard + rules + docs ship in the repo today; rendering is a deploy step on the operator side.

## Test plan

- [x] Dashboard JSON validates as Grafana schema v39
- [x] Alert rules validate (mirror the structure of the existing \`ligate-node.liveness\` / \`ligate-node.capacity\` / \`ligate-node.da\` groups)
- [x] Markdown renders cleanly + cross-references resolve