### PR TITLE
chore: add .pre-commit-config.yaml (cargo fmt) to catch formatting drift locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# pre-commit-config.yaml for `ligate-chain`.
+#
+# Runs every-commit gates that CI later re-runs. Goal: catch the
+# common low-effort failures (mainly `cargo fmt` drift, since rustfmt
+# is strict and humans rarely produce its exact whitespace by hand)
+# before the commit leaves the developer machine, instead of after a
+# CI roundtrip.
+#
+# One-time setup, done once per clone:
+#
+#   brew install pre-commit          # or: pip install pre-commit
+#   pre-commit install               # writes .git/hooks/pre-commit
+#
+# After that, every `git commit` runs the hooks below. Bypass with
+# `--no-verify` in emergencies but the same checks then re-fire in CI.
+
+repos:
+  - repo: local
+    hooks:
+      # `cargo fmt --check` — same gate CI uses. Fast (~1s per file).
+      # Doesn't auto-format; failure tells the developer to run
+      # `cargo fmt --all` then re-commit.
+      - id: cargo-fmt
+        name: cargo fmt --all -- --check
+        description: Verify Rust formatting matches rustfmt.toml.
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      # `cargo check`, `clippy`, `cargo deny`, `cargo audit`, and the
+      # DA-isolation + risc0 build-script harness are intentionally
+      # OUT of the pre-commit gate — they pull the full workspace
+      # through the SDK fork patch table and/or download advisory
+      # databases. Way too slow for every commit. CI runs them
+      # server-side where the caching is durable.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ cargo audit
 
 Ignored advisories and their rationales are documented in [`audit.toml`](audit.toml). All current ignores are transitive dependencies pinned by the Sovereign SDK; they clear automatically on SDK upgrades.
 
+### Pre-commit hooks
+
+`.pre-commit-config.yaml` runs `cargo fmt --check` on every commit so formatting drift is caught locally instead of in CI. One-time setup per clone:
+
+```bash
+brew install pre-commit         # or: pip install pre-commit
+pre-commit install              # writes .git/hooks/pre-commit
+```
+
+Skip the hook for an emergency commit with `git commit --no-verify`; the same check still re-runs in CI.
+
 ## Protocol at a glance
 
 The v0 protocol has three entities. Full detail in [the spec](docs/protocol/attestation-v0.md).


### PR DESCRIPTION
## Summary

Adds a [pre-commit](https://pre-commit.com) config that runs \`cargo fmt --all -- --check\` on every \`git commit\`. Catches formatting drift before it leaves the developer machine instead of after a CI roundtrip + a fix-up commit.

## Setup (one-time per clone)

\`\`\`bash
brew install pre-commit         # or: pip install pre-commit
pre-commit install              # writes .git/hooks/pre-commit
\`\`\`

After that, every \`git commit\` runs the hook. Bypass for emergencies with \`--no-verify\`; the same check still runs in CI.

## What's not in the hook

\`cargo check\`, \`clippy\`, \`cargo deny\`, \`cargo audit\`, DA-isolation, the risc0 build-script harness — all intentionally excluded. They pull the full workspace through the SDK patch table and/or download advisory databases; way too slow for every commit. CI runs them server-side where caching is durable.

## Companion PRs

- ligate-io/ligate-cli#30 — same pattern for cli
- ligate-io/ligate-api#38 — same pattern for api
- ligate-io/ligate-js (prettier instead of cargo fmt; coming next)