### PR TITLE
ops(backup): --sparse rsync + fix awk-exit SIGPIPE producing malformed manifest

### DIFF
--- a/scripts/backup-rocksdb.sh
+++ b/scripts/backup-rocksdb.sh
@@ -54,20 +54,31 @@ mkdir -p "${LIGATE_SNAPSHOT_DIR}/${TIER}"
 # `--delete` keeps the snapshot tidy if a file disappeared upstream.
 PREVIOUS_SNAPSHOT="$(ls -dt "${LIGATE_SNAPSHOT_DIR}/${TIER}"/* 2>/dev/null | head -1 || true)"
 
+# `--sparse` preserves sparseness on copy. RocksDB NOMT files contain
+# many sparse holes; without --sparse, rsync fills them with zeros on
+# the destination, inflating each snapshot ~4x on disk for nothing.
+# Tested: 1.2 GB physical → 5 GB after copy without --sparse,
+# vs 1.2 GB → 1.2 GB with --sparse.
 echo "==> Local snapshot: ${LOCAL_SNAPSHOT}"
 if [ -n "${PREVIOUS_SNAPSHOT}" ] && [ "${PREVIOUS_SNAPSHOT}" != "${LOCAL_SNAPSHOT}" ]; then
     echo "    using --link-dest=${PREVIOUS_SNAPSHOT}"
-    rsync -a --delete --link-dest="${PREVIOUS_SNAPSHOT}" \
+    rsync -a --sparse --delete --link-dest="${PREVIOUS_SNAPSHOT}" \
           "${LIGATE_STORAGE_DIR}/" "${LOCAL_SNAPSHOT}/"
 else
-    rsync -a --delete "${LIGATE_STORAGE_DIR}/" "${LOCAL_SNAPSHOT}/"
+    rsync -a --sparse --delete "${LIGATE_STORAGE_DIR}/" "${LOCAL_SNAPSHOT}/"
 fi
 
 # Write a manifest alongside so restore can verify checksum + height.
 HEIGHT_FILE="${LOCAL_SNAPSHOT}/.snapshot-manifest.json"
-HEIGHT="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null \
-            | awk '/^ligate_block_height /{print $2; exit}' \
-            || echo "unknown")"
+# Buffer-then-parse to avoid `set -o pipefail` + `awk … exit` SIGPIPE-ing
+# the writer of the pipe, which previously made HEIGHT capture BOTH
+# awk's match AND the `|| echo "unknown"` fallback (the manifest's
+# block_height field would contain a literal newline: `"15187\nunknown"`).
+# `<<<` here-string feeds awk via a temp file, not a pipe — no SIGPIPE
+# possible even when awk exits before the writer finishes.
+METRICS="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
+HEIGHT="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS}")"
+[ -z "${HEIGHT}" ] && HEIGHT="unknown"
 {
     echo "{"
     echo "  \"tier\": \"${TIER}\","

--- a/scripts/restore-rocksdb.sh
+++ b/scripts/restore-rocksdb.sh
@@ -121,8 +121,11 @@ while ! curl -sf http://127.0.0.1:9100/metrics >/dev/null 2>&1; do
     fi
 done
 
-CURRENT_HEIGHT="$(curl -sf http://127.0.0.1:9100/metrics \
-                    | awk '/^ligate_block_height /{print $2; exit}')"
+# Buffer-then-parse via here-string to avoid `set -o pipefail` +
+# `awk … exit` SIGPIPE-ing curl. Same shape as in backup-rocksdb.sh.
+CURRENT_METRICS="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
+CURRENT_HEIGHT="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${CURRENT_METRICS}")"
+[ -z "${CURRENT_HEIGHT}" ] && CURRENT_HEIGHT="unknown"
 echo "==> Node restarted; current block_height: ${CURRENT_HEIGHT}"
 echo "==> Expected from snapshot:               ${EXPECTED_HEIGHT}"
 echo


### PR DESCRIPTION
Closes two followups from #359 in one PR (both touch `scripts/backup-rocksdb.sh`).

## 1. `--sparse` on rsync (saves ~4x local disk)

RocksDB NOMT files contain many sparse holes. `rsync -a` doesn't preserve sparseness on copy — destination gets zeros in the holes, inflating each snapshot from ~1.2 GB physical to ~5 GB on disk. Adding `--sparse` keeps them sparse end-to-end.

Verified live on `ligate-devnet-1-sequencer` after deploy: new 17:00Z hourly snapshot landed at **56 MB on disk** (was ~5 GB before this fix). Even better than physical 1.2 GB because `--link-dest` against the previous snapshot deduplicated most files via hardlinks; only fresh SSTs got fully copied.

GCS object storage doesn't have a sparse concept, so the wire size of each upload is still the logical (5 GB) size — but for **local snapshot retention** (24 hourly × ~5 GB = up to 120 GB) this is a massive win.

## 2. Manifest `block_height` had embedded newline (`"15187\nunknown"`)

Every snapshot manifest written since the backup infra shipped had a malformed `block_height` value:

```json
"block_height": "15187
unknown",
```

Root cause: `set -o pipefail` + `awk '... exit'` interact pathologically.

1. `awk` matches the gauge line, prints `15187`, calls `exit`
2. `awk` closes stdin → `curl` writer gets SIGPIPE → exits non-zero
3. `pipefail` propagates curl's non-zero as the pipeline's exit code
4. `|| echo "unknown"` sees the non-zero, fires
5. The subshell's stdout already contains awk's `15187\n`; now `unknown\n` appends
6. `$(...)` captures both: `HEIGHT="15187\nunknown"`
7. Manifest gets the literal newline embedded in the JSON string value

Reproduced live; **every manifest in `gs://ligate-devnet-1-backups/` since launch had this bug** — `restore-rocksdb.sh` would've failed at `jq -r .block_height` (jq can't parse a JSON string containing a raw `\n`).

Fix: drop the pipe in favor of a `<<<` here-string. Bash creates a temp file for here-strings — no pipe means no SIGPIPE possible, regardless of when awk exits.

```bash
METRICS="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
HEIGHT="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS}")"
[ -z "${HEIGHT}" ] && HEIGHT="unknown"
```

Same exact bug + same exact fix applied to `restore-rocksdb.sh::CURRENT_HEIGHT` (line 124) for consistency.

## Verification (live)

```
$ gcloud storage cat gs://ligate-devnet-1-backups/ligate-devnet-1-sequencer/hourly/20260516T170000Z/20260516T170000Z/.snapshot-manifest.json
{
  "tier": "hourly",
  "timestamp": "20260516T170000Z",
  "hostname": "ligate-devnet-1-sequencer",
  "storage_path": "/var/lib/ligate/rocksdb",
  "block_height": "16735",   ← clean single value, was "16735\nunknown" pre-fix
  "created_at_utc": "2026-05-16T17:29:31Z"
}

$ sudo du -sh /var/lib/ligate/snapshots/hourly/20260516T170000Z
56M                            ← was 5.1G pre-fix
```

## Test plan

- [ ] `bash -n scripts/backup-rocksdb.sh && bash -n scripts/restore-rocksdb.sh` parse-OK
- [ ] After deploy: trigger `sudo systemctl start ligate-backup@hourly.service`
- [ ] Verify the new manifest's `block_height` parses with `jq -r .block_height`
- [ ] `du -sh` on the new snapshot should be ≤ ~100 MB (was 5 GB pre-fix)