### PR TITLE
feat(attestation): surface digest+submitter on sig-verify error + LIP-5 wire-format appendix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "attestation",
  "borsh",
  "ed25519-dalek",
+ "hex",
  "prometheus",
  "proptest",
  "schemars 0.8.22",

--- a/crates/modules/attestation/Cargo.toml
+++ b/crates/modules/attestation/Cargo.toml
@@ -14,6 +14,12 @@ rust-version.workspace = true
 anyhow.workspace = true
 borsh.workspace = true
 ed25519-dalek.workspace = true
+# hex-encoding for the `expected_digest` field on
+# `AttestationError::InvalidSignature`, so attestors whose off-chain
+# digest differs from the chain's can read the chain's value out of
+# the error response directly. Matches `bootstrap-cli` / `genesis-tool`
+# pin (workspace doesn't share a `hex` entry).
+hex = "0.4"
 schemars.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -1048,8 +1048,38 @@ pub enum AttestationError {
     },
 
     /// A signature did not verify against the canonical attestation digest.
-    #[error("signature did not verify against attestation digest")]
-    InvalidSignature,
+    ///
+    /// The carried fields surface the exact inputs the chain used to
+    /// re-derive the digest, so an attestor whose off-chain signer
+    /// produced something else can spot the mismatch without having to
+    /// reverse-engineer the protocol's wire format. The most common
+    /// cause of this error is omitting the `MultiAddress::Standard`
+    /// discriminator byte (`0x00`) between `payload_hash` and
+    /// `submitter` when borsh-encoding the `SignedAttestationPayload`
+    /// off-chain; see LIP-5 §wire-format for the byte-by-byte layout.
+    #[error(
+        "signature did not verify for pubkey {pubkey}: chain computed digest \
+         0x{expected_digest} from (submitter={submitter}, timestamp={timestamp}). \
+         If your off-chain digest differs, check the MultiAddress::Standard \
+         discriminator byte (0x00) before the submitter address. See LIP-5 \
+         wire-format appendix."
+    )]
+    InvalidSignature {
+        /// Pubkey whose signature failed to verify, in bech32m `lpk1...`.
+        pubkey: PubKey,
+        /// Lowercase hex of the digest the chain computed and tried
+        /// to verify the signature against (no `0x` prefix in the
+        /// stored field; the Display impl above prepends one).
+        expected_digest: String,
+        /// Bech32m `lig1...` of the tx submitter the chain used as
+        /// part of the digest. Equals `context.sender()` in the chain
+        /// at submission time.
+        submitter: String,
+        /// Block timestamp the chain used in the digest. Pinned to 0
+        /// in v0 because the runtime doesn't yet expose block headers
+        /// to module handlers.
+        timestamp: u64,
+    },
 
     /// Fewer valid signatures than the schema's attestor set requires.
     #[error("quorum not met: {provided} valid signatures, need {required}")]
@@ -1106,7 +1136,7 @@ impl AttestationError {
             Self::UnknownAttestorPubkey => "unknown_attestor_pubkey",
             Self::InvalidAttestorPubkey => "invalid_attestor_pubkey",
             Self::BadSignatureLength { .. } => "bad_signature_length",
-            Self::InvalidSignature => "invalid_signature",
+            Self::InvalidSignature { .. } => "invalid_signature",
             Self::BelowThreshold { .. } => "below_threshold",
             Self::MissingAttestorSet => "missing_attestor_set",
             Self::ChainNotConfigured => "chain_not_configured",
@@ -1563,7 +1593,7 @@ impl<S: Spec> AttestationModule<S> {
             SignedAttestationPayload::<S> { schema_id, payload_hash, submitter, timestamp }
                 .digest();
 
-        validate_signatures(&signatures, &attestor_set, &digest)?;
+        validate_signatures::<S>(&signatures, &attestor_set, &digest, &submitter, timestamp)?;
 
         // Charge the attestation fee BEFORE writing the attestation.
         // Split per `schema.fee_routing_bps`: builder share goes to
@@ -1719,10 +1749,12 @@ fn split_attestation_fee(total: Amount, bps: u16) -> (Amount, Amount) {
 /// Ed25519 is the only scheme accepted in v0. BLS aggregates or other
 /// schemes would be added as separate variants later; `AttestorSignature.sig`
 /// is `Vec<u8>` today precisely to leave room for that.
-fn validate_signatures(
+fn validate_signatures<S: Spec>(
     signatures: &[AttestorSignature],
     set: &AttestorSet,
     digest: &Hash32,
+    submitter: &S::Address,
+    timestamp: u64,
 ) -> anyhow::Result<()> {
     use std::collections::HashSet;
 
@@ -1750,7 +1782,17 @@ fn validate_signatures(
         let signature = Signature::from_bytes(&sig_bytes);
 
         if verifying_key.verify(digest, &signature).is_err() {
-            return Err(AttestationError::InvalidSignature.into());
+            // Surface the exact inputs the chain used so an attestor
+            // whose off-chain digest computation disagrees can spot
+            // the mismatch directly. See `AttestationError::InvalidSignature`
+            // for the rationale.
+            return Err(AttestationError::InvalidSignature {
+                pubkey: attested.pubkey,
+                expected_digest: hex::encode(digest),
+                submitter: submitter.to_string(),
+                timestamp,
+            }
+            .into());
         }
 
         valid = valid.saturating_add(1);

--- a/crates/modules/attestation/src/metrics.rs
+++ b/crates/modules/attestation/src/metrics.rs
@@ -21,6 +21,31 @@
 //! in `lib.rs` so the in-zkVM guest build doesn't pull `prometheus`
 //! for no reason. The host build always enables `native`, so
 //! `record_*` is always live there.
+//!
+//! # These counters are **per-process**, not chain state
+//!
+//! Every `record_*` call increments the in-process counter once.
+//! That includes calls made during state replay at node startup
+//! (Sovereign rollups rebuild in-memory state by re-running the
+//! STF over historical slots from DA on every boot). One on-chain
+//! registration can therefore appear as N >= 1 increments after
+//! N - 1 node restarts.
+//!
+//! Operator dashboards that want to answer "how many things are
+//! actually registered right now" should query the indexer's
+//! state-derived aggregates, not these counters:
+//!
+//! - `GET /v1/stats/totals` on `ligate-api`
+//! - `GET /v1/schemas`, `/v1/attestor-sets/{id}` (per-entity)
+//! - chain REST: `/v1/modules/attestation/state/schemas/` (direct)
+//!
+//! These counters remain useful for *event-rate* questions
+//! ("registrations per hour during devnet-1 week 1"), where the
+//! per-replay double-counting is bounded and dashboards typically
+//! apply `rate()` or `increase()` over a window. They are NOT
+//! useful as absolute "current registered count" gauges. See
+//! `ligate-io/ligate-api#TBD` for the operator-dashboard panels
+//! that moved from these counters to the api aggregates.
 
 use std::sync::OnceLock;
 

--- a/crates/modules/attestation/tests/unit.rs
+++ b/crates/modules/attestation/tests/unit.rs
@@ -406,7 +406,12 @@ fn discriminant_labels_are_stable_and_unique() {
         AttestationError::UnknownAttestorPubkey,
         AttestationError::InvalidAttestorPubkey,
         AttestationError::BadSignatureLength { actual: 0 },
-        AttestationError::InvalidSignature,
+        AttestationError::InvalidSignature {
+            pubkey: PubKey::from([0u8; 32]),
+            expected_digest: String::new(),
+            submitter: String::new(),
+            timestamp: 0,
+        },
         AttestationError::BelowThreshold { provided: 0, required: 0 },
         AttestationError::MissingAttestorSet,
         AttestationError::ChainNotConfigured,

--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -195,18 +195,73 @@ The state transitions MUST enforce:
 
 ## Signed payload for attestations
 
-Attestors sign the canonical Borsh encoding of:
+Attestors sign `SHA-256(borsh(SignedAttestationPayload))` where:
 
-```
-SignedPayload {
-    schema_id:    [u8; 32],
-    payload_hash: [u8; 32],
-    submitter:    [u8; 32],
+```rust
+struct SignedAttestationPayload<S: Spec> {
+    schema_id:    SchemaId,    // [u8; 32]
+    payload_hash: PayloadHash, // [u8; 32]
+    submitter:    S::Address,  // MultiAddress<VmAddress>, enum
     timestamp:    u64,
 }
 ```
 
-Signatures do NOT cover the `signatures` field itself (that would be circular). Replay is prevented by the `(schema_id, payload_hash)` write-once invariant, the same pair can't be submitted twice, so the same signature can't be replayed.
+The signature is verified by the chain in `handle_submit_attestation`; if your off-chain digest doesn't match the chain's, the chain now surfaces the exact inputs it used (see `AttestationError::InvalidSignature`).
+
+### Wire format (read this if you're rolling your own signer)
+
+The Borsh encoding is the bytes that get SHA-256'd. **Total: 101 bytes** (NOT 100, see discriminator below):
+
+| Offset | Length | Field           | Notes |
+|--------|--------|-----------------|-------|
+| 0      | 32     | `schema_id`     | Raw 32 bytes (Borsh of `[u8; 32]` is the raw array, no length prefix). |
+| 32     | 32     | `payload_hash`  | Raw 32 bytes. |
+| 64     | 1      | submitter tag   | `0x00` for `MultiAddress::Standard`. **Easy to miss.** |
+| 65     | 28     | submitter addr  | The 28-byte `Address` payload inside `Standard`. |
+| 93     | 8      | `timestamp`     | u64 little-endian. Pinned to `0x0000000000000000` in v0 (chain hardcodes `timestamp = 0` until the runtime exposes block headers; tracked in [ligate-chain#TBD]). |
+
+The submitter byte is the most common stumble. `S::Address` resolves through `MockRollupSpec` to `MultiAddress<VmAddress>`, a two-variant enum (`Standard(Address)`, `Vm(VmAddress)`). Borsh prepends a 1-byte discriminator before the variant payload. For chain-native `lig1...` addresses you always want the `0x00` `Standard` variant.
+
+### Test vector
+
+Inputs (the exact values are also baked into the `attestation_digest` rustdoc as a doctest, so this stays in sync with the impl):
+
+| Field          | Value |
+|----------------|-------|
+| `schema_id`    | `lsc1zg3qygc(...)`, raw bytes `0x1c24...9486` |
+| `payload_hash` | `lph1he42sgwn(...)`, raw bytes `0xbe6a...13ac` |
+| `submitter`    | `lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac`, raw bytes `0x134b...441d` |
+| `timestamp`    | `0` |
+
+Borsh bytes (101 bytes, hex):
+
+```
+1c24a84b8307ff2a9e859218d76476932555b5214f8c1c555224b620f8b19486
+be6aa821d3f6c3405edcb7cddbcf419e00119e321c6fb46452281dafd55913ac
+00
+134b250b46a508d9b0bb3a5e16ba2c82a47e3dd483419ea6be3b441d
+0000000000000000
+```
+
+Expected digest (SHA-256 of the above):
+
+```
+b26c0c1698c07e97f3f426ccbdc61ae16dee6f13b780d59c612c7c2b6ba3a079
+```
+
+If you compute the digest in your off-chain signer and get something different, the most likely cause is the missing `0x00` byte before the submitter address. The next most likely is the timestamp not being 8 little-endian bytes (Borsh `u64` is always 8 LE).
+
+### Helpers
+
+Don't roll your own if you can avoid it. Use:
+
+- **Rust:** `ligate_client::attestation_digest::<S>(schema_id, payload_hash, submitter, timestamp)` + `ligate_client::sign_attestation(signing_key, &digest)`.
+- **CLI:** `ligate sign-attestation --schema <lsc1> --payload-hash <lph1> --submitter <lig1> --signer <role>` produces a ready-to-submit signature entry.
+- **TypeScript:** `@ligate/js`'s `signAttestation(...)` (same byte layout, verified against the Rust path via the cross-impl test in `packages/js/test/attestation-vector.test.ts`).
+
+### Replay
+
+Signatures don't cover the `signatures` field of `Attestation` (that would be circular). Replay is prevented by the `(schema_id, payload_hash)` write-once invariant: the same pair can't be submitted twice, so the same signature can't be replayed.
 
 ---
 


### PR DESCRIPTION
## Summary

Two related fixes to make attestation signing debuggable for anyone rolling their own off-chain signer (Mneme, third-party attestor services, scripted test rigs):

1. **\`AttestationError::InvalidSignature\` now carries data** — pubkey, expected_digest (hex), submitter, timestamp. Today the error is the literal string \`"signature did not verify against attestation digest"\` with zero context, so an attestor whose off-chain digest doesn't match the chain's has nothing to compare against. With this PR, the chain's error response includes the exact bytes it tried to verify against, plus a hint at the most common cause (\`MultiAddress::Standard\` discriminator omission).
2. **\`docs/protocol/attestation-v0.md\` wire-format appendix** — the existing "Signed payload for attestations" section listed \`submitter: [u8; 32]\` which is wrong (it's actually \`MultiAddress<VmAddress>\`, a tagged enum, so the borsh layout is 1+28 not 32). Replaced with a byte-by-byte offset table showing the 101-byte layout, the discriminator byte at offset 64, and a canonical test vector with expected digest. Cross-referenced by the new \`ligate sign-attestation\` cli subcommand and the new \`@ligate-labs/sdk\` \`attestationDigest\` helper.

This is the second-most-common stumble surfaced by the ligate-devnet-1 smoke test (the first was the SDK fork nonce-path bug; tracked separately in ligate-io/sovereign-sdk#2). My own off-chain signer in Python computed a 100-byte borsh sequence instead of 101, signature failed to verify, the chain's error said nothing useful, took ~20 min to bisect against a Rust example that called \`borsh::to_vec\` on the real type. Saving the next attestor that time.

## Changes

| File | Change |
|---|---|
| \`crates/modules/attestation/src/lib.rs\` | \`InvalidSignature\` -> \`InvalidSignature { pubkey, expected_digest, submitter, timestamp }\`. \`validate_signatures\` now takes \`submitter\` + \`timestamp\` to plumb them into the error. Snake_case label match arm updated. |
| \`crates/modules/attestation/Cargo.toml\` | Add \`hex = "0.4"\` dep for the \`expected_digest\` field. Matches \`bootstrap-cli\` / \`genesis-tool\` pin (workspace doesn't share a \`hex\` entry). |
| \`crates/modules/attestation/tests/unit.rs\` | Update the AttestationError-variants-tripwire to construct the new variant shape. |
| \`docs/protocol/attestation-v0.md\` | Rewrite "Signed payload for attestations" section: byte-offset table, MultiAddress discriminator explanation, canonical test vector with expected digest, links to Rust + cli + TS helpers. |

## Test plan

- [x] \`cargo check -p attestation\` passes locally
- [ ] \`cargo test -p attestation --lib --tests\` passes (verified once the local libclang/librocksdb-sys env issue is resolved; CI is Linux)
- [ ] CI on this PR
- [ ] After merge: submit a deliberately-broken attestation (e.g. sign with wrong submitter) against ligate-devnet-1; verify error includes \`expected_digest\` + \`submitter\` fields in the JSON response
- [ ] Cross-impl check: \`@ligate-labs/sdk\`'s \`attestationDigest\` test vector matches the doc's test vector matches the Rust impl (ligate-io/ligate-js#TBD adds the matching test)

## Followups (separate PRs / repos)

- ligate-io/sovereign-sdk#2 — SDK fork nonce-path fix. After it lands, bump the fork rev in this repo's \`[patch."https://github.com/Sovereign-Labs/sovereign-sdk.git"]\` table; downstream cli + api workarounds become deletable.
- ligate-io/ligate-cli#28 — \`ligate sign-attestation\` subcommand + \`keys show --pubkey\` flag (the attestor side).
- ligate-io/ligate-js#TBD — \`attestationDigest\` + \`signAttestation\` + \`pubkeyBech32FromPrivateKey\` helpers.