### PR TITLE
ops(grafana): Host VM row gains Root / disk + Uptime panels

### DIFF
--- a/monitoring/grafana/ligate-operator.json
+++ b/monitoring/grafana/ligate-operator.json
@@ -1758,7 +1758,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 4,
         "x": 0,
         "y": 68
       },
@@ -1817,8 +1817,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 4,
+        "x": 4,
         "y": 68
       },
       "id": 902,
@@ -1876,8 +1876,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
+        "w": 4,
+        "x": 8,
         "y": 68
       },
       "id": 903,
@@ -1908,7 +1908,7 @@
           "refId": "A"
         }
       ],
-      "title": "State disk used (/var/lib/ligate)",
+      "title": "/var/lib/ligate used",
       "type": "stat"
     },
     {
@@ -1935,8 +1935,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
+        "w": 4,
+        "x": 12,
         "y": 68
       },
       "id": 904,
@@ -1967,7 +1967,7 @@
           "refId": "A"
         }
       ],
-      "title": "Load avg (1m)",
+      "title": "Load 1m",
       "type": "stat"
     },
     {
@@ -2111,6 +2111,124 @@
       ],
       "title": "Disk I/O (sdb = state disk)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "Root fs (boot disk) fill %. Watch for /var/log runaway or unintended writes off the persistent disk.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 68
+      },
+      "id": 907,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "(1 - (node_filesystem_avail_bytes{job=\"integrations/unix\",mountpoint=\"/\"} / node_filesystem_size_bytes{job=\"integrations/unix\",mountpoint=\"/\"})) * 100",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "/ (boot disk) used",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-ligate-prom"
+      },
+      "description": "Seconds since last boot of the chain VM. Drops to ~0 on a reboot (planned restart, image refresh, scope-bump cycle).",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 68
+      },
+      "id": 908,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-ligate-prom"
+          },
+          "expr": "(time() - node_boot_time_seconds{job=\"integrations/unix\"})",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
     }
   ],
   "refresh": "15s",
@@ -2131,5 +2249,5 @@
   "timezone": "browser",
   "title": "Ligate Devnet \u2014 Operator view",
   "uid": "ligate-operator",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
Closes another followup from #359. The Host VM row only had visibility into `/var/lib/ligate` (the persistent state disk); the boot disk was invisible. Adds a `/` mountpoint panel + a server uptime panel.

## Layout change

Was: 4 stats × w=6 at y=68 (CPU, RAM, State disk, Load).
Now: 6 stats × w=4 at y=68 — same vertical footprint, two new tiles fit in the freed horizontal space.

| x | id | title | query |
|---|---|---|---|
| 0 | 901 | CPU usage | `100 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100` |
| 4 | 902 | Memory used | `(1 - MemAvailable/MemTotal) * 100` |
| 8 | 903 | `/var/lib/ligate used` | `(1 - avail/size) * 100` on `mountpoint="/var/lib/ligate"` |
| 12 | 904 | Load 1m | `node_load1` |
| **16** | **907** | **`/` (boot disk) used** | **`(1 - avail/size) * 100` on `mountpoint="/"`** |
| **20** | **908** | **Uptime** | **`time() - node_boot_time_seconds`** |

Two existing panel titles tightened to fit the narrower width:
- "State disk used (/var/lib/ligate)" → "/var/lib/ligate used"
- "Load avg (1m)" → "Load 1m"

## Why this matters

Before, the only signal that the boot disk was filling came from SSH-ing in and running `df -h`. With this PR, the same Grafana dashboard that surfaces chain block height, RPC latency, and DA finality now also flags root-disk growth — important because `/var/log/journal` autoexpands to 10% of /, and a runaway log producer would otherwise be invisible until the next `df`.

Uptime panel surfaces planned vs unplanned restarts at a glance — useful during the launch window when we'll want to notice if anything's bouncing.

## Verification (live)

Dashboard already PUT to Grafana (v4 of `ligate-operator`). Both new panel queries return values:

```
/ (boot disk) used:   35.23%
Uptime:               10,343 s  (≈ 2.87 h since the 14:40Z scope-bump restart)
```

## Test plan

- [ ] https://ligate.grafana.net/d/ligate-operator renders 6 stats in the Host VM row (no overlap, no wasted space)
- [ ] `/` panel shows non-zero %, increases when `/var/log/journal` grows
- [ ] Uptime drops to ~0s if the VM is rebooted, then climbs