### PR TITLE
chore(release): drop -devnet suffix from version (clean semver convention)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,21 @@ name: Release
 #
 # Tracking issue: #194.
 #
-# Tagging convention:
-#   - Pre-devnet:  `v0.0.X` per chain-side change set.
-#   - At devnet:   `v0.1.0-devnet` and freeze.
-#   - Mainnet:     `v1.0.0` and forward.
+# Tagging convention (clean semver, no network-name suffix):
+#   - Pre-mainnet:     `v0.x.y` (the `v0.x` numbering itself signals
+#                      "pre-1.0, unstable"; nothing else needed).
+#   - Mainnet RC:      `v1.0.0-rc.1`, `v1.0.0-rc.2`, ...
+#   - Mainnet GA:      `v1.0.0` and forward.
+#
+# Network identity (`chain_id = "ligate-devnet-1"`, future
+# `"ligate-testnet-1"` / `"ligate-mainnet-1"`) lives in the genesis
+# config and chain spec, NOT in the binary tag — the same `ligate-node`
+# binary boots whichever network it's pointed at via
+# `--rollup-config-path` + `--genesis-config-dir`. Matches the pattern
+# every mature chain uses (Solana, Aptos, Cosmos, etc.).
+#
+# Historical tags `v0.1.0-devnet` and `v0.1.1-devnet` predate this
+# convention and stay as-is.
 #
 # This workflow does NOT include cosign signing for v0; add as a
 # follow-up if downstream consumers want provenance verification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
-## [0.1.2-devnet] - 2026-05-17
+## [0.1.2] - 2026-05-17
 
-Launch-eve hardening pass: chain ops infrastructure (backups, monitoring, persistent-disk migration, runbook fixes) plus the workspace version bump that makes the binary self-report `0.1.2-devnet` instead of the workspace-default `0.0.1`. No state-breaking changes; `chain_hash` unchanged. Operators upgrading from `v0.1.1-devnet` swap the binary in place — no re-genesis.
+Launch-eve hardening pass: chain ops infrastructure (backups, monitoring, persistent-disk migration, runbook fixes) plus the workspace version bump that makes the binary self-report its real version (was `0.0.1` regardless of git tag).
+
+**Versioning convention change.** Dropping the `-devnet` suffix from release tags starting with this release. Past tags (`v0.1.0-devnet`, `v0.1.1-devnet`) stay as-is for archaeology, but going forward the convention is clean semver: `v0.1.2`, `v0.1.3`, ..., `v1.0.0-rc.1`, `v1.0.0` for mainnet GA. The `v0.x.y` numbering already signals pre-1.0 / unstable; `-devnet` was redundant AND semver-wrong (it's a pre-release identifier meaning "before 0.1.2 stable" but we were treating it as a final release). Network identity belongs in `chain_id` (`ligate-devnet-1`, future `ligate-testnet-1` / `ligate-mainnet-1`) and genesis directory names, not in the binary's semver. This matches how every mature chain does it (Solana, Aptos, Cosmos, etc. — only Sui prefixes tags with network name, and that's because they have divergent release trains per network, which we don't). Companion repos (`ligate-cli`, `ligate-js`, `ligate-api`) adopt the same convention at their next release.
+
+No state-breaking changes; `chain_hash` unchanged. Operators upgrading from `v0.1.1-devnet` swap the binary in place — no re-genesis.
 
 **State-preservation note.** `attestation.json` / genesis bytes / `chain_hash` all unchanged from `v0.1.1-devnet`. Operators deploying this binary to an existing `devnet-1` VM keep their RocksDB state intact across the swap.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.1.2-devnet"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.2-devnet"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]


### PR DESCRIPTION
Per-discussion convention change: drop the `-devnet` suffix from release tags going forward. Past tags (`v0.1.0-devnet`, `v0.1.1-devnet`) stay as-is; this PR moves the in-flight v0.1.2 release off the now-deprecated convention.

## Why

`v0.1.2-devnet` puts "devnet" in semver's pre-release slot, which formally means "pre-release before 0.1.2 stable" — but we were treating it as a final release. Two problems:

1. **Semver tooling treats `v0.1.2-devnet < v0.1.2`.** Wrong direction for what we mean.
2. **Network name in the binary version conflates two independent things** — what code is this (semver) AND which network it's for (chain_id). The same `ligate-node` binary boots whichever network you point it at via `--rollup-config-path` + `--genesis-config-dir`.

Every mature chain decouples binary version from network identity. Solana, Aptos, Cosmos, Near, Polkadot, Geth: all clean semver on the binary, network identity in `chain_id` / genesis config / spec. Only Sui prefixes tags with network name (`devnet-v1.16.0`) — and that's because they have divergent release trains per network. We don't.

## Change

- `Cargo.toml`: `version = "0.1.2"` (was `"0.1.2-devnet"`)
- `Cargo.lock` updated to match
- `CHANGELOG.md`: `## [0.1.2]` section (was `## [0.1.2-devnet]`), plus a paragraph documenting the convention change at the top of the section
- `.github/workflows/release.yml` tagging-convention comment block rewritten: clean semver going forward, network identity in genesis config, historical `-devnet` tags noted

## What stays

- `chain_id = "ligate-devnet-1"` — unchanged, this is where network identity belongs
- `devnet-1/` directory — unchanged
- `v0.1.0-devnet`, `v0.1.1-devnet` historical tags — unchanged, archaeology
- Companion repos (`ligate-cli`, `ligate-js`, `ligate-api`) — adopt the convention at their next release

## Post-merge

1. Tag merge commit as `v0.1.2`
2. Release workflow builds binaries
3. Swap on prod VM
4. `/v1/info` reports `"version": "0.1.2"`

## Test plan

- [ ] CI green
- [ ] After tag + release: `ligate-node-0.1.2-linux-amd64.tar.gz` artifact exists
- [ ] After binary swap: `/v1/info` reports `"version": "0.1.2"` (no `-devnet` suffix)
- [ ] `chain_id` still `"ligate-devnet-1"` (network identity preserved)