### PR TITLE
fix: drop _doc keys from JSON files (strict schema validators)

### DIFF
--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -1,22 +1,4 @@
 {
-  "_doc": [
-    "Grafana dashboard for ligate-devnet-1 cost monitoring (#277).",
-    "Two halves: Mocha TIA spend (left) + GCP infra spend (right).",
-    "",
-    "Import via Grafana UI > Dashboards > New > Import > Paste JSON.",
-    "Pin to the 'Ligate Ops' folder once the public Grafana (#234)",
-    "is up.",
-    "",
-    "Data sources:",
-    "- 'Prometheus' for TIA panels (scrapes celestia-light's /metrics).",
-    "- 'GCP-BigQuery' for infra panels (reads billing export tables).",
-    "",
-    "Variables (drop-down at top of dashboard):",
-    "- $instance: which chain VM (sequencer / followers).",
-    "- $window: aggregation window for draw-down rates (1h, 24h, 7d).",
-    "",
-    "Time-range default: Last 7 days, refresh 1m."
-  ],
   "title": "Ligate devnet-1 — cost monitoring",
   "uid": "ligate-devnet-1-cost",
   "tags": ["ligate", "devnet-1", "cost"],

--- a/ops/backup/gcs-lifecycle.json
+++ b/ops/backup/gcs-lifecycle.json
@@ -1,18 +1,4 @@
 {
-  "_doc": [
-    "GCS lifecycle policy for the ligate-devnet-1 backup bucket.",
-    "Apply via: gcloud storage buckets update gs://$GCS_BUCKET --lifecycle-file=ops/backup/gcs-lifecycle.json",
-    "",
-    "Combined with the local rotation in `scripts/backup-rocksdb.sh`,",
-    "this gives a dense-recent / sparse-old retention curve:",
-    "",
-    "  - hourly snapshots: last 7 days on GCS",
-    "  - daily snapshots:  last 60 days on GCS",
-    "  - weekly snapshots: last 1 year on GCS",
-    "",
-    "GCS prunes anything matching the conditions below. The local",
-    "rotation prunes the staging dir on the chain VM independently."
-  ],
   "rule": [
     {
       "action": { "type": "Delete" },

--- a/ops/backup/gcs-snapshot-lifecycle.json
+++ b/ops/backup/gcs-snapshot-lifecycle.json
@@ -1,17 +1,4 @@
 {
-  "_doc": [
-    "GCS lifecycle policy for the PUBLIC snapshot bucket.",
-    "Apply via: gcloud storage buckets update gs://$PUBLIC_BUCKET --lifecycle-file=ops/backup/gcs-snapshot-lifecycle.json",
-    "",
-    "Distinct from gcs-lifecycle.json (which is for the operator-private",
-    "backup bucket). Public snapshots have different retention because",
-    "partners may import snapshots months old for forensic / audit use.",
-    "",
-    "  - daily snapshots:   last 30 days",
-    "  - weekly snapshots:  last 12 weeks",
-    "  - monthly snapshots: last 12 months",
-    "  - latest-*.json pointers: never deleted (always-current pointer)"
-  ],
   "rule": [
     {
       "action": { "type": "Delete" },


### PR DESCRIPTION
Three JSON files I shipped earlier this session had a custom `_doc` array key with inline doc strings. The validators that consume them are strict and reject extra keys:

- `ops/backup/gcs-lifecycle.json` — `gcloud storage buckets update --lifecycle-file` validates against the GCS API schema
- `ops/backup/gcs-snapshot-lifecycle.json` — same
- `monitoring/grafana/ligate-devnet-1-cost.json` — Grafana's dashboard import is more permissive but no reason to risk it

Caught when Vercel rejected the same pattern in `vercel.json` over in ligate-explorer ([#17](https://github.com/ligate-io/ligate-explorer/pull/17)). Same fix here, applied preemptively.

The doc content was redundant — `backup-restore.md`, `follower-bootstrap.md`, and `cost-monitoring.md` already cover the same ground. Pure subtraction.

## Test plan

- [x] All 3 files re-validate as JSON (python json.load)
- [x] No `_doc` keys remaining (grep -c 0)