### PR TITLE
chore(openapi): override Sovereign defaults with Ligate Chain branding (title/contact/version)

### DIFF
--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -242,13 +242,11 @@ where
         // /v1/swagger-ui/ shows what's actually serving the API.
         let mut spec = self.0.openapi_spec()?;
         use sov_modules_api::prelude::utoipa::openapi::{Contact, Info, License};
-        let mut info = Info::new(
-            "Ligate Chain JSON API",
-            env!("CARGO_PKG_VERSION"),
-        );
+        let mut info = Info::new("Ligate Chain JSON API", env!("CARGO_PKG_VERSION"));
         info.description = Some(
-            "REST API for Ligate Chain — an attestation-native rollup on Celestia. \
-             Mounts the chain's ledger, runtime, and sequencer surfaces under /v1.".to_string(),
+            "REST API for Ligate Chain — the attestation-native rollup. \
+             Mounts the chain's ledger, runtime, and sequencer surfaces under /v1."
+                .to_string(),
         );
         let mut contact = Contact::new();
         contact.name = Some("Ligate Labs".to_string());

--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -244,7 +244,7 @@ where
         use sov_modules_api::prelude::utoipa::openapi::{Contact, Info, License};
         let mut info = Info::new("Ligate Chain JSON API", env!("CARGO_PKG_VERSION"));
         info.description = Some(
-            "REST API for Ligate Chain — the attestation-native rollup. \
+            "REST API for Ligate Chain, the attestation-native rollup. \
              Mounts the chain's ledger, runtime, and sequencer surfaces under /v1."
                 .to_string(),
         );

--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -234,6 +234,29 @@ where
     }
 
     fn openapi_spec(&self) -> Option<sov_modules_api::prelude::utoipa::openapi::OpenApi> {
-        self.0.openapi_spec()
+        // Sovereign SDK's default `openapi_spec()` populates the `info`
+        // block with upstream branding (title "Sovereign SDK Rollup JSON
+        // API", contact info@sovereign.xyz, etc.) and pins the version
+        // string to "0.1.0" regardless of our Cargo.toml. Override the
+        // info section with Ligate Chain identity so the swagger UI at
+        // /v1/swagger-ui/ shows what's actually serving the API.
+        let mut spec = self.0.openapi_spec()?;
+        use sov_modules_api::prelude::utoipa::openapi::{Contact, Info, License};
+        let mut info = Info::new(
+            "Ligate Chain JSON API",
+            env!("CARGO_PKG_VERSION"),
+        );
+        info.description = Some(
+            "REST API for Ligate Chain — an attestation-native rollup on Celestia. \
+             Mounts the chain's ledger, runtime, and sequencer surfaces under /v1.".to_string(),
+        );
+        let mut contact = Contact::new();
+        contact.name = Some("Ligate Labs".to_string());
+        contact.email = Some("hello@ligate.io".to_string());
+        contact.url = Some("https://github.com/ligate-io/ligate-chain".to_string());
+        info.contact = Some(contact);
+        info.license = Some(License::new("Apache-2.0 OR MIT"));
+        spec.info = info;
+        Some(spec)
     }
 }

--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -288,6 +288,18 @@ rpc.ligate.io {
         reverse_proxy 127.0.0.1:12346
     }
 
+    # Swagger UI hot-fix: the bundled swagger-initializer.js hardcodes
+    # `url: "/openapi-v3.json"` (absolute, no /v1/ prefix). The spec
+    # actually lives at /v1/openapi-v3.json (the chain mounts
+    # everything under /v1). Rewrite the request internally so the
+    # browser request succeeds without touching the chain binary.
+    # Drop this block once the upstream swagger-ui config in
+    # Sovereign SDK points at the right path.
+    handle /openapi-v3.json {
+        rewrite * /v1/openapi-v3.json
+        reverse_proxy 127.0.0.1:12346
+    }
+
     # Block the Prometheus surface from being public.
     # Operators scrape it from inside the VPC over 9100.
     handle /metrics {
@@ -295,6 +307,8 @@ rpc.ligate.io {
     }
 }
 ```
+
+Production also wraps the above with a `(cloudflare_only)` macro that 403s any request whose source IP isn't in Cloudflare's published edge ranges. See `/etc/caddy/Caddyfile` on `ligate-devnet-1-sequencer` (or the CF-IP list at <https://www.cloudflare.com/ips-v4/>) for the macro. Skip for non-Cloudflare deploys.
 
 Install + enable:
 


### PR DESCRIPTION
The OpenAPI spec served at `/v1/openapi-v3.json` (and rendered by the Swagger UI at `/v1/swagger-ui/`) currently shows upstream Sovereign SDK identity:

```json
"info": {
  "title": "Sovereign SDK Rollup JSON API",
  "description": "Sovereign SDK Runtime, Ledger and Sequencer JSON API",
  "version": "0.1.0",
  "contact": {
    "name": "Sovereign Labs",
    "email": "info@sovereign.xyz",
    "url": "https://github.com/Sovereign-Labs/sovereign-sdk-wip"
  }
}
```

Bad on three counts:
1. **Branding**: we're Ligate Labs, not Sovereign Labs. Anyone hitting the swagger UI sees the wrong project name.
2. **Contact**: `info@sovereign.xyz` isn't ours; it shouldn't be the public contact for our chain's API.
3. **Version**: hardcoded `"0.1.0"` regardless of `Cargo.toml` (we just shipped `v0.1.2`).

## Fix

Override the `info` block in our `openapi_spec()` impl in `crates/stf/src/runtime.rs`. The base spec from Sovereign's macro-generated `Runtime` is unchanged; only the `info` section gets replaced with Ligate Chain identity + the real `env!("CARGO_PKG_VERSION")` from our workspace:

```rust
let mut info = Info::new("Ligate Chain JSON API", env!("CARGO_PKG_VERSION"));
info.description = Some("REST API for Ligate Chain, the attestation-native rollup. \
                         Mounts the chain's ledger, runtime, and sequencer surfaces under /v1.".to_string());
// contact: Ligate Labs, hello@ligate.io, github.com/ligate-io/ligate-chain
// license: Apache-2.0 OR MIT (matches Cargo.toml workspace.package.license)
```

Description is DA-agnostic per the project's DA-isolation policy (no Celestia name in stf/modules/client-rs/stf-declaration crates).

## Test plan

- [ ] CI green (cargo check / clippy / test / build)
- [ ] After binary swap on prod: `curl https://rpc.ligate.io/openapi-v3.json | jq .info` shows Ligate branding
- [ ] Browser-load `https://rpc.ligate.io/v1/swagger-ui/` renders the header with our title + version

## What this does NOT fix

The Swagger UI page title itself (the HTML `<title>` tag) still says "Swagger UI"; that's hardcoded in the static-asset bundle the chain serves via Sovereign SDK's swagger-ui mount. Fixing that would mean either:
- Replacing the swagger-ui static-asset bundle (intrusive)
- Caddy response-modify on the HTML (hacky)
- An upstream Sovereign SDK PR to allow page-title config

Punting to a followup; not user-facing for API consumers.