### PR TITLE
rebrand: chain README lockup + mark (new three-piece glyph, Ligate Chain text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://ligate.io">
-    <img src="docs/assets/lockup.svg" alt="Ligate Labs" width="220">
+    <img src="docs/assets/lockup.svg" alt="Ligate Chain" width="220">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
   </a>
 </p>
 
-<h1 align="center">Ligate Chain</h1>
-
 <p align="center">
   <strong>The permissionless on-chain attestation protocol.</strong><br>
   A sovereign rollup on Celestia. AI provenance is the wedge use case, not the only one.

--- a/docs/assets/lockup.svg
+++ b/docs/assets/lockup.svg
@@ -1,12 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="185" height="48" viewBox="0 0 185 48" fill="none" role="img" aria-label="Ligate Labs">
-  <title>Ligate Labs</title>
-  <mask id="lm">
-    <rect width="48" height="48" fill="white"/>
-    <rect x="2.5" y="13.5" width="28" height="21" rx="10.5" fill="black"/>
-  </mask>
-  <g mask="url(#lm)">
-    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="160" viewBox="0 0 640 160" fill="none" role="img" aria-label="Ligate Chain">
+  <title>Ligate Chain</title>
+  <g transform="translate(20 24)">
+    <path d="M123.03 55.9332L115.623 68.7795L108.216 81.6154L100.819 94.4513L93.4121 107.277H34.2075L26.8004 94.4513L19.4037 81.6154H78.6187L86.0154 68.7795L93.4121 55.9332H123.03Z" stroke="#A7D28C" stroke-width="9.2" stroke-linejoin="round"/>
+    <path d="M49.0113 30.2718L41.6042 43.0973L34.2075 55.9332L26.8004 68.7795L19.4037 81.6154L11.9967 68.7795L4.59998 55.9332L11.9967 43.0973L19.4037 30.2718H49.0113Z" stroke="#A7D28C" stroke-width="9.2" stroke-linejoin="round"/>
+    <path d="M108.216 30.2718L100.819 43.0973L93.4121 55.9332H63.8046L71.2221 43.0973L78.6188 30.2718H49.0112L56.4079 17.4359L63.8046 4.60001H93.4121L100.819 17.4359L108.216 30.2718Z" stroke="#A7D28C" stroke-width="9.2" stroke-linejoin="round"/>
   </g>
-  <rect x="4" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
-  <text x="62" y="24" dominant-baseline="central" style="font-family:'Space Grotesk','Inter','Helvetica Neue',Arial,sans-serif;font-size:22px;font-weight:500;letter-spacing:-0.02em;" fill="#A7D28C">Ligate<tspan dx="4" style="font-weight:400;" fill="#A7D28C">Labs</tspan></text>
+  <text x="184" y="98" style="font-family:'Space Grotesk','Inter','Helvetica Neue',Arial,sans-serif;font-size:72px;font-weight:500;letter-spacing:-1.5px;" fill="#A7D28C">Ligate Chain</text>
 </svg>

--- a/docs/assets/mark.svg
+++ b/docs/assets/mark.svg
@@ -1,11 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none" role="img" aria-label="Ligate Labs mark">
-  <title>Ligate Labs mark</title>
-  <mask id="lm">
-    <rect width="48" height="48" fill="white"/>
-    <rect x="2.5" y="13.5" width="28" height="21" rx="10.5" fill="black"/>
-  </mask>
-  <g mask="url(#lm)">
-    <rect x="19" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
-  </g>
-  <rect x="4" y="15" width="25" height="18" rx="9" stroke="#A7D28C" stroke-width="3" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="112" viewBox="0 0 128 112" fill="none" role="img" aria-label="Ligate Chain mark">
+  <title>Ligate Chain mark</title>
+  <path d="M123.03 55.9332L115.623 68.7795L108.216 81.6154L100.819 94.4513L93.4121 107.277H34.2075L26.8004 94.4513L19.4037 81.6154H78.6187L86.0154 68.7795L93.4121 55.9332H123.03Z" stroke="#A7D28C" stroke-width="9.2" stroke-linejoin="round"/>
+  <path d="M49.0113 30.2718L41.6042 43.0973L34.2075 55.9332L26.8004 68.7795L19.4037 81.6154L11.9967 68.7795L4.59998 55.9332L11.9967 43.0973L19.4037 30.2718H49.0113Z" stroke="#A7D28C" stroke-width="9.2" stroke-linejoin="round"/>
+  <path d="M108.216 30.2718L100.819 43.0973L93.4121 55.9332H63.8046L71.2221 43.0973L78.6188 30.2718H49.0112L56.4079 17.4359L63.8046 4.60001H93.4121L100.819 17.4359L108.216 30.2718Z" stroke="#A7D28C" stroke-width="9.2" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
The chain repo's README hero embedded \`docs/assets/lockup.svg\` (old two-pill design, \"Ligate Labs\" text). PR #156 over in \`ligate-marketing\` swapped to the new three-piece chevron glyph; this catches the chain README up to match.

## Changes

- \`docs/assets/lockup.svg\`: old two-pill mark + \"Ligate Labs\" -> new three-chevron mark + **\"Ligate Chain\"** (sage \`#A7D28C\`). The chain repo is the chain product surface, so the lockup is chain-flavored rather than reusing the company \"Ligate Labs\" lockup.
- \`docs/assets/mark.svg\`: same swap (mark only, no text). Currently unreferenced in the repo but kept for parity with \`lockup.svg\` in case anything starts using it.
- \`README.md\` line 3: \`alt=\"Ligate Labs\"\` -> \`alt=\"Ligate Chain\"\`. Matches the new SVG title/aria-label.

## Why now

- v0.1.0-devnet just shipped (CHANGELOG fold merged in #339). README is the first thing a partner sees clicking through from \`ligate.io\` or a tweet; having the old glyph there now reads as a stale repo even when everything else is current.
- No code or runtime impact. Only static assets + one alt attribute.

## Test plan

- [ ] CI green (path filter routes this through Detect changes -> docs-only path)
- [ ] Render check: GitHub README preview shows the new chevron + \"Ligate Chain\" text