### PR TITLE
chore(release): cut v0.1.3 (workspace bump + folded CHANGELOG)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,21 +240,44 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Read the section between `## [Unreleased]` and the next
-          # `## ` heading. That's the bucket of entries this release
-          # represents.
-          awk '
-            /^## \[Unreleased\]/ {capture=1; next}
+          # Find the CHANGELOG section that matches the tag being built
+          # (e.g. tag `v0.1.3` → `## [0.1.3] - YYYY-MM-DD`). Our release
+          # hygiene folds `[Unreleased]` INTO the new version section
+          # BEFORE tagging (Keep-a-Changelog standard), so by tag-push
+          # time `[Unreleased]` is empty and the entries live under the
+          # versioned header. Extract that block.
+          #
+          # If the tag is `v*-rc.N` or some other non-version-named tag
+          # we couldn't classify, fall back to `[Unreleased]` so we
+          # don't ship blank release bodies (the historic bug that
+          # silently shipped v0.1.2 with an empty body).
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+
+          # Try the version-specific section first.
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" {capture=1; next}
             /^## / {if (capture) {capture=0}}
             capture==1 {print}
           ' CHANGELOG.md > release-notes.md
 
-          # If empty, fall back to a one-liner.
-          if ! [[ -s release-notes.md ]]; then
-            echo "_(No changelog entries; see commit history.)_" > release-notes.md
+          # If empty, try `[Unreleased]` (covers RC tags or pre-fold
+          # workflow dispatches).
+          if [[ "$(wc -c < release-notes.md | tr -d ' ')" -le 1 ]]; then
+            awk '
+              /^## \[Unreleased\]/ {capture=1; next}
+              /^## / {if (capture) {capture=0}}
+              capture==1 {print}
+            ' CHANGELOG.md > release-notes.md
           fi
 
-          echo "Release notes preview:"
+          # If STILL empty/whitespace-only, fall back to a one-liner so
+          # the release page never ships a blank body.
+          if [[ "$(wc -c < release-notes.md | tr -d ' ')" -le 1 ]]; then
+            echo "_(No changelog entries found for ${VERSION}; see commit history.)_" > release-notes.md
+          fi
+
+          echo "Release notes preview (${VERSION}):"
           head -40 release-notes.md
 
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Same-day follow-up to v0.1.2. Four PRs: cold-backup downtime fix, swagger UI wir
 ### Fixed
 
 - Swagger UI at `https://rpc.ligate.io/v1/swagger-ui/` previously rendered blank because the bundled `swagger-initializer.js` hardcodes its OpenAPI spec URL as `/openapi-v3.json` (without the `/v1` prefix the chain actually serves it under). Fixed operator-side with a Caddy `handle /openapi-v3.json { rewrite * /v1/openapi-v3.json; reverse_proxy 127.0.0.1:12346 }` block; the chain binary itself doesn't change. Caddyfile snippet codified in `docs/development/public-devnet-deploy.md`. (#376)
+- `.github/workflows/release.yml`: changelog-excerpt step now extracts from the version-specific section (`## [X.Y.Z]`) that matches the tag being built, instead of `## [Unreleased]`. Our release hygiene folds `[Unreleased]` into the new versioned section BEFORE tagging (Keep-a-Changelog standard), which meant the workflow was reading an empty `[Unreleased]` block and silently shipping releases with one-byte bodies (v0.1.2 was the first visible casualty; backfilled manually after the fact). Fallback chain: versioned section → `[Unreleased]` → one-liner placeholder, so future releases never ship blank.
 
 ## [0.1.2] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-17
+
+Same-day follow-up to v0.1.2. Four PRs: cold-backup downtime fix, swagger UI wiring, OpenAPI spec branding override, and a prose-style scrub (em dashes out across the docs landed in v0.1.2). `chain_hash` unchanged; binary swap is in-place.
+
+**State-preservation note.** `attestation.json` / genesis bytes / `chain_hash` all unchanged from `v0.1.2`. Operators deploying this binary keep their RocksDB state intact.
+
+### Changed
+
+- `crates/stf/src/runtime.rs`: `openapi_spec()` now overrides the upstream Sovereign SDK `info` block with Ligate Chain identity. Title becomes `Ligate Chain JSON API`, contact becomes `Ligate Labs <hello@ligate.io>`, version pulls from `env!("CARGO_PKG_VERSION")` (so it tracks the workspace version instead of being hardcoded to `0.1.0`), license set to `Apache-2.0 OR MIT`. Description is DA-agnostic per the project's DA-isolation policy. Visible via `curl https://rpc.ligate.io/v1/openapi-v3.json | jq .info` and on the swagger UI page header. (#377)
+- `scripts/backup-rocksdb.sh`: cold-snapshot path (daily + weekly tiers) now uses `systemctl stop --no-block` followed by SIGKILL escalation after a 3s grace window. Fixes a 5-min cold-backup downtime caused by two stacked bugs: (1) upstream Sovereign SDK shutdown hang where the process logs "shutdown complete" within ~1s but doesn't actually exit, eating `TimeoutStopSec=300`; (2) using bare `systemctl kill` triggered `Restart=on-failure` auto-restart, defeating the cold snapshot by re-starting the chain mid-rsync. Verified live: cold backup downtime dropped from 5.5 min to 32 s. (#375)
+- `scripts/backup-rocksdb.sh`: manifest height capture now prefers the chain RPC (`/v1/ledger/slots/latest`) over the Prometheus metrics gauge (`ligate_block_height`). RPC returns the real head height as soon as the HTTP server is up; the metrics gauge takes ~2 min to populate after a cold-backup restart, which made the post-restore manifest record `"unknown"` even though the chain was healthy. (#375)
+- `ops/backup/sudoers.d/ligate-backup`: extended NOPASSWD rule set to allow `systemctl stop --no-block`, `kill`, `kill --signal=SIGTERM`, `kill --signal=SIGKILL` against `ligate-node.service`. sudo matches by exact arg list, so each escalation variant needs its own rule. Same narrow service scope. (#375)
+- Documentation prose: em dashes replaced with colons / semicolons / parens across CHANGELOG `[0.1.2]` section, `docs/development/public-devnet-deploy.md`, `docs/development/runbooks/backup-restore.md`, `monitoring/grafana/README.md`, `ops/backup/systemd/ligate-backup@.service`, and `scripts/restore-rocksdb.sh`. No semantic shifts. (#378)
+
+### Fixed
+
+- Swagger UI at `https://rpc.ligate.io/v1/swagger-ui/` previously rendered blank because the bundled `swagger-initializer.js` hardcodes its OpenAPI spec URL as `/openapi-v3.json` (without the `/v1` prefix the chain actually serves it under). Fixed operator-side with a Caddy `handle /openapi-v3.json { rewrite * /v1/openapi-v3.json; reverse_proxy 127.0.0.1:12346 }` block; the chain binary itself doesn't change. Caddyfile snippet codified in `docs/development/public-devnet-deploy.md`. (#376)
+
 ## [0.1.2] - 2026-05-17
 
 Launch-eve hardening pass: chain ops infrastructure (backups, monitoring, persistent-disk migration, runbook fixes) plus the workspace version bump that makes the binary self-report its real version (was `0.0.1` regardless of git tag).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]


### PR DESCRIPTION
Same-day follow-up release to v0.1.2. Folds the four ops PRs that landed today:

| PR | Scope |
|---|---|
| #375 | Cold-backup downtime fix: SIGKILL escalation + `stop --no-block` (5.5 min → 32 s) |
| #376 | Swagger UI rewrite (Caddy `/openapi-v3.json` → `/v1/openapi-v3.json`) |
| #377 | OpenAPI spec branding override (Ligate Chain identity, real workspace version) |
| #378 | Em-dash scrub across [0.1.2] CHANGELOG + recently-edited prose |

## Workspace version

`0.1.2` → `0.1.3`. `Cargo.lock` regenerated.

## State preservation

`chain_hash` unchanged from v0.1.2. Operators swap the binary in place; no re-genesis, no RocksDB reset.

## What ships externally

Once the binary is built + swapped on the prod VM:
- `curl https://rpc.ligate.io/v1/info | jq .version` reports `0.1.3`
- `curl https://rpc.ligate.io/v1/openapi-v3.json | jq .info` shows Ligate Chain branding
- Swagger UI at `https://rpc.ligate.io/v1/swagger-ui/` renders the spec with our title + version
- Next scheduled cold daily backup at 03:30 UTC takes <60 s of chain downtime

## Test plan

- [ ] CI green
- [ ] Tag pushed (`v0.1.3`), release workflow builds + publishes the binary
- [ ] `/v1/info` shows `"version": "0.1.3"` after binary swap
- [ ] `/v1/openapi-v3.json` shows Ligate Labs contact (not Sovereign)
- [ ] Swagger UI renders without blank page