### PR TITLE
docs(devnet): add pin-genesis_da_height step to deploy runbook

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -168,6 +168,15 @@ The cloud-init does the chassis. The operator still has to:
 
 - Place the `ligate-node` binary at `/opt/ligate/bin/ligate-node`. From a tag onward, the canonical artifact is a GitHub Release tarball (`ligate-node-${VERSION}-linux-amd64.tar.gz` or `linux-arm64.tar.gz` for the Linux server case; `darwin-arm64` and `darwin-amd64` are also published for developer tooling). The release workflow at `.github/workflows/release.yml` produces all four targets on every `v*` tag. Pre-tag operators build from source via `cargo build --release --bin ligate-node`.
 - Clone the chain repo's `devnet-1/` directory to `/opt/ligate/devnet-1/`.
+- **Pin `genesis_da_height` before first boot.** `devnet-1/genesis/chain_state.json` ships `genesis_da_height: 0` — a placeholder. Celestia rejects a request for DA block 0, so the chain cannot initialize against Mocha while it's `0` (this is exactly what the Mocha smoke gate surfaced; see [#331](https://github.com/ligate-io/ligate-chain/issues/331)). Set it to a recent **finalized** Mocha height:
+  ```bash
+  # Latest Mocha consensus height, minus a finality margin.
+  MOCHA_HEIGHT=$(curl -s https://rpc-mocha.pops.one/status | jq -r .result.sync_info.latest_block_height)
+  PIN=$((MOCHA_HEIGHT - 20))
+  jq ".genesis_da_height = $PIN" /opt/ligate/devnet-1/genesis/chain_state.json \
+      > /tmp/chain_state.json && mv /tmp/chain_state.json /opt/ligate/devnet-1/genesis/chain_state.json
+  ```
+  The chain starts reading DA from this height, so it must be recent — a stale value forces the node to sync months of Mocha history before producing its first slot. This is a launch-time value: re-pin it on every re-genesis, including `devnet-N` rotation after a Mocha reset (see the re-genesis playbook below).
 - Write `/etc/ligate/env` with the secrets (sequencer only):
   ```
   SOV_CELESTIA_RPC_AUTH_TOKEN=<from "celestia light auth admin">


### PR DESCRIPTION
The Mocha smoke saga surfaced that `devnet-1/genesis/chain_state.json` ships `genesis_da_height: 0` — a template placeholder. Celestia rejects a request for DA block 0, so the chain literally cannot initialize against Mocha while it's `0`. The smoke workflow already patches it at runtime; the public-devnet deploy runbook didn't mention it at all.

This adds an explicit pin step to `docs/development/public-devnet-deploy.md` (Step 2 operator-actions list, right after staging the `devnet-1/` bundle and before writing `/etc/ligate/env`), with the `jq` one-liner that fetches a recent finalized Mocha height and rewrites `chain_state.json`. Also notes the value is launch-time (re-pin on every re-genesis, including `devnet-N` rotation after a Mocha reset).

## What this does *not* do

- **Doesn't set the height in the committed genesis.** That value is inherently launch-time; the committed `0` stays as a template placeholder (like the placeholder addresses in `devnet-1/genesis/`).
- **Doesn't close #331.** #331 also tracks the actual launch-time pinning, which is still pending the real devnet bring-up. Worth keeping open as the launch reminder.

## Follow-up worth filing later

The properly-engineered fix is a `--da-height` flag on `ligate-genesis-tool generate` so it substitutes `genesis_da_height` the same way it does the placeholder addresses — that turns the "remember to re-pin" runbook step into a tool guarantee. Rust change, deferrable.

Refs #331.