### PR TITLE
chore(genesis): scale devnet $LGT supply from 120M to 1B

### DIFF
--- a/devnet-1/genesis/bank.json
+++ b/devnet-1/genesis/bank.json
@@ -3,15 +3,15 @@
     "address_and_balances": [
       [
         "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8",
-        "100000000000000000"
+        "900000000000000000"
       ],
       [
         "lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544",
-        "10000000000000000"
+        "50000000000000000"
       ],
       [
         "lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz",
-        "10000000000000000"
+        "50000000000000000"
       ]
     ],
     "admins": [

--- a/devnet/genesis/bank.json
+++ b/devnet/genesis/bank.json
@@ -3,9 +3,9 @@
     "token_name": "LGT",
     "token_decimals": 9,
     "address_and_balances": [
-      ["lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt", "100000000000000000"],
-      ["lig1d0vqhkvnlaga6xe8rfed900qxnzhqnmhweqe3rxqdexp56lvqv7", "10000000000000000"],
-      ["lig1njjerykggkxvwa55x4lupkl67qnxsx9rwqxpuq4s3cmh7vmn7kx", "10000000000000000"],
+      ["lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt", "899990000000000000"],
+      ["lig1d0vqhkvnlaga6xe8rfed900qxnzhqnmhweqe3rxqdexp56lvqv7", "50000000000000000"],
+      ["lig1njjerykggkxvwa55x4lupkl67qnxsx9rwqxpuq4s3cmh7vmn7kx", "50000000000000000"],
       ["lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u", "10000000000000"]
     ],
     "admins": [


### PR DESCRIPTION
## Summary

Bump devnet genesis $LGT supply from 120M to 1B. Placeholder ahead of the formal tokenomics RFC at #258 — the current 120M predates any tokenomics discussion and reads as "we didn't think about this." 1B matches industry conventions (Celestia, Cosmos Hub, Solana all launched ~200M-1B; 1B is the modal "serious chain" default).

## Split

| Address | Before | After | Role |
|---|---|---|---|
| `lig1rh9...8fyp8` | 100M | **900M** | Treasury (admin) |
| `lig19tz...j544` | 10M | **50M** | Demo wallet 1 |
| `lig1e0l...j4sz` | 10M | **50M** | Demo wallet 2 |
| **Total (devnet-1)** | 120M | **1B** | |

Localnet (`devnet/`) scales similarly, preserving the 4th wallet's intent as a "small balance for tests" (kept at 10K LGT):

| Address | Before | After |
|---|---|---|
| Treasury admin | 100M | **899.99M** |
| Demo 1 | 10M | **50M** |
| Demo 2 | 10M | **50M** |
| Small-balance test wallet | 10K | 10K (unchanged) |
| **Total (devnet)** | 120M + 10K | **1B exactly** |

## Why placeholder, not RFC

The formal token model (caps, inflation curve, validator emission, vesting, bucket distribution) lives in #258 and is still open. This PR doesn't commit to any of that — it just sets a more defensible placeholder for devnet so the explorer/docs/marketing don't have to apologize for the number.

Mainnet supply + minting policy is decided pre-mainnet via #258.

## What this does NOT change

- Fee values (`schema_registration_fee = 0.1 LGT`, `attestation_fee = 0.0001 LGT`, etc.) — absolute amounts, calibrated correctly at either scale
- Faucet drip amounts (none coded yet, see ligate-api#26)
- Sequencer / operator / attester / prover bonds — absolute LGT values
- `gas_token_config.admins` — same treasury address retains admin role
- `token_decimals = 9` — unchanged
- `token_name = "LGT"` — unchanged

## Test plan

- [ ] CI green (cargo check / clippy / test / fmt / genesis-determinism matrix)
- [ ] `cargo run --bin ligate-genesis-tool -- verify --genesis-dir devnet-1/genesis` passes
- [ ] Local `pnpm dev:ligate` chain boot against `devnet/genesis/` succeeds (or via `cargo run --bin ligate-node`)

## Cross-references

- #258 — RFC: Token model spec (formal tokenomics — this PR is placeholder until #258 lands)
- #286 — RFC: Token primitives (companion RFC on token module mechanics)