### PR TITLE
ci(fuzz): bump nightly timeout to 60min + cache-on-failure

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,9 +25,14 @@ jobs:
   fuzz:
     name: cargo fuzz
     runs-on: ubuntu-latest
-    # Cold build is ~5 min, then 7 targets × ~85s = ~10 min runs.
-    # 30 leaves headroom for the first-run cache miss.
-    timeout-minutes: 30
+    # Cold build is ~20 min (sanitizer-instrumented compile of the
+    # whole chain dep tree pulled in by `sov-test-utils` via the
+    # SDK-fork patch block added in #330), then 10 targets × ~60s =
+    # ~10 min runs. The previous 30-min cap got blown by the
+    # cache-save tail once #330 fattened the build; 60 leaves real
+    # headroom. Warm runs (post `cache-on-failure` below) should
+    # land in ~10-15 min.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
@@ -44,6 +49,13 @@ jobs:
           # workspace cache with sanitizer-flavoured builds.
           workspaces: |
             crates/modules/attestation/fuzz
+          # Save the cache even when the job fails or is cancelled.
+          # Default `false` discards the multi-GB sanitizer `target/`
+          # whenever a run times out or libfuzzer finds a crash, which
+          # forces a ~20 min cold rebuild on every subsequent nightly
+          # (same trap `mocha-smoke.yml` hit until the cache-on-failure
+          # fix landed there).
+          cache-on-failure: true
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -56,7 +68,7 @@ jobs:
       # runtime. Each target re-uses the build artifact from the
       # previous step so the only cost here is fuzzing time. The
       # REST extractor targets (rest_*) added in #157 share the
-      # budget; each is ~60s. Total still under the 30-min job cap.
+      # budget; each is ~60s. Total well under the 60-min job cap.
       - name: Run targets
         working-directory: crates/modules/attestation/fuzz
         run: |


### PR DESCRIPTION
The latest nightly fuzz run (#13, run `25903659402`) was reported as `cancelled` after 30m5s. The actual work succeeded — all 10 fuzz targets ran clean — but the 30-min job cap fired during the post-job `Swatinem/rust-cache` save step, so the cleanup tail got killed and the whole run is stamped cancelled.

## Why it suddenly tightened up

The fuzz crate is a separate sub-workspace that transitively pulls the full chain dep tree. When #330 (the fork-patch fix) gave the fuzz crate the correct SDK pin, it also meant the fuzz build now compiles the whole chain dependency graph with sanitizer instrumentation. The workflow comment claimed "Cold build ~5 min, then ~10 min targets," but reality is now ~20 min build + ~10 min targets = ~30 min cold, right against the cap. The verifying run on `fix/fuzz-crate-sdk-pin-drift` took **29m27s** (squeaked under); the first post-merge nightly tipped over at 30m05s.

## Fixes

1. **`timeout-minutes: 30 → 60`** — gives cold builds + cleanup real headroom. Updated header comment to match the actual cost.
2. **`cache-on-failure: true`** on the `Swatinem/rust-cache@v2` step — same trap `mocha-smoke.yml` hit until last session: default `false` discards the multi-GB sanitizer `target/` whenever a run times out or libfuzzer finds a crash, forcing a ~20 min cold rebuild every nightly. Saving on failure lets the next run restore.

After both: warm nightlies should land in ~10-15 min once the cache is primed, well under any cap.

## Test plan

- [ ] Workflow file parses (workflow run dispatches on the PR branch).
- [ ] Next scheduled run (or a dispatched run on this branch) builds + runs all 10 targets + saves cache without hitting the timeout.
- [ ] Run after that lands warm in <20 min.