### PR TITLE
fix(test): disable metrics endpoint in restart_recovery to remove port-9100 flake

### DIFF
--- a/crates/rollup/tests/restart_recovery.rs
+++ b/crates/rollup/tests/restart_recovery.rs
@@ -111,11 +111,20 @@ async fn spawn_node(temp_dir: &Path, port: u16) -> Child {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let genesis_dir = format!("{manifest_dir}/../../devnet/genesis");
 
+    // Disable the metrics endpoint. `ligate-node` defaults
+    // `--metrics-bind` to `127.0.0.1:9100`, which races with parallel
+    // test runs (this file's tests are `#[serial]` but the OS holds
+    // the port in TIME_WAIT between sequential SIGKILL + respawn
+    // cycles, and `cargo llvm-cov` sometimes parallelizes across
+    // crates anyway). Tests don't assert on metrics; disable the
+    // endpoint to remove the false-negative flake.
     Command::new(ligate_node_binary())
         .arg("--rollup-config-path")
         .arg(&rollup_path)
         .arg("--genesis-config-dir")
         .arg(&genesis_dir)
+        .arg("--metrics-bind")
+        .arg("off")
         .kill_on_drop(true)
         .spawn()
         .expect("spawn ligate-node binary")


### PR DESCRIPTION
PR #326's \`cargo llvm-cov\` flaked with \`Address already in use: 127.0.0.1:9100\` in the \`restart_recovery\` test. The race condition:

- \`ligate-node\` defaults \`--metrics-bind\` to \`127.0.0.1:9100\` when the flag is omitted
- \`restart_recovery::spawn_node\` doesn't pass \`--metrics-bind\`, so every spawn binds :9100
- Tests are \`#[serial]\`, but the OS holds the port in TIME_WAIT between sequential SIGKILL + respawn cycles
- \`cargo llvm-cov\` also sometimes parallelizes across crates regardless of \`#[serial]\`

Fix: pass \`--metrics-bind off\` (a documented disable option per \`crates/rollup/src/main.rs::is_metrics_disabled\`). The test doesn't assert on metrics, only on REST state recovery, so disabling is the cleanest path.

## Test plan

- [ ] CI green on this PR
- [ ] Re-run \`cargo llvm-cov\` a few times in PR follow-ups to confirm the flake is gone