### PR TITLE
ops: TimeoutStopSec=300 + Alloy node_exporter + Host VM dashboard row

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -126,6 +126,7 @@ write_files:
 
       [Service]
       User=ligate
+      Group=ligate
       WorkingDirectory=/opt/ligate
       EnvironmentFile=/etc/ligate/env
       ExecStart=/opt/ligate/bin/ligate-node \
@@ -135,6 +136,11 @@ write_files:
           --metrics-bind 127.0.0.1:9100
       Restart=on-failure
       RestartSec=10
+      # RocksDB compaction + WAL flush on shutdown can take 2-3 min on a
+      # hot state DB. The systemd default of 90s triggered a SIGKILL
+      # during the v0.1.1-devnet swap on 2026-05-15 (chain#362). 300s
+      # gives headroom without leaving zombie processes around forever.
+      TimeoutStopSec=300
       LimitNOFILE=65536
 
       [Install]

--- a/monitoring/grafana/README.md
+++ b/monitoring/grafana/README.md
@@ -19,10 +19,9 @@ What's currently scraped and queryable in `grafanacloud-ligate-prom`:
 - `process_*` — 7 process metrics from the `ligate-node` binary (cpu_seconds_total, resident_memory_bytes, open_fds, max_fds, threads, virtual_memory_bytes, start_time_seconds)
 - `rockbound_*` + `schemadb_*` — RocksDB hot-path latency / bytes histograms
 - `storage_*` — storage layer counters
+- `node_*` — 265 host-level series from Alloy's in-process `prometheus.exporter.unix` (CPU, memory, filesystem, network, disk I/O, load average, systemd unit state, boot time). Added 2026-05-16 per chain#363.
 
-8 rows: live status, throughput, block production over time, DA finality (single-pane + percentile time series), RPC latency + load, ligate-node process, RocksDB hot path, telemetry health.
-
-**Not on this dashboard yet:** host-level VM metrics (`node_*`). Alloy on `ligate-devnet-1-sequencer` doesn't have `prometheus.exporter.unix` configured. Tracked in [ligate-chain#363](https://github.com/ligate-io/ligate-chain/issues/363). When that lands, panels for host CPU / memory / disk / network either fold into this dashboard or move to a third `ligate-vm.json`.
+9 rows: live status, throughput, block production over time, DA finality (single-pane + percentile time series), RPC latency + load, ligate-node process, RocksDB hot path, telemetry health, host VM (CPU / RAM / state disk fill / load + network and disk-I/O time series).
 
 ## Investor dashboard (Infinity)
 
@@ -66,10 +65,13 @@ Commit so the repo stays the source of truth.
 
 ## Alloy config reference (the scraper)
 
-Lives on `ligate-devnet-1-sequencer` at `/etc/alloy/config.alloy`. Two
+Lives on `ligate-devnet-1-sequencer` at `/etc/alloy/config.alloy`. Five
 blocks today:
 
+- `local.file "gc_token"` — reads the Grafana Cloud API token from `/etc/alloy/grafana_cloud_token` (chmod 600) at agent start so it never appears in process listings
 - `prometheus.scrape "ligate_node"` — scrapes `127.0.0.1:9100` every 15s, forwards to `grafana_cloud`
-- `prometheus.remote_write "grafana_cloud"` — pushes to `https://prometheus-prod-66-prod-us-east-3.grafana.net/api/prom/push` with the token at `/etc/alloy/grafana_cloud_token`
+- `prometheus.exporter.unix "node"` — in-process node_exporter, default collector set minus the GCE-irrelevant ones (`ipvs`, `btrfs`, `infiniband`, `tapestats`, `zfs`). Added 2026-05-16 per chain#363
+- `prometheus.scrape "node"` — scrapes the in-process exporter targets above every 15s, same forward path
+- `prometheus.remote_write "grafana_cloud"` — pushes to `https://prometheus-prod-66-prod-us-east-3.grafana.net/api/prom/push` with the token, 12h local WAL buffer
 
-When VM-level metrics land (#363), add a `prometheus.exporter.unix` + matching `prometheus.scrape "node"` block. No agent reinstall needed — `sudo systemctl reload alloy` picks up config changes.
+`sudo systemctl reload alloy` picks up config changes; no agent reinstall needed.

--- a/monitoring/grafana/ligate-operator.json
+++ b/monitoring/grafana/ligate-operator.json
@@ -1720,6 +1720,397 @@
       ],
       "title": "Metrics dropped (total)",
       "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 900,
+      "panels": [],
+      "title": "Host VM",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "100% - idle CPU, averaged across all cores over 5m.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 68
+      },
+      "id": 901,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "100 - (avg(rate(node_cpu_seconds_total{job=\"integrations/unix\",mode=\"idle\"}[5m])) * 100)",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "Memory pressure. Uses MemAvailable (includes reclaimable cache) not MemFree.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 68
+      },
+      "id": 902,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "(1 - (node_memory_MemAvailable_bytes{job=\"integrations/unix\"} / node_memory_MemTotal_bytes{job=\"integrations/unix\"})) * 100",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory used",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "Fill % of the 52GB chain state disk (mounted at /var/lib/ligate). Watch for 80%+ \u2014 RocksDB compaction needs headroom.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 68
+      },
+      "id": 903,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "(1 - (node_filesystem_avail_bytes{job=\"integrations/unix\",mountpoint=\"/var/lib/ligate\"} / node_filesystem_size_bytes{job=\"integrations/unix\",mountpoint=\"/var/lib/ligate\"})) * 100",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "State disk used (/var/lib/ligate)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "System load average over the past 1 minute. Watch for sustained > num_cores.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 68
+      },
+      "id": 904,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "node_load1{job=\"integrations/unix\"}",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Load avg (1m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "Sustained network rx/tx on the primary interface. CF + Caddy + RPC traffic flow here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 72
+      },
+      "id": 905,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "rate(node_network_receive_bytes_total{job=\"integrations/unix\",device=\"ens4\"}[5m])",
+          "instant": false,
+          "legendFormat": "rx",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "rate(node_network_transmit_bytes_total{job=\"integrations/unix\",device=\"ens4\"}[5m])",
+          "instant": false,
+          "legendFormat": "tx",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Network throughput (ens4)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "Sustained disk r/w on /dev/sdb (the chain state disk holding RocksDB).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 72
+      },
+      "id": 906,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "rate(node_disk_read_bytes_total{job=\"integrations/unix\",device=\"sdb\"}[5m])",
+          "instant": false,
+          "legendFormat": "read",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "rate(node_disk_written_bytes_total{job=\"integrations/unix\",device=\"sdb\"}[5m])",
+          "instant": false,
+          "legendFormat": "write",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Disk I/O (sdb = state disk)",
+      "type": "timeseries"
     }
   ],
   "refresh": "15s",
@@ -1740,5 +2131,5 @@
   "timezone": "browser",
   "title": "Ligate Devnet \u2014 Operator view",
   "uid": "ligate-operator",
-  "version": 1
+  "version": 3
 }


### PR DESCRIPTION
Closes #362
Closes #363

## What changed

Three things, all already applied to the live `ligate-devnet-1-sequencer` VM (this PR commits the corresponding doc / config drift to the repo).

### 1. systemd `TimeoutStopSec=300` (closes #362)

Default of 90s killed RocksDB mid-flush during the v0.1.1-devnet swap on 2026-05-15 (chain recovered via WAL on next boot, no data loss, but a clean shutdown is preferable). Bumped to 5 min — generous headroom for compaction + WAL flush, still finite so a stuck process can't linger forever.

- Live VM: applied + `daemon-reload` verified (`TimeoutStopUSec=5min`)
- Repo: `docs/development/public-devnet-deploy.md` cloud-init systemd unit now matches. Also adds `Group=ligate` (was on live unit, missing from doc).

### 2. Alloy `prometheus.exporter.unix` + scrape (closes #363 part 1)

`/etc/alloy/config.alloy` gains an in-process node_exporter and a 15s scrape, forwarded to the same `grafana_cloud` remote_write. Collector set is Alloy defaults minus GCE-irrelevant ones (`ipvs`, `btrfs`, `infiniband`, `tapestats`, `zfs`).

Result: **265 new `node_*` metric families** flowing into `grafanacloud-ligate-prom` under `job="integrations/unix"`. Verified `node_cpu_seconds_total`, `node_load1`, `node_filesystem_*`, `node_network_*`, `node_disk_*` all populated.

Live config reloaded via `sudo systemctl reload alloy`. No restart needed.

### 3. Host VM dashboard row (closes #363 part 2)

New row 900 at the bottom of `ligate-operator.json` (Grafana version 3). Six panels:

| Panel | Type | Query | Live now |
|---|---|---|---|
| CPU usage | stat | `100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)` | 9.4% |
| Memory used | stat | `(1 - MemAvailable/MemTotal) * 100` | 23.1% |
| State disk used (/var/lib/ligate) | stat | `(1 - avail/size) * 100` on `mountpoint="/var/lib/ligate"` | 5.1% |
| Load avg (1m) | stat | `node_load1` | 0.05 |
| Network throughput (ens4) | timeseries | `rate(node_network_{receive,transmit}_bytes_total[5m])` | rx/tx |
| Disk I/O (sdb = state disk) | timeseries | `rate(node_disk_{read,written}_bytes_total[5m])` | r/w |

Dashboard is already PUT to Grafana (version 3, https://ligate.grafana.net/d/ligate-operator). Repo file is the canonical sorted export pulled back after the PUT.

## Test plan

- [ ] Operator dashboard renders the new Host VM row at the bottom with non-empty values for CPU/RAM/disk/load/network/disk-I/O
- [ ] `systemctl show ligate-node.service -p TimeoutStopUSec` returns `5min` on the VM
- [ ] `node_load1{job="integrations/unix"}` returns a value via Explore in Grafana