### PR TITLE
chore(devnet-1): re-substitute genesis (round 2) - new operator + real Celestia DA address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+### Changed
+
+- `devnet-1/genesis/` re-substituted with the round-2 operator key. The round-1 substitution (PR #251, 2026-05-08) replaced the public-seed bootstrap placeholder with `lig1rh9vcu879l36...`, but the private key for that address was never persisted to `~/.ligate-keys/` and is unrecoverable. No public-facing system ever read the round-1 `chain_hash` (devnet never came up against it), so this round-2 substitution has zero downstream blast radius -- partners haven't seen the round-1 hash anywhere. Round 2 also substitutes the all-zeros Celestia DA placeholder (`celestia1qqqqqq...zf30as`) with the real operator-controlled Mocha wallet (`celestia1mphanjz...`), which round 1 left untouched. The operator key is now persisted in three places to prevent recurrence: `~/.ligate-keys/devnet-1/operator.key` (chmod 600), `~/.config/ligate/secrets.env` as `LIGATE_DEVNET1_OPERATOR_KEY`, and GCP Secret Manager (`projects/utopian-spring-494915-q1/secrets/ligate-devnet-1-operator-key`). Closes the broken-key issue surfaced during the GCP devnet bring-up.
+
 ## [0.1.0-devnet] - 2026-05-15
 
 ### Changed

--- a/devnet-1/genesis/attestation.json
+++ b/devnet-1/genesis/attestation.json
@@ -6,5 +6,5 @@
   "lgt_token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
   "max_builder_bps": 5000,
   "schema_registration_fee": "100000000",
-  "treasury": "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
+  "treasury": "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
 }

--- a/devnet-1/genesis/attester_incentives.json
+++ b/devnet-1/genesis/attester_incentives.json
@@ -1,7 +1,7 @@
 {
   "initial_attesters": [
     [
-      "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8",
+      "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac",
       "1000000000000"
     ]
   ],

--- a/devnet-1/genesis/bank.json
+++ b/devnet-1/genesis/bank.json
@@ -2,7 +2,7 @@
   "gas_token_config": {
     "address_and_balances": [
       [
-        "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8",
+        "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac",
         "900000000000000000"
       ],
       [
@@ -15,7 +15,7 @@
       ]
     ],
     "admins": [
-      "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
+      "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
     ],
     "token_decimals": 9,
     "token_name": "LGT"

--- a/devnet-1/genesis/operator_incentives.json
+++ b/devnet-1/genesis/operator_incentives.json
@@ -1,3 +1,3 @@
 {
-  "reward_address": "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
+  "reward_address": "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
 }

--- a/devnet-1/genesis/prover_incentives.json
+++ b/devnet-1/genesis/prover_incentives.json
@@ -1,7 +1,7 @@
 {
   "initial_provers": [
     [
-      "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8",
+      "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac",
       "1000000000000"
     ]
   ],

--- a/devnet-1/genesis/sequencer_registry.json
+++ b/devnet-1/genesis/sequencer_registry.json
@@ -3,7 +3,7 @@
   "sequencer_config": {
     "is_preferred_sequencer": true,
     "seq_bond": "5000000000000",
-    "seq_da_address": "celestia1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzf30as",
-    "seq_rollup_address": "lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8"
+    "seq_da_address": "celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33",
+    "seq_rollup_address": "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
   }
 }


### PR DESCRIPTION
Round-2 genesis substitution. Round 1 (PR #251, 2026-05-08) is superseded.

## Why

The round-1 substitution replaced the public-seed bootstrap placeholder with `lig1rh9vcu879l36...`, but the private key for that address was never persisted to `~/.ligate-keys/` and is unrecoverable. Combined with the never-substituted all-zeros Celestia DA placeholder, the current `devnet-1/genesis/` couldn't actually be used to bring up the chain — treasury / sequencer registry / reward all pointed at an unsignable address.

No public-facing system ever read the round-1 `chain_hash` (devnet never came up against it), so this round-2 substitution has zero downstream blast radius. Partners haven't seen the round-1 hash anywhere.

## Substitutions in this PR

| Field | Round 1 (before) | Round 2 (after) |
|-|-|-|
| bootstrap (treasury, sequencer registry, attester / prover bond, reward) | `lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8` (key lost) | `lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac` (key persisted) |
| Celestia DA address | `celestia1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzf30as` (all-zeros placeholder) | `celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33` (operator-controlled, 11 TIA balance) |

Demo wallets unchanged (`lig19tzz...` and `lig1e0lp...` keys are intact in `~/.ligate-keys/devnet-1/demo{1,2}.key`).

## Key custody — never losing this again

Round-2 operator key is persisted in THREE places:
- `~/.ligate-keys/devnet-1/operator.key` (chmod 600)
- `~/.config/ligate/secrets.env` as `LIGATE_DEVNET1_OPERATOR_KEY=...`
- GCP Secret Manager: `projects/utopian-spring-494915-q1/secrets/ligate-devnet-1-operator-key`

Same triple-storage applied to faucet, attestor, and Celestia signer keys.

## Validation

```
$ cargo test --release -p ligate-rollup --test devnet_config

running 6 tests
test devnet_1_does_not_ship_a_rollup_toml ... ok
test devnet_1_celestia_toml_parses_against_celestia_blueprint_types ... ok
test celestia_toml_parses_against_celestia_blueprint_types ... ok
test rollup_toml_parses_against_mock_blueprint_types ... ok
test devnet_1_genesis_jsons_load_and_pass_cross_module_validation ... ok
test genesis_jsons_load_and_pass_cross_module_validation ... ok

test result: ok. 6 passed
```

`ligate-genesis-tool verify` confirms the bundle parses with DA=Celestia and the cross-module validator passes.

## After merge

Unblocks GCP devnet bring-up. The chain VM will be provisioned next, configured with the round-2 genesis bundle, and the chain_hash minted from this commit will be the canonical `ligate-devnet-1` hash that partners record.

## Test plan

- [x] `cargo test -p ligate-rollup --test devnet_config` — green locally
- [x] `ligate-genesis-tool verify --dir devnet-1/genesis/` — passes (DA=Celestia)
- [ ] CI green on this PR
- [ ] After merge, GCP deploy uses this commit's genesis