### PR TITLE
ops: migrate chain state to /var/lib/ligate/rocksdb via symlink (devnet-1 sequencer applied)

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -36,14 +36,16 @@ Tracking issue: [#189](https://github.com/ligate-io/ligate-chain/issues/189). Si
 
 ## VM sizing
 
-| Role | GCP shape | vCPU | RAM | Disk | $/mo (sustained-use) |
-|---|---|---|---|---|---|
-| Sequencer | `e2-medium` | 2 | 4 GB | 50 GB SSD | ~25 USD |
-| Follower | `e2-medium` | 2 | 4 GB | 50 GB SSD | ~25 USD |
+| Role | GCP shape | vCPU | RAM | Boot disk | Data disk | $/mo (sustained-use) |
+|---|---|---|---|---|---|---|
+| Sequencer | `e2-standard-4` | 4 | 16 GB | 20 GB SSD | 150 GB SSD | ~135 USD |
+| Follower | `e2-medium` | 2 | 4 GB | 20 GB SSD | 100 GB SSD | ~30 USD |
 
-Sequencer sizing covers `ligate-node` + co-located Celestia light node only. Faucet and indexer **do not run on this VM** — they live in [`ligate-io/ligate-api`](https://github.com/ligate-io/ligate-api), deployed to Railway alongside a Railway-managed Postgres. The Next.js explorer at `explorer.ligate.io` is yet another deploy on Vercel, talking to `api.ligate.io`. Follower sizing matches sequencer (no auxiliary services to host either way).
+Sequencer sizing covers `ligate-node` + co-located Celestia light node + the local backup snapshot stage (`/var/lib/ligate/snapshots/`, which keeps last 24 hourly + 7 daily + 4 weekly per `backup-rocksdb.sh` rotation). RocksDB NOMT files are sparse but rsync inflates them on copy, so each local snapshot is currently ~5GB; steady-state worst case for local snapshots is ~120GB (tracked under #359 followups; `--sparse` flag in the backup script would cut this ~4x).
 
-Both roles can drop to half their disk if you don't need history retention longer than a month; the chain's NOMT prunes aggressively. Conservative numbers above so you don't fight low-disk alerts in the first 90 days.
+Faucet and indexer **do not run on this VM** — they live in [`ligate-io/ligate-api`](https://github.com/ligate-io/ligate-api), deployed to Railway alongside a Railway-managed Postgres. The Next.js explorer at `explorer.ligate.io` is yet another deploy on Vercel, talking to `api.ligate.io`. Follower sizing is smaller because followers don't keep the local backup stage (they restore from GCS or replay from DA if state is lost).
+
+Persistent data disk can be **live-resized without downtime** via `gcloud compute disks resize` + `resize2fs /dev/sdb`; ext4 supports online growth. Done on `ligate-devnet-1-sequencer` on 2026-05-16 (50GB → 150GB) when local snapshot accumulation projected to fill the original 50GB within ~24h.
 
 ## Step 1: Provision the VM
 
@@ -60,7 +62,7 @@ gcloud compute instances create ligate-devnet-1-sequencer \
     --metadata-from-file=user-data=cloud-init.yaml
 ```
 
-For a follower, swap `--machine-type=e2-medium`, `--create-disk=...,size=50GB`, and rename the instance.
+For a follower, swap `--machine-type=e2-medium`, `--create-disk=...,size=100GB`, and rename the instance.
 
 Reserve a static external IP and bind it:
 

--- a/docs/development/runbooks/backup-restore.md
+++ b/docs/development/runbooks/backup-restore.md
@@ -299,6 +299,27 @@ sudo rm -rf /opt/ligate/devnet-1/data-celestia.MIGRATION-BACKUP-*
 
 ---
 
+## Resizing the persistent disk (online, no downtime)
+
+GCE persistent disks grow live, and ext4 resizes online — no chain stop needed.
+
+```sh
+# 1. Grow the GCE disk.
+gcloud compute disks resize ligate-data-v2 --zone us-central1-a --size 150GB
+
+# 2. Inside the VM, grow the ext4 filesystem to fill the new size.
+gcloud compute ssh ligate-devnet-1-sequencer --zone us-central1-a --command '
+  sudo resize2fs /dev/sdb
+  df -h /var/lib/ligate
+'
+```
+
+Done on `ligate-devnet-1-sequencer` 2026-05-16 (50GB → 150GB) when projected local snapshot accumulation (24 hourly × ~5GB) was on track to fill the original disk within ~24h. With the `--sparse` rsync fix (see followups) each snapshot drops from ~5GB to ~1.2GB and the 50GB disk would have been fine; 150GB is comfortable headroom either way.
+
+You can't shrink a GCE persistent disk, so size up cautiously. ext4 supports shrinking but only offline; not a path we'd take on this host.
+
+---
+
 ## Out of scope
 
 - **Multi-region replication.** A second GCS bucket in `us-east1` would survive a regional outage. Deferred to mainnet.

--- a/docs/development/runbooks/backup-restore.md
+++ b/docs/development/runbooks/backup-restore.md
@@ -2,7 +2,7 @@
 
 **Status:** v0 — covers the GCS-backed rsync flow that ships in `scripts/` + `ops/backup/systemd/`. Companion to the broader operational layer ([`celestia-light-node.md`](./celestia-light-node.md), [`alerts/`](./alerts/)).
 
-`ligate-node` writes persistent state to RocksDB at `<storage>.path`. On the live devnet-1 sequencer this resolves to `/opt/ligate/devnet-1/data-celestia` (currently on `/dev/root`; migration to `/var/lib/ligate` persistent disk is a separate followup tracked under chain#359). Without backups, a single bad disk loses the chain's local history; recovery requires full DA replay from genesis, which on a multi-month devnet means hours of replay before we even hit any DA fetch quirks.
+`ligate-node` writes persistent state to RocksDB at `<storage>.path`. On the live devnet-1 sequencer that path is `/opt/ligate/devnet-1/data-celestia`, which is a symlink to `/var/lib/ligate/rocksdb` on the persistent data disk (`/dev/sdb`, 50 GB). The symlink approach keeps the rollup config (`devnet-1/celestia.toml`) host-portable while still landing the actual bytes on the persistent disk so a VM image rebuild doesn't wipe state. Without backups, a single bad disk still loses the chain's local history; recovery would require full DA replay from genesis, which on a multi-month devnet means hours of replay before we even hit any DA fetch quirks.
 
 This runbook covers: routine snapshotting to GCS, point-in-time restore from a snapshot, and the quarterly drill that proves the restore path actually works.
 
@@ -24,10 +24,11 @@ Backups give a known-good fast restore path. DA replay remains the ultimate-sour
 
 ```
 ┌─────────────────────────────┐         ┌──────────────────────┐
-│ /var/lib/ligate/rollup      │ rsync   │ /var/lib/ligate/     │
-│ (RocksDB write-active)      ├────────►│   snapshots/<tier>/  │
-│                             │ --link- │   <timestamp>/       │
-│                             │ dest    │  (hardlinked)        │
+│ /var/lib/ligate/rocksdb     │ rsync   │ /var/lib/ligate/     │
+│ (RocksDB write-active,      ├────────►│   snapshots/<tier>/  │
+│  symlinked from             │ --link- │   <timestamp>/       │
+│  /opt/ligate/devnet-1/      │ dest    │  (hardlinked)        │
+│  data-celestia)             │         │                      │
 └─────────────────────────────┘         └──────────┬───────────┘
                                                    │
                                                    │ gcloud storage cp -r
@@ -255,6 +256,49 @@ Exit codes encode the failure stage (1 = backup, 2 = restore, 3 = post-restore v
 
 ---
 
+## Migrating an existing host to the persistent disk
+
+If you're operating a host where chain state landed on `/dev/root` instead of the persistent disk (cloud-init didn't pre-create the symlink), here's the in-place migration. Done on `ligate-devnet-1-sequencer` on 2026-05-16 with ~3 min of chain downtime.
+
+```sh
+# 1. Stop the chain cleanly. TimeoutStopSec=300 gives RocksDB room
+#    to flush WAL + finish compaction.
+sudo systemctl stop ligate-node.service
+
+# 2. Stage the new home + rsync existing data over. Use --sparse to
+#    preserve sparseness on NOMT files (or accept ~4x bloat).
+sudo mkdir -p /var/lib/ligate/rocksdb
+sudo chown ligate:ligate /var/lib/ligate/rocksdb
+sudo -u ligate rsync -a --sparse --info=progress2 \
+    /opt/ligate/devnet-1/data-celestia/ \
+    /var/lib/ligate/rocksdb/
+
+# 3. Swap the original dir for a symlink pointing at the new home.
+#    Keep the original as .MIGRATION-BACKUP-<date> for at least 24h
+#    in case the new path has a config / permissions issue surface
+#    only after startup.
+sudo mv /opt/ligate/devnet-1/data-celestia \
+        /opt/ligate/devnet-1/data-celestia.MIGRATION-BACKUP-$(date -u +%Y%m%d)
+sudo ln -s /var/lib/ligate/rocksdb /opt/ligate/devnet-1/data-celestia
+sudo chown -h ligate:ligate /opt/ligate/devnet-1/data-celestia
+
+# 4. Start the chain. Verify head advances past the pre-stop height
+#    AND chain_hash is unchanged (symlink swap shouldn't touch state).
+sudo systemctl start ligate-node.service
+curl -s https://api.ligate.io/v1/info | jq
+
+# 5. Update /etc/ligate/backup.env: set LIGATE_STORAGE_DIR=/var/lib/ligate/rocksdb
+#    so the snapshot manifest records the physical path.
+
+# 6. Trigger one manual backup against the new path:
+sudo systemctl start ligate-backup@hourly.service
+
+# 7. After 24h of uneventful operation, reclaim the /dev/root space:
+sudo rm -rf /opt/ligate/devnet-1/data-celestia.MIGRATION-BACKUP-*
+```
+
+---
+
 ## Out of scope
 
 - **Multi-region replication.** A second GCS bucket in `us-east1` would survive a regional outage. Deferred to mainnet.
@@ -270,9 +314,10 @@ What's live on devnet-1 as of 2026-05-16 vs what's still pending:
 
 | Limitation | Impact | Tracked |
 |---|---|---|
-| Live chain data is at `/opt/ligate/devnet-1/data-celestia` (the `<storage>.path` from the rollup config TOML), which resolves under `/dev/root`. The persistent disk at `/var/lib/ligate` is mounted but unused. Backup script + manifest reflect the actual live path; future operators should migrate to `/var/lib/ligate/rocksdb` so a VM-image rebuild doesn't wipe chain state. | A VM image rebuild today would lose the chain state (still recoverable via DA replay or GCS restore, but the persistent disk's whole point is to avoid that). | chain#359 followups |
 | `backup-rocksdb.sh`'s `block_height` capture in the manifest can produce a multi-line value (height + `unknown`) because the script tries two height-extraction paths and writes both. Manifest is still parseable; the value is just ugly. | Cosmetic; restore doesn't depend on this field. | chain#359 followups |
+| `backup-rocksdb.sh` uses `rsync -a` without `--sparse`, so sparse files (RocksDB NOMT files contain many) inflate ~4x on copy. Doesn't affect chain operation but bloats local snapshot stage + GCS storage. | Disk-cost only; ~$4/mo extra storage at devnet scale. | chain#359 followups |
 | `ligate-node.service` is not enabled by default after first cloud-init boot — the original runbook left it as a manual `systemctl start` step. After every `gcloud compute instances stop|start`, the service must be re-enabled with `sudo systemctl enable --now ligate-node.service`. | One-time post-deploy step; now codified in §1 above. | n/a, fixed in the runbook |
+| Cloud-init in `public-devnet-deploy.md` doesn't pre-create the `/var/lib/ligate/rocksdb` directory + symlink at `/opt/ligate/devnet-1/data-celestia`. Until that lands, fresh deploys need a manual symlink step before first `ligate-node` start (else the chain writes to `/dev/root` again). | One-time step on fresh deploys. | chain#359 followups |
 
 ---
 

--- a/ops/backup/backup.env.example
+++ b/ops/backup/backup.env.example
@@ -22,10 +22,12 @@ GCS_BUCKET=ligate-devnet-1-backups
 
 # Required.
 # Absolute path to the live RocksDB rollup data directory. On
-# devnet-1 sequencer this is /opt/ligate/devnet-1/data-celestia
-# (currently on /dev/root; migration to /var/lib/ligate persistent
-# disk is a separate followup, also tracked in chain#359 followups).
-LIGATE_STORAGE_DIR=/opt/ligate/devnet-1/data-celestia
+# devnet-1 sequencer the chain config points at
+# /opt/ligate/devnet-1/data-celestia, which is a symlink to
+# /var/lib/ligate/rocksdb on the persistent disk. The backup script
+# reads the physical path directly so the manifest records the real
+# storage location (not the symlink).
+LIGATE_STORAGE_DIR=/var/lib/ligate/rocksdb
 
 # Required.
 # Local stage dir for rsync --link-dest snapshots before GCS upload.


### PR DESCRIPTION
Closes another followup from #359 (chain state on persistent disk so VM rebuild can't wipe it).

## What changed on the live VM

`ligate-devnet-1-sequencer` storage path was redirected from `/opt/ligate/devnet-1/data-celestia` (writing to `/dev/root`, 19 GB boot disk) to `/var/lib/ligate/rocksdb` (the 50 GB persistent data disk `/dev/sdb`). Done with a symlink so the rollup config (`devnet-1/celestia.toml`) stays host-portable:

```
$ ls -la /opt/ligate/devnet-1/data-celestia
lrwxrwxrwx 1 ligate ligate 23 May 16 15:10 /opt/ligate/devnet-1/data-celestia -> /var/lib/ligate/rocksdb
```

Procedure: stop chain → rsync 1.2 GB of state (~31 s, 5.4 GB transferred — RocksDB sparse files inflate; see followup) → swap dir for symlink → restart chain.

## Verification (live now)

```
Pre-stop  : head_height=15291, chain_hash=lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v
Post-start: head_height=15357 (advanced past pre-stop), chain_hash UNCHANGED
Indexer   : caught up (head_lag_slots=0)
Backup    : manual @hourly run completed at 15:13 UTC, manifest now records storage_path=/var/lib/ligate/rocksdb
```

Original data preserved at `/opt/ligate/devnet-1/data-celestia.MIGRATION-BACKUP-20260516` (1.2 GB) for 24-hour rollback window. Will be deleted via the runbook's step 7 tomorrow.

## What this PR commits

- **`docs/development/runbooks/backup-restore.md`**
  - Intro: clarifies the symlink topology (chain config points at the friendly path; bytes land on persistent disk)
  - Architecture diagram updated to show the symlink
  - New "Migrating an existing host to the persistent disk" section documenting the exact procedure just performed (for any future host stuck in the same pre-launch state)
  - Known limitations: removed the data-migration row (now done); added two new ones (sparse-files inflation in the script; cloud-init doesn't pre-create the symlink for fresh deploys)
- **`ops/backup/backup.env.example`** — `LIGATE_STORAGE_DIR` flipped to the physical `/var/lib/ligate/rocksdb` path so the snapshot manifest records the real storage location, not the symlink

## What's still in #359 followups

- Add `--sparse` to `backup-rocksdb.sh` rsync (so future snapshots don't inflate ~4x from RocksDB NOMT sparse files)
- Cloud-init in `public-devnet-deploy.md` should pre-create the `/var/lib/ligate/rocksdb` + symlink so fresh deploys never write to `/dev/root` in the first place
- Public snapshot publish path (`ligate-snapshot-publish.service` + bucket) for follower bootstrap
- `backup-rocksdb.sh` manifest height-capture bug (multi-line value)
- Update Host VM dashboard "State disk used" panel — now that data is actually on `/var/lib/ligate`, the existing query is correct, but the value will jump from 5% to ~55%; might want to add a "/" mountpoint panel too
- Restore drill on a non-prod VM (validates the backup → restore loop end-to-end)

## Test plan

- [ ] `ls -la /opt/ligate/devnet-1/data-celestia` shows the symlink to `/var/lib/ligate/rocksdb`
- [ ] `curl -s api.ligate.io/v1/info` returns same `chain_hash` as before migration
- [ ] Next hourly backup manifest records `storage_path: /var/lib/ligate/rocksdb`
- [ ] `df -h /var/lib/ligate` reflects the chain data (now ~55% used vs 0% before migration)