### PR TITLE
ops(backup): fix 5min cold-backup downtime (SIGKILL escalation + stop --no-block to dodge systemd auto-restart)

### DIFF
--- a/ops/backup/sudoers.d/ligate-backup
+++ b/ops/backup/sudoers.d/ligate-backup
@@ -1,9 +1,17 @@
-# Allow the `ligate` user to start/stop ligate-node.service WITHOUT
+# Allow the `ligate` user to manage ligate-node.service WITHOUT
 # password prompt. Used by scripts/backup-rocksdb.sh in cold-snapshot
 # mode (daily + weekly tiers): the backup runs as `ligate`, briefly
 # stops ligate-node for a consistent rsync of the NOMT/RocksDB
-# directory, then starts it back. Scope is narrow: only the two
-# commands needed, only on ligate-node.service, only NOPASSWD.
+# directory, then starts it back.
+#
+# Why three commands not two: ligate-node logs "shutdown complete"
+# within ~1s of SIGTERM but the process doesn't actually exit
+# (upstream Sovereign SDK hang surfaced 2026-05-17 03:30 UTC). The
+# script escalates to SIGKILL after a brief SIGTERM grace window
+# instead of waiting `TimeoutStopSec=300` and eating ~5 min of
+# chain downtime per backup. `systemctl kill` is needed for that
+# escalation path; `systemctl start` is needed to bring the chain
+# back after the rsync.
 #
 # Install on the chain VM with:
 #   sudo install -o root -g root -m 0440 \
@@ -11,4 +19,4 @@
 #
 # `visudo -c -f /etc/sudoers.d/ligate-backup` validates syntax.
 # `/etc/sudoers.d/` files must be mode 0440 owned root:root.
-ligate ALL=(root) NOPASSWD: /usr/bin/systemctl stop ligate-node.service, /usr/bin/systemctl start ligate-node.service
+ligate ALL=(root) NOPASSWD: /usr/bin/systemctl start ligate-node.service, /usr/bin/systemctl stop ligate-node.service, /usr/bin/systemctl stop --no-block ligate-node.service, /usr/bin/systemctl kill ligate-node.service, /usr/bin/systemctl kill --signal=SIGTERM ligate-node.service, /usr/bin/systemctl kill --signal=SIGKILL ligate-node.service

--- a/scripts/backup-rocksdb.sh
+++ b/scripts/backup-rocksdb.sh
@@ -90,7 +90,41 @@ esac
 
 if [ "$COLD" = "true" ]; then
     echo "==> Cold snapshot: pausing ligate-node for a consistent rsync"
-    sudo systemctl stop ligate-node.service
+    # Two-part shutdown to dodge two bugs:
+    #
+    # 1. Upstream Sovereign SDK hang: ligate-node logs "shutdown
+    #    complete" within ~1s of SIGTERM but the process doesn't
+    #    actually exit (surfaced 2026-05-17 03:30 UTC when the first
+    #    scheduled daily backup hit `TimeoutStopSec=300` and took
+    #    ~5.5 min of chain downtime). SIGKILL is safe in practice:
+    #    RocksDB + NOMT WALs recover cleanly on next start,
+    #    chain_hash unchanged across the forced-kill events we've
+    #    observed.
+    #
+    # 2. systemd auto-restart from `Restart=on-failure`: a bare
+    #    `systemctl kill` makes systemd see the process exit as a
+    #    failure and restart ligate-node automatically — the rsync
+    #    then runs against a LIVE chain again, defeating the cold
+    #    snapshot. Using `systemctl stop --no-block` tells systemd
+    #    "we are intentionally stopping, don't restart", then we
+    #    escalate to SIGKILL once the SIGTERM grace window expires.
+    sudo systemctl stop --no-block ligate-node.service
+    # Give graceful-shutdown logs ~3s to flush. The chain finishes
+    # its shutdown sequence well within 1s; 3s is a defensive margin.
+    sleep 3
+    # Escalate: SIGKILL the process if it hasn't exited yet (it
+    # almost certainly hasn't, per bug #1). systemd is in "stopping"
+    # state from the --no-block stop above, so this doesn't trigger
+    # the Restart=on-failure path.
+    sudo systemctl kill --signal=SIGKILL ligate-node.service 2>/dev/null || true
+    # Wait for the unit to actually transition to inactive/failed so
+    # the rsync runs against a quiescent storage directory.
+    for _ in $(seq 1 30); do
+        STATE=$(systemctl show ligate-node.service -p ActiveState --value)
+        [ "$STATE" = "inactive" ] || [ "$STATE" = "failed" ] && break
+        sleep 0.5
+    done
+    echo "    ligate-node stopped (state=${STATE:-unknown})"
 fi
 
 # `--sparse` preserves sparseness on copy. RocksDB NOMT files contain

--- a/scripts/backup-rocksdb.sh
+++ b/scripts/backup-rocksdb.sh
@@ -55,14 +55,22 @@ mkdir -p "${LIGATE_SNAPSHOT_DIR}/${TIER}"
 PREVIOUS_SNAPSHOT="$(ls -dt "${LIGATE_SNAPSHOT_DIR}/${TIER}"/* 2>/dev/null | head -1 || true)"
 
 # Capture the current block height BEFORE any cold-snapshot stop so
-# the manifest records the height the snapshot corresponds to. If we
-# read it after stopping the chain the metrics endpoint is gone and
-# the manifest ends up as "unknown". Same idiom as the post-rsync
-# block (the script writes the manifest there) — buffer-then-parse
-# via here-string to dodge the `set -o pipefail` + `awk … exit`
-# SIGPIPE issue.
-METRICS_PRESTOP="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
-HEIGHT_PRESTOP="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS_PRESTOP}")"
+# the manifest records the height the snapshot corresponds to.
+#
+# Source preference: chain RPC (`/v1/ledger/slots/latest .number`)
+# over the Prometheus metrics gauge (`ligate_block_height`). The RPC
+# returns the real head height as soon as the HTTP server is up,
+# while the metrics gauge isn't populated until the chain replays
+# enough state to set it — observed empty for ~2 min after a
+# cold-backup-induced restart on 2026-05-17 04:00 UTC, which made
+# the manifest record "unknown" even though the chain was healthy.
+# RPC fallback to metrics, fallback to "unknown".
+HEIGHT_PRESTOP="$(curl -sf http://127.0.0.1:12346/v1/ledger/slots/latest 2>/dev/null \
+                    | jq -r '.number // empty' 2>/dev/null)"
+if [ -z "${HEIGHT_PRESTOP}" ]; then
+    METRICS_PRESTOP="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
+    HEIGHT_PRESTOP="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS_PRESTOP}")"
+fi
 
 # Hot vs cold snapshot semantics:
 #
@@ -156,8 +164,15 @@ HEIGHT_FILE="${LOCAL_SNAPSHOT}/.snapshot-manifest.json"
 if [ -n "${HEIGHT_PRESTOP}" ]; then
     HEIGHT="${HEIGHT_PRESTOP}"
 else
-    METRICS="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
-    HEIGHT="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS}")"
+    # Same source preference as the pre-stop capture: RPC over
+    # metrics gauge. Chain is back up by now (post-rsync, post-cold
+    # restart in the cold path; never stopped in the hot path).
+    HEIGHT="$(curl -sf http://127.0.0.1:12346/v1/ledger/slots/latest 2>/dev/null \
+                | jq -r '.number // empty' 2>/dev/null)"
+    if [ -z "${HEIGHT}" ]; then
+        METRICS="$(curl -sf http://127.0.0.1:9100/metrics 2>/dev/null || true)"
+        HEIGHT="$(awk '/^ligate_block_height /{print $2; exit}' <<< "${METRICS}")"
+    fi
     [ -z "${HEIGHT}" ] && HEIGHT="unknown"
 fi
 {

--- a/scripts/backup-rocksdb.sh
+++ b/scripts/backup-rocksdb.sh
@@ -10,7 +10,7 @@
 #   1. Take a consistent point-in-time snapshot of the storage
 #      directory by `rsync --link-dest` against the previous local
 #      snapshot. Cheap (hardlinks unchanged files) and atomic enough
-#      for our purposes — ligate-node uses RocksDB's WAL so partial
+#      for our purposes: ligate-node uses RocksDB's WAL so partial
 #      writes don't corrupt the on-disk state.
 #   2. Upload the snapshot dir to `gs://$GCS_BUCKET/<host>/<timestamp>/`
 #      via `gcloud storage cp -r`. Idempotent on re-runs.
@@ -29,7 +29,7 @@ set -euo pipefail
 : "${GCS_BUCKET:?GCS_BUCKET must be set (e.g. ligate-devnet-1-backups)}"
 : "${HOSTNAME:=$(hostname -s)}"
 
-# Snapshot tag — hour for routine runs, day for the daily-keep tier,
+# Snapshot tag: hour for routine runs, day for the daily-keep tier,
 # week for the weekly-keep tier. Daily and weekly tiers are written
 # by the same script on its respective trigger (the systemd timer
 # config lives in `ops/backup/systemd/`).
@@ -61,7 +61,7 @@ PREVIOUS_SNAPSHOT="$(ls -dt "${LIGATE_SNAPSHOT_DIR}/${TIER}"/* 2>/dev/null | hea
 # over the Prometheus metrics gauge (`ligate_block_height`). The RPC
 # returns the real head height as soon as the HTTP server is up,
 # while the metrics gauge isn't populated until the chain replays
-# enough state to set it — observed empty for ~2 min after a
+# enough state to set it. Observed empty for ~2 min after a
 # cold-backup-induced restart on 2026-05-17 04:00 UTC, which made
 # the manifest record "unknown" even though the chain was healthy.
 # RPC fallback to metrics, fallback to "unknown".
@@ -74,7 +74,7 @@ fi
 
 # Hot vs cold snapshot semantics:
 #
-# rsync of a live RocksDB+NOMT directory is best-effort — NOMT files
+# rsync of a live RocksDB+NOMT directory is best-effort: NOMT files
 # (bbn, ht, ln, meta, wal in user_nomt_db / kernel_nomt_db) can be
 # caught mid-write, producing a snapshot that triggers
 # `assertion failed: pn.0 < max_pn` in nomt-1.0.3's free-list
@@ -87,7 +87,7 @@ fi
 # rsync, restart. ~30-60s pause on a healthy state DB; runs at
 # off-peak hours per the timers (03:30 / 04:00 UTC).
 #
-# Hourly tier stays HOT (no pause) — best-effort, frequent, useful
+# Hourly tier stays HOT (no pause): best-effort, frequent, useful
 # for "last 6 hours" rollback if the chain itself didn't survive a
 # rough event. Restore is best-effort; the last clean cold daily
 # snapshot is always available as fallback.
@@ -111,7 +111,7 @@ if [ "$COLD" = "true" ]; then
     #
     # 2. systemd auto-restart from `Restart=on-failure`: a bare
     #    `systemctl kill` makes systemd see the process exit as a
-    #    failure and restart ligate-node automatically — the rsync
+    #    failure and restart ligate-node automatically: the rsync
     #    then runs against a LIVE chain again, defeating the cold
     #    snapshot. Using `systemctl stop --no-block` tells systemd
     #    "we are intentionally stopping, don't restart", then we


### PR DESCRIPTION
Two bugs surfaced when the first scheduled daily backup fired at 03:30 UTC tonight. Fixed both, verified live with ~32s total chain downtime (was 5.5 min).

## Bug 1: ligate-node doesn't exit on SIGTERM, hits TimeoutStopSec=300

When the cold daily backup ran at 03:30:00 UTC, ligate-node logged its full graceful-shutdown sequence within 265ms:

```
03:30:00.703  SIGTERM received
03:30:00.703  BlobSender: Shutting down task (x4)
03:30:00.724  Runner main loop completed
03:30:00.928  STF Runner has completed execution
03:30:00.964  Metrics task completed
03:30:00.968  DA finalized header provider stopped
              ↓ 5 MINUTES OF SILENCE ↓
03:35:00      systemd: TimeoutStopSec hit → SIGKILL
03:35:26      chain restart, normal startup, chain_hash unchanged
```

The chain's shutdown handlers complete almost instantly, but **the process itself doesn't exit**. Some upstream Sovereign SDK background task (most likely the Risc0 prover, RocksDB compaction, or a stuck tokio task) doesn't release the runtime. Result: every cold backup eats the full `TimeoutStopSec=300` + restart time = ~5.5 min of chain unavailability.

**SIGKILL is safe in practice**: RocksDB's WAL + the chain's startup recovery handle it cleanly (verified across multiple forced-kill events today; chain_hash unchanged). So escalate to SIGKILL after a short SIGTERM grace window instead of waiting the full TimeoutStopSec.

## Bug 2: `systemctl kill` triggers `Restart=on-failure` → rsync runs against LIVE chain

First fix attempt used `systemctl kill --signal=SIGTERM` directly. That made systemd treat the resulting process exit as a failure, and the unit's `Restart=on-failure` rule **auto-restarted ligate-node ~11s after the kill**, before the rsync ran. The rsync then captured 30+ seconds of writes from the live restarted chain (same NOMT mid-write inconsistency the cold mode was trying to avoid).

**Fix**: use `systemctl stop --no-block` first. This signals systemd "we are intentionally stopping this unit", so `Restart=on-failure` is suppressed because the stop wasn't a failure, it was requested. Then escalate to SIGKILL after the grace window. systemd transitions the unit to inactive/failed and stays there until we explicitly start it again.

## Verification (live)

Deployed to prod and ran two consecutive cold daily backups. Second one (after both fixes):

```
03:57:54  Cold snapshot pause initiated
03:57:54  Stopping ligate-node.service (--no-block)
03:57:54  Runner main loop completed (chain's graceful logs)
03:57:54  STF Runner completed
03:57:57  SIGKILL sent (script escalation after 3s)
03:57:57  systemd: process killed, transition to inactive (NO auto-restart)
03:57:57  ligate-node stopped (state=failed)
          ↓ rsync runs against quiescent storage ↓
03:58:23  systemctl start ligate-node
03:58:23  Started ligate-node.service
03:58:26  HTTP server back up

Total chain downtime: 32 seconds (was 5.5 min)
chain_hash: unchanged
Manifest: {"block_height": "23015", ...}  (clean single integer per #368)
```

## Sudoers updated

`/etc/sudoers.d/ligate-backup` extended to allow the new commands (sudo matches by exact arg list, so `stop --no-block` needs its own rule alongside `stop`). New scope:

```
ligate ALL=(root) NOPASSWD:
  /usr/bin/systemctl start ligate-node.service,
  /usr/bin/systemctl stop ligate-node.service,
  /usr/bin/systemctl stop --no-block ligate-node.service,
  /usr/bin/systemctl kill ligate-node.service,
  /usr/bin/systemctl kill --signal=SIGTERM ligate-node.service,
  /usr/bin/systemctl kill --signal=SIGKILL ligate-node.service
```

Same narrow scope: only the systemctl commands needed, only on ligate-node.service.

## Followup

- The underlying Sovereign SDK shutdown hang is still real and should be fixed upstream. Filed under chain#359 followups.
- TimeoutStopSec=300 on the unit is now somewhat moot (the script kills well before that), but kept for safety in non-backup-initiated stop paths.

## Test plan

- [ ] Next scheduled daily fire (03:30 UTC) completes with <60s chain downtime
- [ ] `chain_hash` unchanged after the next daily backup
- [ ] Manifest's `block_height` is a clean integer
- [ ] No auto-restart entry in journal between SIGKILL and the script's explicit `systemctl start`