### PR TITLE
ops: restore-script double-nest fix + runbook OS/Celestia version (drill findings)

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -47,6 +47,8 @@ Faucet and indexer **do not run on this VM** — they live in [`ligate-io/ligate
 
 Persistent data disk can be **live-resized without downtime** via `gcloud compute disks resize` + `resize2fs /dev/sdb`; ext4 supports online growth. Done on `ligate-devnet-1-sequencer` on 2026-05-16 (50GB → 150GB) when local snapshot accumulation projected to fill the original 50GB within ~24h.
 
+**OS choice: Ubuntu 24.04 LTS, not Debian 12.** The released `ligate-node` binary is built on Ubuntu 24.04 and links against GLIBC 2.39. Debian 12 ships GLIBC 2.36, so the binary fails to load with `version GLIBC_2.39 not found`. If you want Debian for some reason, build from source (`cargo build --release --bin ligate-node`) on the same Debian VM — but that pulls in a Rust toolchain + ~30 min of compile time. Ubuntu is the pragmatic default.
+
 ## Step 1: Provision the VM
 
 ```bash
@@ -54,8 +56,8 @@ gcloud compute instances create ligate-devnet-1-sequencer \
     --project=$YOUR_GCP_PROJECT \
     --zone=us-central1-a \
     --machine-type=e2-standard-4 \
-    --image-family=debian-12 \
-    --image-project=debian-cloud \
+    --image-family=ubuntu-2404-lts-amd64 \
+    --image-project=ubuntu-os-cloud \
     --boot-disk-size=20GB \
     --create-disk=name=ligate-data,size=150GB,type=pd-ssd \
     --tags=http-server,https-server \
@@ -169,11 +171,15 @@ runcmd:
   - chown ligate:ligate /var/lib/ligate/rocksdb
   # Install Rust + risc0 toolchain (sequencer only; follower can skip risc0)
   - sudo -u ligate bash -lc 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
-  # Install Celestia light node binary
+  # Install Celestia light node binary. Newer Celestia releases ship
+  # as a tar.gz (was a bare binary in earlier releases); extract and
+  # install the `celestia` binary.
   - |
-    CELESTIA_VERSION=v0.20.0
-    curl -L "https://github.com/celestiaorg/celestia-node/releases/download/${CELESTIA_VERSION}/celestia-linux-amd64" \
-      -o /usr/local/bin/celestia && chmod +x /usr/local/bin/celestia
+    CELESTIA_VERSION=v0.30.2
+    curl -fsSL "https://github.com/celestiaorg/celestia-node/releases/download/${CELESTIA_VERSION}/celestia-node_Linux_x86_64.tar.gz" \
+      -o /tmp/celestia.tar.gz
+    tar -xzf /tmp/celestia.tar.gz -C /tmp/
+    install -o root -g root -m 0755 /tmp/celestia /usr/local/bin/celestia
   - sudo -u ligate /usr/local/bin/celestia light init --p2p.network=mocha
   - systemctl daemon-reload
   - systemctl enable --now celestia-light.service

--- a/scripts/restore-rocksdb.sh
+++ b/scripts/restore-rocksdb.sh
@@ -25,6 +25,15 @@ set -euo pipefail
 : "${GCS_BUCKET:?GCS_BUCKET must be set}"
 : "${HOSTNAME:=$(hostname -s)}"
 
+# When the script runs via `sudo -u ligate` from another user's
+# session, sudo preserves the caller's HOME — gcloud then tries to
+# read `${HOME}/.config/gcloud/active_config` which lives in the
+# caller's home and trips a permission error. Re-derive HOME from
+# the effective user so gcloud finds its config no matter how sudo
+# was invoked. Idempotent under systemd User=ligate (HOME is already
+# right) and under direct ligate-user invocation.
+export HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
+
 TIER="hourly"
 TIMESTAMP=""
 
@@ -79,7 +88,26 @@ mkdir -p "${LIGATE_STAGING_DIR}"
 rm -rf "${LIGATE_STAGING_DIR}/restored"
 echo "==> Downloading to ${LIGATE_STAGING_DIR}/restored"
 gcloud storage cp -r "${GCS_SOURCE}/" "${LIGATE_STAGING_DIR}/" --quiet
-mv "${LIGATE_STAGING_DIR}/${TIMESTAMP}" "${LIGATE_STAGING_DIR}/restored"
+
+# `gcloud storage cp -r SRC/ DST/` copies SRC as a CHILD of DST and
+# preserves the source directory's name inside DST. Combined with the
+# backup script's own `gcloud storage cp -r LOCAL_SNAPSHOT/ GCS_PREFIX/`
+# (which itself double-nests on upload — snapshots in GCS have layout
+# `<HOSTNAME>/<TIER>/<TS>/<TS>/...files...`), the download landing pad
+# is `${LIGATE_STAGING_DIR}/${TIMESTAMP}/${TIMESTAMP}/...`. Promote
+# the inner dir to `restored/` so the manifest path below stays sane
+# regardless of how many levels gcloud nests. Also handle the flat
+# layout for forward-compat if the backup script is later fixed to
+# upload without double-nesting.
+if [ -d "${LIGATE_STAGING_DIR}/${TIMESTAMP}/${TIMESTAMP}" ]; then
+    mv "${LIGATE_STAGING_DIR}/${TIMESTAMP}/${TIMESTAMP}" "${LIGATE_STAGING_DIR}/restored"
+    rmdir "${LIGATE_STAGING_DIR}/${TIMESTAMP}" 2>/dev/null || true
+elif [ -d "${LIGATE_STAGING_DIR}/${TIMESTAMP}" ]; then
+    mv "${LIGATE_STAGING_DIR}/${TIMESTAMP}" "${LIGATE_STAGING_DIR}/restored"
+else
+    echo "downloaded dir not found at ${LIGATE_STAGING_DIR}/${TIMESTAMP}" >&2
+    exit 1
+fi
 
 # ----- Verify manifest ---------------------------------------------
 MANIFEST="${LIGATE_STAGING_DIR}/restored/.snapshot-manifest.json"


### PR DESCRIPTION
Three bugs surfaced from setting up a fresh follower VM to drill the backup → restore loop end-to-end. All would bite anyone trying to bring up a follower from our docs.

## Bug 1: `restore-rocksdb.sh` doesn't handle gcloud's double-nesting

`backup-rocksdb.sh` uploads with `gcloud storage cp -r LOCAL_SNAPSHOT/ GCS_PREFIX/`. With trailing slashes, gcloud copies the source dir as a CHILD of the destination, creating layout `<HOSTNAME>/<TIER>/<TS>/<TS>/...files...` in GCS (double-nested timestamp).

`restore-rocksdb.sh` then did `mv STAGING/${TIMESTAMP} STAGING/restored` and looked for the manifest at `STAGING/restored/.snapshot-manifest.json`, but the actual manifest lived one level deeper at `STAGING/restored/${TIMESTAMP}/.snapshot-manifest.json`. Restore aborted with `snapshot manifest missing` on every snapshot in the bucket.

Fix: detect both flat and double-nested layouts after download, promote the inner dir to `restored/` either way. Forward-compat for if we ever fix the backup script's upload to not double-nest.

## Bug 2: `restore-rocksdb.sh` breaks when run as `ligate` via sudo from another user's session

`gcloud storage cp` reads `${HOME}/.config/gcloud/active_config` to pick up auth. `sudo -u ligate` preserves the CALLER's HOME by default (e.g. `/home/stefdev`), and `ligate` can't read stefdev's gcloud dir → restore aborts with `Permission denied: '/home/stefdev/.config/gcloud/active_config'`.

Fix: re-derive HOME from the effective user at the top of the script. Idempotent under systemd `User=ligate` (HOME is already right) and under `sudo -i -u ligate` (HOME also right) — only fixes the broken `sudo -u ligate` case.

## Bug 3: runbook says Debian 12 + Celestia v0.20.0, both wrong

The runbook said:
- `--image-family=debian-12 --image-project=debian-cloud`
- `CELESTIA_VERSION=v0.20.0` from `celestia-linux-amd64` (bare-binary URL)

What actually works (verified on prod sequencer + the drill VM):
- **Ubuntu 24.04 LTS** — the released `ligate-node` binary links GLIBC 2.39 (Debian 12 has 2.36 → `version GLIBC_2.39 not found`). Prod is on Ubuntu, the runbook just hadn't been updated.
- **Celestia v0.30.2** — the URL pattern changed too (now `celestia-node_Linux_x86_64.tar.gz` not `celestia-linux-amd64`).

Fix: update both. Add an explicit note in the VM sizing section explaining why Ubuntu, not Debian, so future operators don't pick Debian thinking it's a free choice.

## Verification (drill VM)

Done end-to-end on `ligate-devnet-1-follower-drill` (Ubuntu 24.04, fresh provision, Celestia v0.30.2):
- `ligate-node` binary smoke-tests fine (commit `eab3f9d0` matches prod)
- `restore-rocksdb.sh --tier hourly` (with `HOSTNAME=ligate-devnet-1-sequencer` override) downloads the latest prod backup, finds the manifest correctly via the new layout-detection, lands state at `/var/lib/ligate/rocksdb/` (58 MB, sparse-preserved per #368, manifest says `block_height: 16895`)

Outstanding for the drill: waiting on Celestia light to finish catchup before starting ligate-node and watching chain head advance past 16895. Will update this PR (or a followup comment on #359) once that completes.

## Test plan

- [ ] `bash -n scripts/restore-rocksdb.sh` parse-OK
- [ ] After deploy: `sudo -u ligate env GCS_BUCKET=... HOSTNAME=ligate-devnet-1-sequencer bash -c "echo y | /opt/ligate/scripts/restore-rocksdb.sh"` runs without aborting at the manifest check
- [ ] Fresh follower from the updated runbook: `gcloud compute instances create ... --image-family=ubuntu-2404-lts-amd64` + cloud-init Celestia install both succeed