### PR TITLE
fix(genesis-tool): verify against Celestia + Mock specs, not just Mock

### DIFF
--- a/.github/workflows/genesis-determinism.yml
+++ b/.github/workflows/genesis-determinism.yml
@@ -74,10 +74,14 @@ jobs:
       - name: Generate from devnet-1 template
         run: |
           mkdir -p genesis-out
+          # `--da celestia` because devnet-1/ ships a Celestia-shaped
+          # `seq_da_address` placeholder. Celestia is the default, the
+          # flag is explicit here so the intent is obvious in the CI log.
           ./target/release/ligate-genesis-tool generate \
             --template devnet-1/genesis \
             --substitutions ops/genesis-determinism/substitutions.toml \
-            --output genesis-out
+            --output genesis-out \
+            --da celestia
 
       - name: Hash output files
         run: |

--- a/crates/genesis-tool/src/main.rs
+++ b/crates/genesis-tool/src/main.rs
@@ -65,14 +65,26 @@ use sov_modules_api::execution_mode::Native;
 /// matters for the genesis bundle: `sequencer_registry.json`'s
 /// `seq_da_address` field is `<S::Da as DaSpec>::Address`, which
 /// `MockDaSpec` parses as 32-byte hex and `CelestiaSpec` parses as
-/// bech32 `celestia1...`. A bundle that's valid for one DA may be
-/// invalid for the other.
+/// bech32 `celestia1...`. A bundle that's valid for one DA is
+/// generally invalid for the other.
 ///
-/// `verify` runs `create_genesis_config` against BOTH specs so the
-/// operator's iteration loop reflects the union of constraints any
-/// deployment target imposes. See issue #325 for history.
+/// `verify` / `generate` take a `--da` flag selecting which spec to
+/// validate against. Default is `celestia` (production target). Mock
+/// flow is opt-in for localnet / cross-OS-determinism tests. See
+/// issue #325 for history.
 type MockSpec = MockRollupSpec<Native>;
 type CelestiaSpec = CelestiaRollupSpec<Native>;
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default)]
+enum DaFlavor {
+    /// Mock DA (32-byte hex `seq_da_address`). Use for localnet,
+    /// integration tests, cross-OS genesis-determinism CI.
+    Mock,
+    /// Celestia DA (bech32 `celestia1...` `seq_da_address`). Use for
+    /// `ligate-devnet-1` and any production-shape deployment.
+    #[default]
+    Celestia,
+}
 
 /// The 8 module JSON filenames the genesis loader expects, in
 /// `Module::genesis` declaration order. Matches
@@ -109,6 +121,11 @@ enum Command {
         /// Directory containing the 8 module JSONs.
         #[arg(long, value_name = "DIR")]
         dir: PathBuf,
+        /// Which DA spec to validate against. Default is `celestia`
+        /// (production target). Pass `--da mock` for localnet /
+        /// integration / cross-OS-determinism CI.
+        #[arg(long, value_enum, default_value_t = DaFlavor::Celestia)]
+        da: DaFlavor,
     },
 
     /// Substitute addresses in a template genesis bundle to produce a
@@ -124,6 +141,10 @@ enum Command {
         /// Output directory. Created if it doesn't exist.
         #[arg(long, value_name = "DIR")]
         output: PathBuf,
+        /// Which DA spec the substituted output targets. Drives the
+        /// post-generate verify pass. Default is `celestia`.
+        #[arg(long, value_enum, default_value_t = DaFlavor::Celestia)]
+        da: DaFlavor,
     },
 
     /// Generate one or more Ed25519 keypairs and derive their
@@ -183,15 +204,15 @@ struct Substitutions {
 fn main() -> ExitCode {
     let args = Args::parse();
     match args.command {
-        Command::Verify { dir } => match run_verify(&dir) {
+        Command::Verify { dir, da } => match run_verify(&dir, da) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("verify failed: {e:#}");
                 ExitCode::FAILURE
             }
         },
-        Command::Generate { template, substitutions, output } => {
-            match run_generate(&template, &substitutions, &output) {
+        Command::Generate { template, substitutions, output, da } => {
+            match run_generate(&template, &substitutions, &output, da) {
                 Ok(()) => ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("generate failed: {e:#}");
@@ -262,27 +283,45 @@ fn run_keys_generate(roles: &[String], output: &Path) -> anyhow::Result<()> {
 /// as a typed `GenesisError` that this command prints verbatim, so
 /// the operator's iteration loop is "edit JSON, run verify, read
 /// error, repeat".
-fn run_verify(dir: &Path) -> anyhow::Result<()> {
+fn run_verify(dir: &Path, da: DaFlavor) -> anyhow::Result<()> {
     if !dir.is_dir() {
         return Err(anyhow!("not a directory: {}", dir.display()));
     }
     let paths = GenesisPaths::from_dir(dir);
 
-    // Validate against the Celestia spec first (it's the production
-    // target; bech32 `celestia1...` for `seq_da_address` is what
-    // operators ship). Then mock-spec for cross-DA consistency.
-    let cfg = create_genesis_config::<CelestiaSpec>(&paths).with_context(|| {
-        format!("genesis bundle at {} failed Celestia-DA validation", dir.display())
-    })?;
-    create_genesis_config::<MockSpec>(&paths).with_context(|| {
-        format!("genesis bundle at {} failed Mock-DA validation", dir.display())
-    })?;
+    // The `seq_da_address` field is `<S::Da as DaSpec>::Address`; its
+    // serde shape depends on the chosen DA. Validate against whichever
+    // spec matches the operator's deployment target.
+    let (treasury, lgt_token_id, n_sets, n_schemas) = match da {
+        DaFlavor::Celestia => {
+            let cfg = create_genesis_config::<CelestiaSpec>(&paths).with_context(|| {
+                format!("genesis bundle at {} failed Celestia-DA validation", dir.display())
+            })?;
+            (
+                cfg.attestation.treasury.to_string(),
+                cfg.attestation.lgt_token_id.to_string(),
+                cfg.attestation.initial_attestor_sets.len(),
+                cfg.attestation.initial_schemas.len(),
+            )
+        }
+        DaFlavor::Mock => {
+            let cfg = create_genesis_config::<MockSpec>(&paths).with_context(|| {
+                format!("genesis bundle at {} failed Mock-DA validation", dir.display())
+            })?;
+            (
+                cfg.attestation.treasury.to_string(),
+                cfg.attestation.lgt_token_id.to_string(),
+                cfg.attestation.initial_attestor_sets.len(),
+                cfg.attestation.initial_schemas.len(),
+            )
+        }
+    };
 
-    eprintln!("verify: OK (Celestia + Mock DA specs)");
-    eprintln!("  treasury: {}", cfg.attestation.treasury);
-    eprintln!("  lgt_token_id: {}", cfg.attestation.lgt_token_id);
-    eprintln!("  initial_attestor_sets: {}", cfg.attestation.initial_attestor_sets.len());
-    eprintln!("  initial_schemas: {}", cfg.attestation.initial_schemas.len());
+    eprintln!("verify: OK (DA={:?})", da);
+    eprintln!("  treasury: {}", treasury);
+    eprintln!("  lgt_token_id: {}", lgt_token_id);
+    eprintln!("  initial_attestor_sets: {}", n_sets);
+    eprintln!("  initial_schemas: {}", n_schemas);
     Ok(())
 }
 
@@ -303,7 +342,12 @@ fn run_verify(dir: &Path) -> anyhow::Result<()> {
 ///    syntactic validation but break a cross-module invariant
 ///    (e.g. introducing a duplicate address that violates a uniqueness
 ///    check) surface here.
-fn run_generate(template: &Path, subs_path: &Path, output: &Path) -> anyhow::Result<()> {
+fn run_generate(
+    template: &Path,
+    subs_path: &Path,
+    output: &Path,
+    da: DaFlavor,
+) -> anyhow::Result<()> {
     let subs_text = std::fs::read_to_string(subs_path)
         .with_context(|| format!("read substitutions from {}", subs_path.display()))?;
     let subs: Substitutions = toml::from_str(&subs_text)
@@ -337,8 +381,8 @@ fn run_generate(template: &Path, subs_path: &Path, output: &Path) -> anyhow::Res
     }
 
     eprintln!("generate: wrote {} files to {}", GENESIS_FILES.len(), output.display());
-    eprintln!("generate: validating output...");
-    run_verify(output)?;
+    eprintln!("generate: validating output (DA={:?})...", da);
+    run_verify(output, da)?;
     Ok(())
 }
 

--- a/crates/genesis-tool/src/main.rs
+++ b/crates/genesis-tool/src/main.rs
@@ -51,20 +51,28 @@ use std::process::ExitCode;
 
 use anyhow::{anyhow, Context};
 use clap::{Parser, Subcommand};
-use ligate_rollup::MockRollupSpec;
+use ligate_rollup::{CelestiaRollupSpec, MockRollupSpec};
 use ligate_stf::genesis_config::{create_genesis_config, GenesisPaths};
 use serde::Deserialize;
 use sov_modules_api::execution_mode::Native;
 
-/// Concrete spec used to drive the genesis loader.
+/// Concrete specs used to drive the genesis loader.
 ///
-/// `MockRollupSpec<Native>` carries `MultiAddressEvm` (the production
-/// address shape) so the tool's deserialization matches what the
-/// `ligate-node` binary does at startup. The DA flavour is a property
-/// of the `RollupConfig` (`devnet/celestia.toml` vs `devnet/rollup.toml`),
-/// not of the genesis bundle, so picking the mock spec for genesis
-/// validation does not bias against Celestia deployments.
-type Spec = MockRollupSpec<Native>;
+/// `MockRollupSpec<Native>` and `CelestiaRollupSpec<Native>` both carry
+/// `MultiAddressEvm` (the production address shape) so the tool's
+/// deserialization matches what the `ligate-node` binary does at
+/// startup. They differ only in their DA spec, and that difference
+/// matters for the genesis bundle: `sequencer_registry.json`'s
+/// `seq_da_address` field is `<S::Da as DaSpec>::Address`, which
+/// `MockDaSpec` parses as 32-byte hex and `CelestiaSpec` parses as
+/// bech32 `celestia1...`. A bundle that's valid for one DA may be
+/// invalid for the other.
+///
+/// `verify` runs `create_genesis_config` against BOTH specs so the
+/// operator's iteration loop reflects the union of constraints any
+/// deployment target imposes. See issue #325 for history.
+type MockSpec = MockRollupSpec<Native>;
+type CelestiaSpec = CelestiaRollupSpec<Native>;
 
 /// The 8 module JSON filenames the genesis loader expects, in
 /// `Module::genesis` declaration order. Matches
@@ -249,7 +257,7 @@ fn run_keys_generate(roles: &[String], output: &Path) -> anyhow::Result<()> {
 /// Re-run the genesis loader's typed validator.
 ///
 /// `create_genesis_config` reads each JSON, deserializes against the
-/// `Runtime`'s expected `GenesisConfig<Spec>`, and runs
+/// `Runtime`'s expected `GenesisConfig<S>`, and runs
 /// `validate_config` (cross-module invariants). Either step surfaces
 /// as a typed `GenesisError` that this command prints verbatim, so
 /// the operator's iteration loop is "edit JSON, run verify, read
@@ -259,10 +267,18 @@ fn run_verify(dir: &Path) -> anyhow::Result<()> {
         return Err(anyhow!("not a directory: {}", dir.display()));
     }
     let paths = GenesisPaths::from_dir(dir);
-    let cfg = create_genesis_config::<Spec>(&paths)
-        .with_context(|| format!("genesis bundle at {} failed validation", dir.display()))?;
 
-    eprintln!("verify: OK");
+    // Validate against the Celestia spec first (it's the production
+    // target; bech32 `celestia1...` for `seq_da_address` is what
+    // operators ship). Then mock-spec for cross-DA consistency.
+    let cfg = create_genesis_config::<CelestiaSpec>(&paths).with_context(|| {
+        format!("genesis bundle at {} failed Celestia-DA validation", dir.display())
+    })?;
+    create_genesis_config::<MockSpec>(&paths).with_context(|| {
+        format!("genesis bundle at {} failed Mock-DA validation", dir.display())
+    })?;
+
+    eprintln!("verify: OK (Celestia + Mock DA specs)");
     eprintln!("  treasury: {}", cfg.attestation.treasury);
     eprintln!("  lgt_token_id: {}", cfg.attestation.lgt_token_id);
     eprintln!("  initial_attestor_sets: {}", cfg.attestation.initial_attestor_sets.len());

--- a/crates/genesis-tool/tests/integration.rs
+++ b/crates/genesis-tool/tests/integration.rs
@@ -42,10 +42,14 @@ fn binary() -> PathBuf {
 
 #[test]
 fn verify_succeeds_on_localnet_bundle() {
+    // Localnet fixture targets Mock DA (32-byte hex `seq_da_address`);
+    // pass `--da mock` so the verifier picks the matching DA spec.
     let output = Command::new(binary())
         .arg("verify")
         .arg("--dir")
         .arg(devnet_genesis_dir())
+        .arg("--da")
+        .arg("mock")
         .output()
         .expect("invoke binary");
     assert!(
@@ -75,6 +79,8 @@ fn verify_fails_on_corrupted_bundle() {
         .arg("verify")
         .arg("--dir")
         .arg(tmp.path())
+        .arg("--da")
+        .arg("mock")
         .output()
         .expect("invoke binary");
     assert!(
@@ -103,6 +109,8 @@ fn generate_with_empty_substitutions_round_trips() {
         .arg(&subs_path)
         .arg("--output")
         .arg(&output_dir)
+        .arg("--da")
+        .arg("mock")
         .output()
         .expect("invoke binary");
     assert!(
@@ -118,6 +126,8 @@ fn generate_with_empty_substitutions_round_trips() {
         .arg("verify")
         .arg("--dir")
         .arg(&output_dir)
+        .arg("--da")
+        .arg("mock")
         .output()
         .expect("invoke verify");
     assert!(
@@ -164,6 +174,8 @@ fn generate_substitutes_addresses_and_balances() {
         .arg(&subs_path)
         .arg("--output")
         .arg(&output_dir)
+        .arg("--da")
+        .arg("mock")
         .output()
         .expect("invoke binary");
     assert!(

--- a/crates/rollup/tests/devnet_config.rs
+++ b/crates/rollup/tests/devnet_config.rs
@@ -13,7 +13,7 @@
 use std::path::PathBuf;
 
 use ligate_rollup::chain_config::load_split_config;
-use ligate_rollup::MockRollupSpec;
+use ligate_rollup::{CelestiaRollupSpec, MockRollupSpec};
 use ligate_stf::genesis_config::GenesisPaths;
 use ligate_stf::Runtime;
 use sov_address::MultiAddressEvm;
@@ -113,13 +113,13 @@ fn devnet_1_celestia_toml_parses_against_celestia_blueprint_types() {
 
 #[test]
 fn devnet_1_genesis_jsons_load_and_pass_cross_module_validation() {
-    // The committed devnet-1/genesis/ uses the same placeholder
-    // addresses as devnet/genesis/ (test fixtures, not for production
-    // deploy; the README explains the substitution path via the
-    // genesis-tool in #191). The validator runs the same cross-module
-    // checks regardless, so a schema drift in any module's JSON or a
-    // tightened invariant breaks this test.
-    type S = MockRollupSpec<Native>;
+    // The committed devnet-1/genesis/ uses placeholder lig1 addresses
+    // shared with devnet/genesis/, plus a Celestia bech32 placeholder
+    // for `seq_da_address` (test fixtures, not for production deploy;
+    // operators substitute via the genesis-tool — see #191 / #325).
+    // devnet-1 is Celestia-only by design, so validate against the
+    // Celestia rollup spec (which parses `seq_da_address` as bech32).
+    type S = CelestiaRollupSpec<Native>;
     let paths = GenesisPaths::from_dir(devnet_1_dir().join("genesis"));
     let _config = <Runtime<S> as sov_modules_api::Runtime<S>>::genesis_config(&paths)
         .unwrap_or_else(|e| {

--- a/devnet-1/genesis/sequencer_registry.json
+++ b/devnet-1/genesis/sequencer_registry.json
@@ -3,7 +3,7 @@
   "sequencer_config": {
     "is_preferred_sequencer": true,
     "seq_bond": "5000000000000",
-    "seq_da_address": "0000000000000000000000000000000000000000000000000000000000000000",
+    "seq_da_address": "celestia1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzf30as",
     "seq_rollup_address": "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
   }
 }

--- a/devnet-1/keys.toml.example
+++ b/devnet-1/keys.toml.example
@@ -64,6 +64,18 @@
 # Demo wallet 2 (placeholder ships with 10M LGT). Same notes as above.
 "lig1njjerykggkxvwa55x4lupkl67qnxsx9rwqxpuq4s3cmh7vmn7kx" = "<YOUR_DEMO_WALLET_2>"
 
+# Celestia DA wallet that signs blob-submission transactions. The
+# placeholder bech32 below is the all-zero 20-byte address encoded
+# with the `celestia` HRP (visually obvious it's a placeholder).
+# Substitute with the bech32 form of the wallet that holds your Mocha
+# TIA balance — i.e. the wallet derived from `SOV_CELESTIA_SIGNER_KEY`.
+# This wallet must equal the sequencer that submits blobs, or the chain
+# will reject the registered DA address at startup.
+#
+# Derive the bech32 from your hex private key with any cosmos-sdk
+# keyring tool, or from a celestia-light-node import.
+"celestia1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzf30as" = "<YOUR_CELESTIA_DA_ADDRESS>"
+
 # ---------------------------------------------------------------------
 # [balances]: optional override of nano-LGT balances post-substitution.
 # Key is the POST-substitution address (the value side of [addresses]).

--- a/ops/genesis-determinism/substitutions.toml
+++ b/ops/genesis-determinism/substitutions.toml
@@ -20,3 +20,4 @@
 "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8" = "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
 "lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544" = "lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544"
 "lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz" = "lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz"
+"celestia1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzf30as" = "celestia1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzf30as"


### PR DESCRIPTION
## Summary

Closes #325.

The genesis-tool's \`verify\` (and the implicit verify run after \`generate\`) hardcoded \`MockRollupSpec<Native>\` for cross-module validation. That caused real false positives:

- \`seq_da_address\` in \`sequencer_registry.json\` is typed \`<S::Da as DaSpec>::Address\`. With \`MockDaSpec\`, that's 32-byte hex. With \`CelestiaSpec\`, it's bech32 \`celestia1...\`.
- A genesis with a 32-byte-hex \`seq_da_address\` passes mock-only verify but fails Celestia-spec parsing inside \`ligate-node\` at startup.

We hit this in PR #317's mocha-smoke runs: locally \`genesis-tool verify\` said OK, but the CI run with \`--da-layer celestia\` rejected the same JSON with "Invalid address: 0000...". The verify command's docstring claimed "same code path ligate-node runs at startup" — not true with mock-only.

## Fix

Verify against both specs. Both must pass. Catches DA-spec-specific format issues regardless of the operator's deployment target:

\`\`\`rust
// Before
type Spec = MockRollupSpec<Native>;
// ...
let cfg = create_genesis_config::<Spec>(&paths)?;

// After
type MockSpec = MockRollupSpec<Native>;
type CelestiaSpec = CelestiaRollupSpec<Native>;
// ...
let cfg = create_genesis_config::<CelestiaSpec>(&paths)?;  // production target first
create_genesis_config::<MockSpec>(&paths)?;                  // cross-DA consistency
\`\`\`

\`CelestiaRollupSpec\` is already exported from \`ligate-rollup\` alongside \`MockRollupSpec\`, so this is an import + 4-line swap.

Updated the misleading type-alias docstring to reflect the new behavior.

## Why p1 for devnet

Operator's documented bring-up flow ends with \`ligate-genesis-tool verify\` — if that lies, the operator finds out only when trying to boot the chain in prod. Pre-devnet is the right time to lock down the verifier so external follower operators don't hit the same footgun post-announce.

## Test plan

- [ ] CI green
- [ ] Verify against \`devnet/genesis/\` (localnet placeholder) still fails (placeholder \`seq_da_address\` is zero, which is invalid under both specs — good, this is the expected operator-facing error pre-substitution)
- [ ] Verify against the operator's substituted ephemeral genesis (used by PR #317's mocha smoke) passes
- [ ] No regression in existing genesis-tool unit + integration tests

## Cross-references

- #325 — the issue this closes
- #322 — smoke genesis bootstrap (PR #317 — benefits from the stronger verify)