### PR TITLE
ops(caddy): rewrite /openapi-v3.json to /v1/openapi-v3.json (swagger UI bundle hardcodes wrong path)

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -288,6 +288,18 @@ rpc.ligate.io {
         reverse_proxy 127.0.0.1:12346
     }
 
+    # Swagger UI hot-fix: the bundled swagger-initializer.js hardcodes
+    # `url: "/openapi-v3.json"` (absolute, no /v1/ prefix). The spec
+    # actually lives at /v1/openapi-v3.json (the chain mounts
+    # everything under /v1). Rewrite the request internally so the
+    # browser request succeeds without touching the chain binary.
+    # Drop this block once the upstream swagger-ui config in
+    # Sovereign SDK points at the right path.
+    handle /openapi-v3.json {
+        rewrite * /v1/openapi-v3.json
+        reverse_proxy 127.0.0.1:12346
+    }
+
     # Block the Prometheus surface from being public.
     # Operators scrape it from inside the VPC over 9100.
     handle /metrics {
@@ -295,6 +307,8 @@ rpc.ligate.io {
     }
 }
 ```
+
+Production also wraps the above with a `(cloudflare_only)` macro that 403s any request whose source IP isn't in Cloudflare's published edge ranges. See `/etc/caddy/Caddyfile` on `ligate-devnet-1-sequencer` (or the CF-IP list at <https://www.cloudflare.com/ips-v4/>) for the macro. Skip for non-Cloudflare deploys.
 
 Install + enable:
 


### PR DESCRIPTION
Hot-fix for the blank-page swagger UI at `https://rpc.ligate.io/v1/swagger-ui/`. Already deployed live to the production VM via direct Caddyfile edit + `systemctl reload caddy`; this PR captures the change in version control so future operators get it from the runbook.

## Bug

`https://rpc.ligate.io/v1/swagger-ui/` returned the swagger UI HTML shell (200, 734 bytes) but the page rendered blank in browsers. The bundled `swagger-initializer.js` script (part of the swagger-ui static-asset bundle the chain serves via Sovereign SDK) hardcodes:

```js
window.ui = SwaggerUIBundle({
  "dom_id": "#swagger-ui",
  "url": "/openapi-v3.json",   // ← absolute path, NO /v1/ prefix
  ...
});
```

The actual OpenAPI spec lives at `/v1/openapi-v3.json` (the chain mounts its full REST surface under `/v1`). So the browser request to `/openapi-v3.json` 404'd, swagger-ui got no spec, and the page rendered as just an empty `<div id="swagger-ui">`.

## Fix

Add a Caddy `handle` block that internally rewrites `/openapi-v3.json` → `/v1/openapi-v3.json` and reverse-proxies to the chain. The browser's hardcoded URL request now succeeds without modifying the chain binary.

```caddyfile
handle /openapi-v3.json {
    rewrite * /v1/openapi-v3.json
    reverse_proxy 127.0.0.1:12346
}
```

## Verification (live)

After deploying + `systemctl reload caddy`:

```
$ curl -s -o /dev/null -w "HTTP %{http_code}  body=%{size_download}  type=%{content_type}\n" \
       https://rpc.ligate.io/openapi-v3.json
HTTP 200  body=130291  type=application/json

$ diff <(curl -s https://rpc.ligate.io/openapi-v3.json) \
       <(curl -s https://rpc.ligate.io/v1/openapi-v3.json)
# (no output: identical responses)
```

Swagger UI now renders properly in the browser at https://rpc.ligate.io/v1/swagger-ui/

## Why not fix upstream

The proper fix is changing the `swagger-ui` config in the chain's REST mount (Sovereign SDK / utoipa) to point at `/v1/openapi-v3.json`. That's a Sovereign SDK fork PR + chain rebuild + binary swap. Too much disruption for a cosmetic UI fix. The Caddy rewrite is a one-line operator-side hot-fix that costs nothing and can be removed once the upstream config lands.

Filed as a chain#359-style followup: drop this `handle` block once `swagger-ui` config in Sovereign SDK points at the right path.

## Test plan

- [ ] `caddy validate --config /etc/caddy/Caddyfile` passes
- [ ] `curl https://rpc.ligate.io/openapi-v3.json` returns the OpenAPI JSON (130KB)
- [ ] sha256 matches `curl https://rpc.ligate.io/v1/openapi-v3.json`
- [ ] Browser-load https://rpc.ligate.io/v1/swagger-ui/ renders the spec UI (not blank)