### PR TITLE
chore(release): cut v0.1.2-devnet (workspace version bump + 8 ops PRs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.1.2-devnet] - 2026-05-17
+
+Launch-eve hardening pass: chain ops infrastructure (backups, monitoring, persistent-disk migration, runbook fixes) plus the workspace version bump that makes the binary self-report `0.1.2-devnet` instead of the workspace-default `0.0.1`. No state-breaking changes; `chain_hash` unchanged. Operators upgrading from `v0.1.1-devnet` swap the binary in place — no re-genesis.
+
+**State-preservation note.** `attestation.json` / genesis bytes / `chain_hash` all unchanged from `v0.1.1-devnet`. Operators deploying this binary to an existing `devnet-1` VM keep their RocksDB state intact across the swap.
+
+### Added
+
+- `monitoring/grafana/`: two production dashboards committed to repo as canonical source. `ligate-operator.json` (Prometheus-backed, 9 rows including the new Host VM row with CPU / RAM / state disk / root disk / load / uptime / network + disk-I/O timeseries) and `ligate-investor.json` (Infinity-backed business metrics). Re-import + export procedures documented in `monitoring/grafana/README.md`. (#361)
+- `ops/backup/`: scheduled RocksDB snapshots to a private GCS bucket actually deployed end-to-end. Hourly tier (every 15 min, 7d retention via lifecycle), daily tier (03:30 UTC, 60d), weekly tier (Sun 04:00 UTC, 365d). systemd template unit (`ligate-backup@.service` with `Environment=TIER=%i`) so each timer fires under its own tier prefix in GCS. (#365, #366)
+- `monitoring/grafana/ligate-operator.json` gains 6 host-VM stat panels powered by Alloy's `prometheus.exporter.unix` (CPU%, RAM%, persistent-disk fill %, boot-disk fill %, load1, uptime). (#364, #370)
+- `ops/backup/sudoers.d/ligate-backup`: narrow drop-in granting the `ligate` user `NOPASSWD` for `systemctl stop|start ligate-node.service` only. Required for the cold-snapshot path used by daily + weekly tiers. (#372)
+- `docs/development/public-devnet-deploy.md` gains a `--mode follower` operator step (the follower guard from #243/#248 was already in code; the runbook just didn't mention it). Same step adds the sudoers install for cold-backup-capable hosts. (#372)
+
+### Changed
+
+- `scripts/backup-rocksdb.sh`: daily + weekly tiers now run in **cold** mode (briefly stop ligate-node for a consistent rsync). Fixes a NOMT mid-write inconsistency that caused `nomt-1.0.3` to panic on restore (`assertion failed: pn.0 < max_pn` in the beatree free-list allocator) on snapshots taken while NOMT was writing `bbn`/`ht`/`ln`/`meta`/`wal`. Hourly stays hot/best-effort for fast rollback. Pre-stop height capture so the manifest records the snapshot's real height even on cold runs. (#372)
+- `scripts/backup-rocksdb.sh`: `rsync -a --sparse` (was `-a` alone) preserves NOMT sparse-file holes on copy — each local snapshot now ~1.2 GB instead of ~5 GB. (#368)
+- `scripts/backup-rocksdb.sh`: SIGPIPE bug in the manifest height-capture pipeline. `set -o pipefail` + `awk '… exit'` was making `curl` exit non-zero, which fired the `|| echo "unknown"` fallback AND captured awk's output, producing `"block_height": "15187\nunknown"` (literal newline in the JSON string value). Switched to a `<<<` here-string so awk reads from a temp file instead of a live pipe — no SIGPIPE possible regardless of when awk exits. (#368)
+- `scripts/restore-rocksdb.sh`: handles both flat and double-nested GCS object layouts. `backup-rocksdb.sh` uploads via `gcloud storage cp -r SRC/ DST/`, which double-nests the timestamp (`<HOSTNAME>/<TIER>/<TS>/<TS>/...`). Restore now detects and flattens. Also re-derives `HOME` from the effective user so `gcloud` finds its config when the script runs via `sudo -u ligate` from another user's session. (#371)
+- `docs/development/public-devnet-deploy.md`: VM image flipped from Debian 12 to Ubuntu 24.04 (the released `ligate-node` binary links GLIBC 2.39; Debian 12 has 2.36 and fails to load the binary). Celestia bumped to v0.30.2 (new `celestia-node_Linux_x86_64.tar.gz` artifact layout). VM sizing table updated to the actual prod shape. Adds an explicit "OS choice" note explaining why Ubuntu. (#371)
+- `docs/development/public-devnet-deploy.md`: cloud-init pre-creates `/var/lib/ligate/rocksdb` so the operator can symlink the chain's storage path into it before first boot. Step 3 of the operator-still-has-to list gains the symlink command. Without this, the chain writes state to `/dev/root` on the 20 GB boot disk and a VM image rebuild loses chain history. (#369)
+- `docs/development/runbooks/backup-restore.md`: full rewrite of the one-time setup section to reflect what actually works (VM scope bump for storage write, since `iam.disableServiceAccountKeyCreation` blocks the documented SA-JSON-key path). Adds in-place migration procedure (done on `ligate-devnet-1-sequencer` 2026-05-17, post-mortem informs the runbook for future hosts). Adds online persistent-disk resize procedure. Known-limitations table at the end documents remaining followups. (#365, #367, #368)
+- `Cargo.toml`: workspace version bumped from `0.0.1` to `0.1.2-devnet`. Previously the workspace-default `0.0.1` propagated to every binary's self-reported version (including what `/v1/info` surfaces) regardless of the git tag. The "tagged release ceremony" pattern that justified the gap was internal-only convention — for the external `/v1/info` consumer the gap was confusing ("why does it report 0.0.1 when the tag is v0.1.1?"). Going forward, workspace version IS the release version and follows the tag.
+
+### Fixed
+
+- `ligate-node` systemd unit: `TimeoutStopSec=300` (was the systemd default of 90s). RocksDB compaction + WAL flush on shutdown can take 2-3 min on a hot state DB; the default triggered a SIGKILL during the `v0.1.1-devnet` swap on 2026-05-16. (#364)
+- `/etc/alloy/config.alloy` on the chain VM: adds `prometheus.exporter.unix "node"` (in-process node_exporter) + matching `prometheus.scrape "node"`. 265 `node_*` series now flow to `grafanacloud-ligate-prom` under `job="integrations/unix"`, powering the new Host VM dashboard row. (#364)
+
 ## [0.1.1-devnet] - 2026-05-16
 
 Pre-launch alignment release. Two operator-visible changes (genesis re-substitution onto the round-2 operator key, sig-verify error UX) and a handful of infrastructure-side tightening (SDK fork pin alignment with the api repo, release-workflow tagging behaviour, pre-commit gate, brand mark refresh).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.0.1"
+version = "0.1.2-devnet"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.1.2-devnet"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]


### PR DESCRIPTION
Release branch for `v0.1.2-devnet`. Workspace version bumped from the `0.0.1` placeholder to `0.1.2-devnet` so the binary self-reports its real version (the gap that #366 / #368 / #371 etc. all shipped without surfacing was the `/v1/info` response showing `"version": "0.0.1"`, which is confusing for any consumer of the public API).

## What's in this release

Eight ops/infra PRs merged since `v0.1.1-devnet`, plus the version bump. No state-affecting changes; `chain_hash` is unchanged. Operators upgrading swap the binary in place — no re-genesis.

PRs folded into the `[0.1.2-devnet]` CHANGELOG section:
- #361 — Grafana dashboards (operator + investor) committed as canonical
- #364 — `TimeoutStopSec=300` + Alloy node_exporter + Host VM dashboard row
- #365 — Hourly GCS backups end-to-end deployed
- #366 — Template-unit refactor so daily + weekly timers actually fire on the right tier
- #367 — Chain state migrated to persistent disk via symlink + 150 GB resize
- #368 — `--sparse` rsync + SIGPIPE manifest fix
- #369 — Cloud-init pre-creates `/var/lib/ligate/rocksdb` + Step 3 symlink doc
- #370 — Host VM row gains `/` boot disk + Uptime panels
- #371 — Restore script double-nest handling + Ubuntu/Celestia version fixes
- #372 — Cold snapshot mode for daily/weekly fixes NOMT mid-write inconsistency

## State preservation

`attestation.json` and every other genesis byte are unchanged. `chain_hash` stays `lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v`. Operators upgrading from `v0.1.1-devnet` swap the binary in place; RocksDB state survives intact.

## Post-merge steps

1. Tag `v0.1.2-devnet` on the merge commit
2. Release workflow builds binaries for linux-amd64 + linux-arm64 + darwin-{amd64,arm64} + sha256
3. Download `ligate-node-0.1.2-devnet-linux-amd64.tar.gz` to local
4. Stop ligate-node on `ligate-devnet-1-sequencer`, swap binary, start
5. Verify `curl https://api.ligate.io/v1/info` reports `"version": "0.1.2-devnet"`

## Test plan

- [ ] CI green (cargo check + clippy + fmt + test + audit + deny + DA isolation + llvm-cov)
- [ ] Release workflow successfully publishes the four platform tarballs on tag push
- [ ] After binary swap on prod: `/v1/info` reports `"version": "0.1.2-devnet"`, chain_hash unchanged, indexer catches up