### PR TITLE
ops(backup): cold mode for daily/weekly fixes NOMT mid-write inconsistency + sudoers + --mode follower docs

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -212,7 +212,22 @@ The cloud-init does the chassis. The operator still has to:
   SOV_CELESTIA_SIGNER_KEY=<hex private key holding Mocha TIA>
   RUST_LOG=info,sov=info
   ```
-- `systemctl enable --now ligate-node.service`.
+  A **follower** uses a similar env but with a freshly-generated 32-byte hex key for `SOV_CELESTIA_SIGNER_KEY` (no Mocha TIA needed — followers don't submit blobs). The follower's DA address derived from that key won't match the registered preferred sequencer, which would normally fail the sequencer-bond identity check — pass `--mode follower` on the binary (see next bullet) and the check is skipped via the follower guard (chain#243 / #248).
+- `systemctl enable --now ligate-node.service`. For a **follower**, add `--mode follower` to the `ExecStart` line in `/etc/systemd/system/ligate-node.service` first. The full ExecStart becomes:
+  ```
+  ExecStart=/opt/ligate/bin/ligate-node \
+      --mode follower \
+      --da-layer celestia \
+      --rollup-config-path /opt/ligate/devnet-1/celestia.toml \
+      --genesis-config-dir /opt/ligate/devnet-1/genesis
+  ```
+  This activates the follower guard (returns 503 on `POST /v1/sequencer/txs` so users get a clear "submit to the upstream sequencer" message) and skips the preferred-sequencer DA-address check that would otherwise refuse to start.
+- If you'll run cold backups (daily/weekly tiers stop ligate-node briefly for a consistent rsync — see `docs/development/runbooks/backup-restore.md`), install the sudoers drop-in:
+  ```bash
+  sudo install -o root -g root -m 0440 \
+      ops/backup/sudoers.d/ligate-backup /etc/sudoers.d/ligate-backup
+  ```
+  That allows the `ligate` user to `systemctl stop/start ligate-node.service` without a password prompt. Narrow scope; only those two commands, only on that one service.
 
 ## Step 2.5: NTP / clock sync (required)
 

--- a/ops/backup/sudoers.d/ligate-backup
+++ b/ops/backup/sudoers.d/ligate-backup
@@ -1,0 +1,14 @@
+# Allow the `ligate` user to start/stop ligate-node.service WITHOUT
+# password prompt. Used by scripts/backup-rocksdb.sh in cold-snapshot
+# mode (daily + weekly tiers): the backup runs as `ligate`, briefly
+# stops ligate-node for a consistent rsync of the NOMT/RocksDB
+# directory, then starts it back. Scope is narrow: only the two
+# commands needed, only on ligate-node.service, only NOPASSWD.
+#
+# Install on the chain VM with:
+#   sudo install -o root -g root -m 0440 \
+#       ops/backup/sudoers.d/ligate-backup /etc/sudoers.d/ligate-backup
+#
+# `visudo -c -f /etc/sudoers.d/ligate-backup` validates syntax.
+# `/etc/sudoers.d/` files must be mode 0440 owned root:root.
+ligate ALL=(root) NOPASSWD: /usr/bin/systemctl stop ligate-node.service, /usr/bin/systemctl start ligate-node.service

--- a/scripts/backup-rocksdb.sh
+++ b/scripts/backup-rocksdb.sh
@@ -54,6 +54,45 @@ mkdir -p "${LIGATE_SNAPSHOT_DIR}/${TIER}"
 # `--delete` keeps the snapshot tidy if a file disappeared upstream.
 PREVIOUS_SNAPSHOT="$(ls -dt "${LIGATE_SNAPSHOT_DIR}/${TIER}"/* 2>/dev/null | head -1 || true)"
 
+# Capture the current block height BEFORE any cold-snapshot stop so
+# the manifest records the height the snapshot corresponds to. If we
+# read it after stopping the chain the metrics endpoint is gone and
+# the manifest ends up as "unknown". Same idiom as the post-rsync
+# block (the script writes the manifest there) — buffer-then-parse
+# via here-string to dodge the `set -o pipefail` + `awk … exit`
+# SIGPIPE issue.
+METRICS_PRESTOP="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
+HEIGHT_PRESTOP="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS_PRESTOP}")"
+
+# Hot vs cold snapshot semantics:
+#
+# rsync of a live RocksDB+NOMT directory is best-effort — NOMT files
+# (bbn, ht, ln, meta, wal in user_nomt_db / kernel_nomt_db) can be
+# caught mid-write, producing a snapshot that triggers
+# `assertion failed: pn.0 < max_pn` in nomt-1.0.3's free-list
+# allocator when the chain tries to load it. RocksDB's own WAL
+# recovers from torn writes; NOMT's beatree allocator doesn't (as of
+# nomt-1.0.3; observed during the restore drill on 2026-05-16).
+#
+# Daily + weekly tiers (the "gold" snapshots used for real restore)
+# go COLD: stop ligate-node briefly, take a consistent point-in-time
+# rsync, restart. ~30-60s pause on a healthy state DB; runs at
+# off-peak hours per the timers (03:30 / 04:00 UTC).
+#
+# Hourly tier stays HOT (no pause) — best-effort, frequent, useful
+# for "last 6 hours" rollback if the chain itself didn't survive a
+# rough event. Restore is best-effort; the last clean cold daily
+# snapshot is always available as fallback.
+COLD=false
+case "$TIER" in
+    daily|weekly) COLD=true ;;
+esac
+
+if [ "$COLD" = "true" ]; then
+    echo "==> Cold snapshot: pausing ligate-node for a consistent rsync"
+    sudo systemctl stop ligate-node.service
+fi
+
 # `--sparse` preserves sparseness on copy. RocksDB NOMT files contain
 # many sparse holes; without --sparse, rsync fills them with zeros on
 # the destination, inflating each snapshot ~4x on disk for nothing.
@@ -68,17 +107,25 @@ else
     rsync -a --sparse --delete "${LIGATE_STORAGE_DIR}/" "${LOCAL_SNAPSHOT}/"
 fi
 
+if [ "$COLD" = "true" ]; then
+    echo "==> Restarting ligate-node"
+    sudo systemctl start ligate-node.service
+fi
+
 # Write a manifest alongside so restore can verify checksum + height.
 HEIGHT_FILE="${LOCAL_SNAPSHOT}/.snapshot-manifest.json"
-# Buffer-then-parse to avoid `set -o pipefail` + `awk … exit` SIGPIPE-ing
-# the writer of the pipe, which previously made HEIGHT capture BOTH
-# awk's match AND the `|| echo "unknown"` fallback (the manifest's
-# block_height field would contain a literal newline: `"15187\nunknown"`).
-# `<<<` here-string feeds awk via a temp file, not a pipe — no SIGPIPE
-# possible even when awk exits before the writer finishes.
-METRICS="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
-HEIGHT="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS}")"
-[ -z "${HEIGHT}" ] && HEIGHT="unknown"
+# Prefer the pre-stop height captured above (always the right
+# point-in-time number, especially for cold snapshots where the
+# metrics endpoint is gone after the systemctl stop). Fall back to
+# a fresh post-rsync read for the hot path, then "unknown" if
+# both failed.
+if [ -n "${HEIGHT_PRESTOP}" ]; then
+    HEIGHT="${HEIGHT_PRESTOP}"
+else
+    METRICS="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
+    HEIGHT="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS}")"
+    [ -z "${HEIGHT}" ] && HEIGHT="unknown"
+fi
 {
     echo "{"
     echo "  \"tier\": \"${TIER}\","


### PR DESCRIPTION
Closes one drill-finding followup from #359 and retracts one (follower mode already exists, I missed it earlier).

## Why

The restore drill (chain#371) exposed: the 17:00Z hourly snapshot panicked ligate-node at restore with `nomt-1.0.3/src/beatree/allocator/free_list.rs:404: assertion failed: pn.0 < max_pn`. Root cause: `rsync -a` of a live RocksDB+NOMT directory can catch NOMT's `bbn`/`ht`/`ln`/`meta`/`wal` files mid-write — RocksDB's WAL recovers from torn writes, NOMT's beatree allocator (as of 1.0.3) doesn't.

## Fix

`scripts/backup-rocksdb.sh` gains tier-aware cold-snapshot mode:

```bash
COLD=false
case "$TIER" in
    daily|weekly) COLD=true ;;
esac

if [ "$COLD" = "true" ]; then
    sudo systemctl stop ligate-node.service
fi
# ... rsync ...
if [ "$COLD" = "true" ]; then
    sudo systemctl start ligate-node.service
fi
```

- **Daily + weekly tiers**: cold → ~30s ligate-node pause for a consistent rsync. Runs at 03:30 / 04:00 UTC (off-peak). The "gold" snapshots that restore is guaranteed to load.
- **Hourly tier**: hot (unchanged) → no pause, best-effort. Restore from an hourly may panic NOMT on a bad-luck capture; fall back to the latest cold daily. 6-hour worst-case RPO from cold daily, 24-hour from weekly.

Also fixes an ordering bug in the manifest height capture (read pre-stop, not post — the metrics endpoint is gone after the systemctl stop).

## Companion bits

- **`ops/backup/sudoers.d/ligate-backup`** (new): narrow drop-in granting `ligate` user `NOPASSWD` on `systemctl stop|start ligate-node.service` only. Required for the cold-mode `sudo systemctl ...` calls in the script.
- **`docs/development/public-devnet-deploy.md`**: documents the sudoers install + adds the `--mode follower` operator step (correcting my earlier-tonight claim that follower mode wasn't supported — it absolutely is, via chain#244/#248. The follower guard at `crates/rollup/src/follower_guard.rs` blocks `POST /v1/sequencer/txs` and skips the preferred-sequencer DA-address check on startup).

## Live verification

Deployed the fixed script + sudoers to `ligate-devnet-1-sequencer` and ran `systemctl start ligate-backup@daily.service` manually:

```
pre-backup chain height: 17664
backup duration: 367s total (chain paused only during rsync window, ~30-60s of that)
post-backup state: inactive / success, ligate-node back active
chain recovered: head_height=17726, indexer caught up
new manifest:
  {"tier":"daily", "timestamp":"20260516", "block_height":"17664", ...}
```

Manifest now records the correct pre-stop height (was "unknown" before the ordering fix), block_height parseable as a plain integer (no embedded newline, post-#368).

## Test plan

- [ ] `bash -n scripts/backup-rocksdb.sh` parse-OK
- [ ] Next daily timer fire (03:30 UTC tomorrow) chain-pauses for <90s, restarts cleanly, manifest records a real height
- [ ] `sudo -u ligate sudo -ln` shows the two ligate-node systemctl commands NOPASSWD
- [ ] Cold snapshot's RocksDB+NOMT loads on a fresh follower VM with `--mode follower` (drill re-validation post-merge)