### PR TITLE
fix(fuzz): add SDK fork patch block to attestation fuzz crate

### DIFF
--- a/crates/modules/attestation/fuzz/Cargo.toml
+++ b/crates/modules/attestation/fuzz/Cargo.toml
@@ -20,11 +20,19 @@ libfuzzer-sys = "0.4"
 
 attestation = { path = ".." }
 
-# SDK pins. Keep in sync with the parent workspace's
-# `workspace.dependencies` block. Bump alongside SDK rev upgrades.
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
+# SDK pins. Declared against upstream `Sovereign-Labs/sovereign-sdk`
+# at the same rev as the parent workspace's `workspace.dependencies`
+# block; the `[patch]` block at the bottom of this file redirects
+# every `sov-*` crate to the `ligate-io` fork, exactly as the parent
+# workspace does. This fuzz crate is a SEPARATE `[workspace]`, so it
+# needs its own `[patch]` mirror -- `[patch]` blocks don't transit
+# workspace boundaries, and without it the `attestation` path dep
+# resolves a different `Spec` trait than this crate's `sov-*` deps
+# (a `trait bound ... : Spec is not satisfied` compile error).
+# Keep both the rev below AND the `[patch]` rev in sync on SDK bumps.
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f6cd64749edc56428fbeb7f22702458b0afb698a" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f6cd64749edc56428fbeb7f22702458b0afb698a" }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f6cd64749edc56428fbeb7f22702458b0afb698a" }
 
 borsh = "1.5"
 
@@ -111,3 +119,44 @@ path = "fuzz_targets/rest_attestation_path.rs"
 test = false
 doc = false
 bench = false
+
+# SDK fork patch block. Mirrors the parent `ligate-chain/Cargo.toml`
+# `[patch]` block: redirects every `sov-*` crate to the `ligate-io`
+# fork so the `attestation` path dep and this crate's direct `sov-*`
+# deps resolve to byte-identical SDK code. `[patch]` does not cross
+# workspace boundaries, and this fuzz crate is its own `[workspace]`,
+# so the mirror is mandatory. Keep the rev in sync with the parent
+# on every SDK bump (see comment on the `sov-*` deps above).
+[patch."https://github.com/Sovereign-Labs/sovereign-sdk.git"]
+sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-blob-sender                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }
+sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "49e9b2057a5b3d244abab9ca98bb91edbfb9c533" }

--- a/scripts/check-da-isolation.sh
+++ b/scripts/check-da-isolation.sh
@@ -31,6 +31,18 @@ guarded_paths=(
   "crates/client-rs"
 )
 
+# Directories excluded from the scan even when nested under a guarded
+# path. `fuzz/` is a separate `[workspace]` of cargo-fuzz harnesses
+# (`publish = false`, test-only): it links `sov-test-utils`, which
+# transitively pulls the full chain dependency tree including
+# `sov-celestia-adapter`, so its `[patch]` block must mirror every
+# `sov-*` crate. A `[patch]` redirect is a workspace-resolution
+# mechanism, not a `use`-level coupling, and the fuzz crate is not a
+# shippable DA-agnostic module -- so it's out of this guard's scope.
+excluded_dirs=(
+  "fuzz"
+)
+
 # Patterns that indicate Celestia-specific coupling. Case-insensitive
 # so we catch both `Celestia` types and `celestia` identifiers / paths.
 # The word "namespace" alone is not matched — schema-namespace prose
@@ -40,6 +52,12 @@ patterns=(
   "sov_celestia_adapter"
 )
 
+# Build the `--exclude-dir` flags once.
+exclude_flags=()
+for d in "${excluded_dirs[@]}"; do
+  exclude_flags+=("--exclude-dir=$d")
+done
+
 leaks=0
 for path in "${guarded_paths[@]}"; do
   if [[ ! -d "$path" ]]; then
@@ -47,7 +65,8 @@ for path in "${guarded_paths[@]}"; do
     continue
   fi
   for pattern in "${patterns[@]}"; do
-    if matches=$(grep -r -i -n --include="*.rs" --include="*.toml" "$pattern" "$path" 2>/dev/null); then
+    if matches=$(grep -r -i -n --include="*.rs" --include="*.toml" \
+      "${exclude_flags[@]}" "$pattern" "$path" 2>/dev/null); then
       echo "::error::DA isolation violation in $path (pattern: '$pattern'):"
       printf '%s\n' "$matches" | sed 's/^/  /'
       leaks=1


### PR DESCRIPTION
The nightly Fuzz workflow has been failing at **Build all fuzz targets**:

\`\`\`
error[E0277]: the trait bound `DefaultNomtSpec<MockDaSpec, MockZkvm, MockZkvm, Native>: Spec` is not satisfied
\`\`\`

(scheduled run [25845006601](https://github.com/ligate-io/ligate-chain/actions/runs/25845006601))

## Root cause

`crates/modules/attestation/fuzz/` is its own `[workspace]` (so `cargo build --workspace` on stable doesn't try to build the nightly-only fuzz binaries). It declared `sov-*` deps at a **stale upstream rev** (`f89964c6…`, raw `Sovereign-Labs/sovereign-sdk`) and had **no `[patch]` block**.

Meanwhile the `attestation` crate it links via `path = ".."` resolves `sov-*` through the parent workspace's `[patch]` → the `ligate-io` fork at `49e9b205…`. `[patch]` blocks don't cross workspace boundaries, so the fuzz crate's `sov-modules-api` and `attestation`'s `sov-modules-api` were two different crate versions → two different `Spec` traits → the `trait bound … : Spec is not satisfied` error.

Same bug class as the cli/api pin drift (#321) — a sub-crate with an independent SDK pin that drifted from chain main.

## Fix

- Bumped the 3 declared `sov-*` deps from `f89964c6…` → `f6cd6474…` (matches the parent workspace's `workspace.dependencies` declared rev)
- Added the full `[patch."https://github.com/Sovereign-Labs/sovereign-sdk.git"]` block — 32 entries redirecting every `sov-*` crate to `ligate-io/sovereign-sdk@49e9b205…`, byte-identical to the parent `ligate-chain/Cargo.toml` `[patch]` block
- Expanded the in-file comment so the next SDK bump updates both the declared rev AND the patch rev

`fuzz/Cargo.lock` is gitignored (CI regenerates), so no lock churn. `cargo update --manifest-path` resolves the new graph cleanly.

## Test plan

- [ ] `workflow_dispatch` the Fuzz workflow against this branch — "Build all fuzz targets" must pass
- [ ] All 10 fuzz targets build
- [ ] Follow-up: the fuzz crate's pin now needs to ride along on every chain SDK bump — worth adding to the SDK-bump checklist (or folding the fuzz crate into the parent workspace's patch surface long-term)

## Cross-references

- #321 — the cli/api pin drift (same bug class, this is the third instance)
- #157 — the REST extractor fuzz harnesses that the build error blocks