### PR TITLE
docs(changelog): fold [Unreleased] into [0.1.0-devnet] - 2026-05-15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-All notable changes to Ligate Chain are tracked here. Pre-launch (devnet target Q2 2026); no semver releases yet, everything sits under `[Unreleased]`. The first tagged release will fold the Unreleased contents into a versioned section at devnet boot.
+All notable changes to Ligate Chain are tracked here. Pre-launch (devnet target Q2 2026). New work accumulates under `[Unreleased]`; tagged releases fold the contents into a versioned section. `v0.1.0-devnet` (2026-05-15) is the first such release.
 
 Format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). Entries group as **Added** (new functionality), **Changed** (behaviour or API shifts on existing functionality), **Fixed** (bugfixes), **Security** (advisories, supply-chain, fuzz), and **Deps** (transitive bumps not otherwise interesting). Issue and PR numbers reference [`ligate-io/ligate-chain`](https://github.com/ligate-io/ligate-chain).
 
 This file is human-curated. Every PR adds an entry under `## [Unreleased]`; releases bump the buckets into a new `## [version] - YYYY-MM-DD` section.
 
 ## [Unreleased]
+
+## [0.1.0-devnet] - 2026-05-15
 
 ### Changed
 


### PR DESCRIPTION
Standard release-fold for the `v0.1.0-devnet` tag pushed earlier today:

- Renames the existing `## [Unreleased]` block to `## [0.1.0-devnet] - 2026-05-15`.
- Inserts a fresh empty `## [Unreleased]` above it for future PR entries.
- Updates the file's intro paragraph (line 3) to drop "no semver releases yet" now that `v0.1.0-devnet` is tagged.

3 line diff, no content rewritten.

## Known gap — backfill opportunity

The recent PRs we shipped during the Mocha-smoke push didn't add their own `[Unreleased]` entries before merging, which means the `[0.1.0-devnet]` section is missing entries for:

- **#317** — Mocha smoke gate green end-to-end against real Celestia Mocha (the multi-commit fix stack: skip-auth, gRPC URL, `signer_private_key` shadow fix, ephemeral genesis via `ligate-genesis-tool`, `genesis_da_height` runtime pin, sync-check curl rewrite, DA-metric fail→warn).
- **#334** — nightly cron + README badge + runbook update.
- **#335** — fuzz workflow timeout bump + `cache-on-failure` + codegen-units / LTO env overrides.
- **#336** — `genesis_da_height` pin step added to the public-devnet deploy runbook.
- **#338** — `[sequencer.preferred]` TOML comments rewritten per #293 option A (closes #293).

The convention says every PR should have added an entry under `[Unreleased]` at merge time — we slipped on that during the smoke saga. The release notes on the **`v0.1.0-devnet`** GitHub Release page will therefore lack these entries (the release workflow extracted whatever `[Unreleased]` was at tag time). Optional follow-up: a separate PR that backfills those entries directly into the `[0.1.0-devnet]` section here + an edit to the GitHub Release page body. Not blocking — those PRs are all CI/docs work, not user-visible chain functionality.