### PR TITLE
ci(release): only -rc. tags prerelease + drop Intel Mac from matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,14 +60,16 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-14
             archive_suffix: darwin-arm64
-          # Intel Mac. `macos-13` is the last GitHub-hosted Intel
-          # runner; `macos-14` and later are Apple Silicon only. Few
-          # operators run Intel Macs as servers, but contributors on
-          # 2018-2019 hardware still benefit from a downloadable
-          # binary instead of a from-source build. Tracking issue: #210.
-          - target: x86_64-apple-darwin
-            runner: macos-13
-            archive_suffix: darwin-amd64
+          # Intel Mac (`x86_64-apple-darwin` on `macos-13`) was
+          # removed 2026-05-15. GitHub's hosted Intel pool has 1-4h
+          # queue waits during EU/US business hours, which blocked the
+          # entire v0.1.0-devnet release since `release:` needs the
+          # full matrix. Operators run Linux servers; remaining macOS
+          # users are overwhelmingly Apple Silicon (`aarch64-apple-darwin`
+          # already shipped). Anyone on 2018-2019 Intel Mac hardware
+          # falls back to `cargo install --git`. Re-add if and when
+          # GitHub stabilises the Intel pool, or when a self-hosted
+          # runner is wired up. Original add: PR #227 (closes #210).
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -251,7 +253,10 @@ jobs:
           name: ${{ github.ref_name }}
           body_path: release-notes.md
           files: release/*
-          # Treat tags ending in `-rc.N` / `-devnet` / `-testnet` as
-          # pre-release; full mainnet uses `vX.Y.Z` plain.
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          # Treat ONLY tags containing `-rc.` as pre-release (true
+          # release candidates). `-devnet` / `-testnet` tags are
+          # "current public network" releases -- pinned, canonical for
+          # that network's lifetime -- and ship as normal releases.
+          # Full mainnet uses `vX.Y.Z` plain.
+          prerelease: ${{ contains(github.ref_name, '-rc.') }}
           fail_on_unmatched_files: true


### PR DESCRIPTION
Two release.yml hygiene fixes in one PR.

## 1) Prerelease heuristic: any hyphen -> only `-rc.`

```yaml
# before
prerelease: ${{ contains(github.ref_name, '-') }}
# after
prerelease: ${{ contains(github.ref_name, '-rc.') }}
```

`-devnet` / `-testnet` tags are pinned, canonical "current public network" releases, not unstable release candidates. They ship as normal releases.

## 2) Drop `x86_64-apple-darwin` from the build matrix

The Intel Mac runner (`macos-13`) has been queued >2h on the v0.1.0-devnet release with `runner_name=null` and `started_at=null` -- no runner has ever picked it up. GitHub's hosted Intel pool has 1-4h queue waits during EU/US business hours, which blocked the entire release because `release:` needs the full matrix.

Rationale for not waiting it out:
- Operators run Linux servers, not Macs. Apple Silicon Macs use `aarch64-apple-darwin` (already shipping).
- Intel Macs are 2018-2019 hardware; few contributors run them as Rust dev machines today.
- `cargo install --git` is the documented fallback for any platform without a binary.
- Original add was PR #227 (closes #210) -- speculative; usage data after one release attempt is "blocks every release". Reverse.

## Why now / what unblocks

Merging this PR + retagging `v0.1.0-devnet` at the new main HEAD lets the chain release workflow rerun with the 3-platform matrix and ship the actual release. Live state for v0.1.0-devnet is currently the stuck workflow run from the old release.yml (Intel Mac forever queued).

Sister PRs:
- [`ligate-cli#23`](https://github.com/ligate-io/ligate-cli/pull/23): identical change in cli
- [`ligate-js#30`](https://github.com/ligate-io/ligate-js/pull/30): prerelease + npm dist-tag fix (no Mac in matrix to drop)