### PR TITLE
docs(devnet): rewrite [sequencer.preferred] comments to reflect conscious choice

### DIFF
--- a/devnet-1/celestia.toml
+++ b/devnet-1/celestia.toml
@@ -164,6 +164,18 @@ max_allowed_node_distance_behind = 10
 rollup_address = "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"
 
 [sequencer.preferred]
+# Conscious choice (per #293, option A). We run preferred sequencer
+# because that's the Sovereign SDK's intended production architecture
+# (soft confirmations from a single sequencer, the universal L2
+# norm). The `disable_state_root_consistency_checks` flag below
+# silences `StateRootTask`'s internal audit (tentative vs
+# post-DA-canonical state-root cross-check) as a workaround for a
+# private upstream bug (`Sovereign-Labs/sovereign-sdk-wip#2814`).
+# At v0 single-sequencer scale that audit is defensive: the
+# sequencer is the only state-root producer, so there is nothing
+# for tentative roots to diverge from. Carrying the flag is fine
+# for devnet. The proper fix is upstreaming the bug and dropping
+# the flag; tracked at #337.
 disable_state_root_consistency_checks = true
 recovery_strategy = "TryToSave"
 batch_execution_time_limit_millis = 12000

--- a/devnet/celestia.toml
+++ b/devnet/celestia.toml
@@ -130,7 +130,10 @@ max_allowed_node_distance_behind = 10
 rollup_address = "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"
 
 [sequencer.preferred]
-# TODO: drop once Sovereign-Labs/sovereign-sdk-wip#2814 lands.
+# Conscious choice per #293, option A. See `devnet-1/celestia.toml`
+# for the long-form explanation: preferred sequencer = SDK norm,
+# the flag below is an upstream-bug workaround we carry knowingly
+# at v0 single-sequencer scale. Proper fix tracked at #337.
 disable_state_root_consistency_checks = true
 recovery_strategy = "TryToSave"
 # 12s — one Celestia block of in-batch work.


### PR DESCRIPTION
Closes #293 by satisfying its **option A** acceptance: *"TOML comments updated to reflect the conscious choice ('we keep preferred because X; flag is fine because Y') rather than reading as 'TODO drop someday'."*

## Decision

After grounding against the Sovereign SDK's own docs + the broader L2 ecosystem, **option A (keep preferred sequencer + carry the flag)** is the right call:

- **Big arch = SDK norm.** The Sovereign SDK's product story centers on "real-time soft confirmations" delivered specifically by the preferred sequencer. The other mode (process blobs in order) is described in the SDK overview spec as "a simple kernel implementation" — i.e., not the intended production path.
- **Single-sequencer + soft confirmations is the universal L2 norm** (OP Stack, Arbitrum, StarkNet, Rollkit-based Celestia rollups, etc.). Switching to standard sequencer would mean deviating from both the SDK *and* the ecosystem.
- **At v0 single-sequencer scale, the disabled audit is defensive.** `StateRootTask` cross-checks tentative state roots (used for soft confirmations) against post-DA-canonical roots. With a single sequencer there's no second source for tentative roots to diverge from, so the check earns its keep more at multi-sequencer / multi-organisation territory (testnet onward).
- **The flag is acknowledged debt, not a chosen deviation.** It works around a private upstream Sovereign SDK bug (`Sovereign-Labs/sovereign-sdk-wip#2814`) that breaks `StateRootTask`. The clean fix is to upstream the patch and drop the flag, tracked separately as **#337** (option C — long-arc cleanup, should land before testnet).

## Changes

- `devnet-1/celestia.toml`: long-form comment above `disable_state_root_consistency_checks = true` explaining the conscious choice, the upstream-bug reference, and the #337 follow-up.
- `devnet/celestia.toml`: short comment pointing at the devnet-1 long-form (same pattern as the `signer_private_key` / `grpc_url` comments in these files), referencing #337.

No behaviour change — purely the "why" surfacing.