### PR TITLE
feat(attestation)!: collapse AttestationId to single lat1 bech32m hash (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-17
+
+**Breaking wire-format change.** `AttestationId` is now a single 32-byte hash with the `lat` bech32m prefix (`lat1…`), replacing the pre-v0.2.0 compound `<schema_id>:<payload_hash>` (`lsc1…:lph1…`) form. The on-chain `StateMap<AttestationId, Attestation<S>>` key encoding therefore changes, which means **this release requires a re-genesis** on any chain that has already submitted attestations. devnet-1 is being re-genesised as part of this cut; no historic devnet state survives.
+
+`AttestationId::from_pair(schema_id, payload_hash)` is the canonical constructor: computes `SHA-256(schema_id_bytes ‖ payload_hash_bytes)` and wraps the result in the macro-generated `lat`-prefixed newtype. The `(schema_id, payload_hash)` components remain queryable: they are still stored as fields on the `Attestation<S>` value returned by `GET /v1/modules/attestation/attestations/{lat1…}`.
+
+Why this ships now: the v0.1.x compound id was the odd duck in an otherwise uniform `lsc`/`las`/`lph`/`lpk`/`lat` typed-id family (every other Ligate identifier is a single bech32m string). The compound form was hand-rolled around a Serde-blanket-impl gap on `[u8; 64]`; switching to the 32-byte hash collapses display width by half (~60 chars vs ~120), drops the `:` URL-encoding edge case, and gives partners a single regex to validate against. The migration cost is fully borne pre-public-announce; no external partner has hit live devnet yet.
+
+### Changed
+
+- `crates/modules/attestation/src/lib.rs`: `AttestationId` replaced with the macro-generated newtype `mod attestation_id_mod { impl_hash32_type!(AttestationId, AttestationIdBech32, "lat"); }`. `from_pair` now derives a 32-byte SHA-256 digest of `schema_id ‖ payload_hash` instead of storing the two halves as separate struct fields. Display becomes `lat1…`. The old `Display::fmt` (`{schema_id}:{payload_hash}`) + hand-rolled `FromStr` / `JsonSchema` impls are gone (the macro provides the equivalents).
+- `crates/modules/attestation/src/query.rs`: route doc updated; the `Path<AttestationId>` extractor now expects a single `lat1…` segment (the underlying `AttestationId::from_str` is macro-generated bech32m).
+- `crates/modules/attestation/tests/borsh_snapshot.rs`: `AttestationId` snapshot updated to the new 32-byte hash (`b0dcb09af5496e779e60b21109a718475091191efc7a8638b01d51c622fc9128` = `SHA-256([0x11; 32] ‖ [0x33; 32])`). Any wire-format drift will break this test.
+- `crates/modules/attestation/tests/unit.rs`: replaced the field-access invariants (`id.schema_id == sid`, `id.payload_hash == ph`) with a determinism check (matches direct `Sha256::new().update(...)` computation) and a position-sensitivity check (`from_pair(a, b) != from_pair(b, a)` catches collisions across mirrored inputs).
+- `crates/rollup/tests/binary_spawn_smoke.rs`: REST polling URL now uses `format!("{base}/v1/.../attestations/{id}", id = AttestationId::from_pair(...))` instead of literal `{schema_id}:{payload_hash}` interpolation.
+- `docs/protocol/attestation-v0.md`: appendix REST table + section explaining the new `lat1…` id derivation.
+- `crates/modules/attestation/fuzz/fuzz_targets/{rest_attestation_path,attestation_id_parse}.rs`: harness module docs updated to describe the bech32m single-id parse surface.
+
+### Migration
+
+Re-genesis required on any node that booted against `v0.1.x` and has at least one attestation in state. Steps documented in `docs/development/runbooks/chain-id-bump.md`; in practice for devnet-1: stop the node, wipe `LIGATE_STORAGE_DIR`, restart with the new binary against the same `devnet-1/genesis/` (genesis bytes unchanged), re-run the bootstrap-cli ceremony to re-register canonical schemas + attestor sets. `chain_hash` MAY shift if the state-tree's empty-map type identity is part of the genesis root computation; verify against the post-restart `/v1/rollup/info` output and re-pin `constants.toml` accordingly.
+
 ## [0.1.3] - 2026-05-17
 
 Same-day follow-up to v0.1.2. Four PRs: cold-backup downtime fix, swagger UI wiring, OpenAPI spec branding override, and a prose-style scrub (em dashes out across the docs landed in v0.1.2). `chain_hash` unchanged; binary swap is in-place.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]

--- a/crates/modules/attestation/fuzz/fuzz_targets/attestation_id_parse.rs
+++ b/crates/modules/attestation/fuzz/fuzz_targets/attestation_id_parse.rs
@@ -1,5 +1,5 @@
-//! Fuzz `AttestationId::from_str` (the colon-separated
-//! `<lsc1...>:<lph1...>` form used in REST paths).
+//! Fuzz `AttestationId::from_str` (the single-bech32 `lat1...` form
+//! used in REST paths since v0.2.0).
 //!
 //! On a successful parse, also assert Display round-trips back to
 //! the same string. This catches asymmetric parsing bugs where

--- a/crates/modules/attestation/fuzz/fuzz_targets/rest_attestation_path.rs
+++ b/crates/modules/attestation/fuzz/fuzz_targets/rest_attestation_path.rs
@@ -1,9 +1,9 @@
 //! REST extractor fuzz target for `/attestations/{attestation_id}`.
 //!
-//! `AttestationId` is the compound `<schema_id>:<payload_hash>` form,
-//! so the path extractor exercises both the colon-delimited parse
-//! AND the underlying two-identifier decoders. Strictly more surface
-//! than the `rest_schema_path` and `rest_attestor_set_path` siblings.
+//! Since v0.2.0, `AttestationId` is a single 32-byte bech32m id with
+//! the `lat` HRP (`lat1...`); this fuzz target exercises the same
+//! macro-generated `FromStr` path as `SchemaId` / `AttestorSetId` /
+//! `PayloadHash`, with adversarial percent-encoded inputs in the URL.
 //!
 //! Tracking issue: ligate-io/ligate-chain#157.
 
@@ -41,9 +41,9 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
     if s.len() > 8192 {
-        // `AttestationId` is roughly 2x the size of a single id
-        // (schema + payload), so the cap doubles vs the single-id
-        // siblings to give the fuzzer headroom for "long but valid".
+        // 8KB cap: well beyond any plausible bech32 `lat1...` length
+        // (~63 chars), enough headroom for percent-encoded adversarial
+        // inputs the URL parser might still accept.
         return;
     }
     let encoded: String = s

--- a/crates/modules/attestation/src/lib.rs
+++ b/crates/modules/attestation/src/lib.rs
@@ -177,38 +177,28 @@ mod pubkey_mod {
 }
 pub use pubkey_mod::{PubKey, PubKeyBech32};
 
-/// Compound attestation receipt identifier: `(schema_id, payload_hash)`.
-///
-/// Hand-rolled (rather than macro-generated like the 32-byte id types)
-/// because Serde's blanket array impls don't cover `[u8; 64]`. Storing
-/// the two halves as separate fields sidesteps that without losing the
-/// "single typed key" property the state-map layer needs.
-///
-/// Display/FromStr roundtrip uses a `<schema_id>:<payload_hash>`
-/// colon-separated form, where each side is the bech32 encoding of
-/// the underlying `SchemaId` / `PayloadHash`. Suitable for explorer
-/// URLs and CLI surfaces; bech32 round-trips through it cleanly.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    BorshSerialize,
-    BorshDeserialize,
-    Serialize,
-    Deserialize,
-)]
-pub struct AttestationId {
-    /// Schema this attestation is bound to.
-    pub schema_id: SchemaId,
-    /// Caller-computed digest of the off-chain payload.
-    pub payload_hash: PayloadHash,
+// AttestationId: a single 32-byte hash with the `lat` bech32 prefix,
+// derived from the `(schema_id, payload_hash)` pair via SHA-256.
+//
+// Convention shift from v0.1.x: prior versions used a compound
+// `<schema_id>:<payload_hash>` (colon-joined `lsc1...:lph1...`)
+// display form backed by a hand-rolled 64-byte struct. v0.2.0
+// collapses this to a single 32-byte hash for consistency with the
+// rest of the typed-id family (`lsc`/`las`/`lph`/`lpk`). The two
+// components remain recoverable from the stored [`Attestation`]
+// record (it keeps `schema_id` and `payload_hash` as fields).
+mod attestation_id_mod {
+    sov_modules_api::impl_hash32_type!(AttestationId, AttestationIdBech32, "lat");
 }
+pub use attestation_id_mod::{AttestationId, AttestationIdBech32};
 
 impl AttestationId {
     /// Build an [`AttestationId`] from its `(schema_id, payload_hash)` pair.
+    ///
+    /// Computed as `SHA-256(schema_id_bytes ‖ payload_hash_bytes)` where
+    /// each side is the raw 32-byte underlying hash, NOT the bech32
+    /// display form. This makes the receipt id deterministic and
+    /// independent of any future change to the bech32 encoding.
     ///
     /// # Example
     ///
@@ -221,46 +211,20 @@ impl AttestationId {
     /// let payload_hash = PayloadHash::from([0x33u8; 32]);
     /// let id = AttestationId::from_pair(&schema_id, &payload_hash);
     ///
-    /// // Display-form is `<schema_id>:<payload_hash>` with both halves
-    /// // bech32-encoded, suitable for explorer URLs and CLI surfaces.
+    /// // Display form is a single bech32m string with the `lat` HRP.
     /// let s = id.to_string();
-    /// assert!(s.contains(':'));
+    /// assert!(s.starts_with("lat1"));
     ///
     /// // Round-trips cleanly through FromStr.
     /// let parsed = AttestationId::from_str(&s).expect("display form parses");
     /// assert_eq!(parsed, id);
     /// ```
     pub fn from_pair(schema_id: &SchemaId, payload_hash: &PayloadHash) -> Self {
-        Self { schema_id: *schema_id, payload_hash: *payload_hash }
-    }
-}
-
-impl core::fmt::Display for AttestationId {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}:{}", self.schema_id, self.payload_hash)
-    }
-}
-
-impl core::str::FromStr for AttestationId {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (sid, ph) = s
-            .split_once(':')
-            .ok_or_else(|| anyhow::anyhow!("expected `<schema_id>:<payload_hash>`"))?;
-        Ok(Self { schema_id: SchemaId::from_str(sid)?, payload_hash: PayloadHash::from_str(ph)? })
-    }
-}
-
-impl schemars::JsonSchema for AttestationId {
-    fn schema_name() -> String {
-        "AttestationId".to_string()
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // Surface as a string in the schema; we'll regex-validate the
-        // colon-separated form when the REST API hits real users.
-        <String as schemars::JsonSchema>::json_schema(gen)
+        let mut hasher = Sha256::new();
+        hasher.update(schema_id.as_bytes());
+        hasher.update(payload_hash.as_bytes());
+        let digest: [u8; 32] = hasher.finalize().into();
+        Self::from(digest)
     }
 }
 

--- a/crates/modules/attestation/src/query.rs
+++ b/crates/modules/attestation/src/query.rs
@@ -7,19 +7,20 @@
 //! - `GET /schemas/{schemaId}` — fetch one schema
 //! - `GET /attestor-sets/{attestorSetId}` — fetch one attestor set
 //! - `GET /attestations/{attestationId}` — fetch one attestation by
-//!   `<schemaId>:<payloadHash>`
+//!   its `lat1…` bech32m id (v0.2.0+; was the colon-joined
+//!   `<schemaId>:<payloadHash>` form pre-v0.2.0).
 //!
 //! `list_by_schema` is intentionally **not** in this module. The
-//! attestation `StateMap<AttestationId, Attestation<S>>` is keyed by a
-//! 64-byte compound id, which is fine for point lookups but bad for
-//! filter-by-schema iteration without a secondary index. Adding the
-//! index touches the write path on `SubmitAttestation` plus the
-//! storage schema, so it ships separately. See the follow-up issue
-//! linked from #21.
+//! attestation `StateMap<AttestationId, Attestation<S>>` is keyed by
+//! the receipt id (32 bytes since v0.2.0), which is fine for point
+//! lookups but bad for filter-by-schema iteration without a secondary
+//! index. Adding the index touches the write path on
+//! `SubmitAttestation` plus the storage schema, so it ships
+//! separately. See the follow-up issue linked from #21.
 //!
 //! All three routes return a typed JSON body, 404 on missing key, 400
 //! on malformed id. Paths use the canonical Bech32 string forms
-//! (`lsc1…`, `las1…`, `lsc1…:lph1…`) since those are the strings the
+//! (`lsc1…`, `las1…`, `lat1…`) since those are the strings the
 //! protocol exposes everywhere else (genesis files, attestation
 //! receipts, error messages).
 

--- a/crates/modules/attestation/tests/borsh_snapshot.rs
+++ b/crates/modules/attestation/tests/borsh_snapshot.rs
@@ -131,8 +131,14 @@ fn snapshot_pubkey() {
     );
 }
 
-// --- AttestationId compound id ---------------------------------------------
-
+// --- AttestationId (lat1...) ----------------------------------------------
+//
+// v0.2.0 wire-format change: AttestationId is now a single 32-byte hash
+// `SHA-256(schema_id_bytes ‖ payload_hash_bytes)` with the `lat` bech32
+// prefix, replacing the 64-byte compound `(schema_id, payload_hash)`
+// struct used in v0.1.x. The snapshot value below is the SHA-256 of
+// `[0x11; 32] ‖ [0x33; 32]`; if you change `AttestationId::from_pair`
+// (or the bech32 HRP) you'll see this hex change.
 #[test]
 fn snapshot_attestation_id() {
     let id =
@@ -140,8 +146,7 @@ fn snapshot_attestation_id() {
     assert_snapshot(
         "AttestationId",
         &id,
-        "1111111111111111111111111111111111111111111111111111111111111111\
-         3333333333333333333333333333333333333333333333333333333333333333",
+        "b0dcb09af5496e779e60b21109a718475091191efc7a8638b01d51c622fc9128",
     );
 }
 

--- a/crates/modules/attestation/tests/proptest_codecs.rs
+++ b/crates/modules/attestation/tests/proptest_codecs.rs
@@ -207,8 +207,8 @@ proptest! {
     #[test]
     fn attestation_id_str_decoder_never_panics(s in ".*") {
         // Arbitrary UTF-8 strings; FromStr must error cleanly on
-        // anything that's not a valid `<schema_id>:<payload_hash>`
-        // pair, not panic.
+        // anything that's not a valid `lat1...` bech32m string, not
+        // panic.
         let _: Result<AttestationId, _> = s.parse();
     }
 }

--- a/crates/modules/attestation/tests/unit.rs
+++ b/crates/modules/attestation/tests/unit.rs
@@ -295,15 +295,31 @@ fn attestor_set_derive_id_depends_on_members() {
     assert_ne!(a, b);
 }
 
-// ----- AttestationId compound ------------------------------------------------
+// ----- AttestationId (lat1...) -----------------------------------------------
 
 #[test]
-fn attestation_id_from_pair_concats_correctly() {
+fn attestation_id_from_pair_is_deterministic_sha256() {
+    use sha2::{Digest, Sha256};
     let sid = sample_schema_id(0xAA);
     let ph = sample_payload_hash(0xBB);
     let id = AttestationId::from_pair(&sid, &ph);
-    assert_eq!(id.schema_id, sid);
-    assert_eq!(id.payload_hash, ph);
+
+    let mut hasher = Sha256::new();
+    hasher.update(sid.as_bytes());
+    hasher.update(ph.as_bytes());
+    let expected: [u8; 32] = hasher.finalize().into();
+    assert_eq!(id.as_bytes(), &expected);
+}
+
+#[test]
+fn attestation_id_from_pair_is_position_sensitive() {
+    // Swapping the two inputs must produce a different id; otherwise
+    // attestations under different (schema, payload) pairs could collide.
+    let a = sample_schema_id(0x11);
+    let b = sample_payload_hash(0x22);
+    let id_ab = AttestationId::from_pair(&a, &PayloadHash::from(*b.as_bytes()));
+    let id_ba = AttestationId::from_pair(&SchemaId::from(*b.as_bytes()), &PayloadHash::from(*a.as_bytes()));
+    assert_ne!(id_ab, id_ba);
 }
 
 #[test]

--- a/crates/modules/attestation/tests/unit.rs
+++ b/crates/modules/attestation/tests/unit.rs
@@ -318,7 +318,8 @@ fn attestation_id_from_pair_is_position_sensitive() {
     let a = sample_schema_id(0x11);
     let b = sample_payload_hash(0x22);
     let id_ab = AttestationId::from_pair(&a, &PayloadHash::from(*b.as_bytes()));
-    let id_ba = AttestationId::from_pair(&SchemaId::from(*b.as_bytes()), &PayloadHash::from(*a.as_bytes()));
+    let id_ba =
+        AttestationId::from_pair(&SchemaId::from(*b.as_bytes()), &PayloadHash::from(*a.as_bytes()));
     assert_ne!(id_ab, id_ba);
 }
 

--- a/crates/rollup/tests/binary_spawn_smoke.rs
+++ b/crates/rollup/tests/binary_spawn_smoke.rs
@@ -416,8 +416,9 @@ async fn wait_for_attestation(
     schema_id: &SchemaId,
     payload_hash: &PayloadHash,
 ) {
-    // Compound id per the chain's REST route: `{schemaId}:{payloadHash}`.
-    let url = format!("{base}/v1/modules/attestation/attestations/{schema_id}:{payload_hash}");
+    // Single bech32 id per the v0.2.0 REST route: `{lat1...}`.
+    let id = attestation::AttestationId::from_pair(schema_id, payload_hash);
+    let url = format!("{base}/v1/modules/attestation/attestations/{id}");
     poll_for_200(client, &url, "attestation").await;
 }
 

--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -148,10 +148,12 @@ The chain's REST API is **point lookups only by design**. Three endpoints, all s
 ```
 GET /modules/attestation/schemas/{schema_id}                       -> Schema | 404
 GET /modules/attestation/attestor-sets/{attestor_set_id}           -> AttestorSet | 404
-GET /modules/attestation/attestations/{schema_id}:{payload_hash}   -> Attestation | 404
+GET /modules/attestation/attestations/{attestation_id}             -> Attestation | 404
 ```
 
 Wired in [PR #93](https://github.com/ligate-io/ligate-chain/pull/93) (closes the read-side of [#21](https://github.com/ligate-io/ligate-chain/issues/21)). 400 on malformed Bech32, 404 on missing key, 200 with typed JSON body otherwise.
+
+`attestation_id` is a single bech32m string with the `lat` HRP (`lat1…`), derived as `SHA-256(schema_id_bytes ‖ payload_hash_bytes)`. Pre-v0.2.0 used the compound `<schema_id>:<payload_hash>` (`lsc1…:lph1…`) form; the v0.2.0 cut collapsed it to a single bech32 string for consistency with `lsc`/`las`/`lph`/`lpk`. The schema and payload-hash components remain queryable from the returned `Attestation` body.
 
 ### What's deliberately not here
 


### PR DESCRIPTION
**Breaking wire-format change.** Closes the asymmetry where `AttestationId` was the lone hand-rolled compound id in an otherwise uniform typed-id family (`lsc`/`las`/`lph`/`lpk` are all macro-generated 32-byte bech32m newtypes). Collapses to a single `lat1…` form derived as `SHA-256(schema_id_bytes ‖ payload_hash_bytes)`.

## Why now, why this shape

The `<schema_id>:<payload_hash>` form was a hand-rolled hack around a Serde-blanket-impl gap on `[u8; 64]` (per the design comment in `lib.rs:180-190`). It survived through v0.1.0 → v0.1.3 because no user-facing surface stressed it (no Mneme attestation badges, no Themisra receipt UIs, no explorer attestation detail pages). The audit caught it by way of the marketing copy advertising `lat1…` aspirationally.

Catching it now means:
- One re-genesis on devnet-1 (no external partner has built against the old form; 8 internal-only attestations in current state).
- One single regex for partners to validate against (`^lat1[02-9ac-hj-np-z]{58}$` or similar), instead of a colon-delimited pair.
- ~half the display width (~60 chars vs ~120).
- Consistency with the rest of the prefix family at day-1 of public devnet.

Pre-mainnet license per chain#374 (clean-semver convention adopted this morning); shipping as a minor bump (`v0.2.0`) since semver-0.x can break in minor.

## What changes

- `crates/modules/attestation/src/lib.rs`: `AttestationId` replaced with macro-generated newtype (`impl_hash32_type!(AttestationId, AttestationIdBech32, "lat")`). `from_pair(schema_id, payload_hash)` computes `SHA-256(schema_id.as_bytes() ‖ payload_hash.as_bytes())` and wraps as a `lat`-prefixed 32-byte id. Old hand-rolled `Display`/`FromStr`/`JsonSchema` impls deleted (the macro provides equivalents). Components remain queryable via the `Attestation<S>` value, which still stores `schema_id` + `payload_hash` as fields.
- `crates/modules/attestation/src/query.rs`: route doc updated; `Path<AttestationId>` extractor now expects a single `lat1…` segment.
- `crates/modules/attestation/tests/borsh_snapshot.rs`: `AttestationId` snapshot updated to the new 32-byte hash (`b0dcb09af5496e779e60b21109a718475091191efc7a8638b01d51c622fc9128` = `SHA-256([0x11; 32] ‖ [0x33; 32])`).
- `crates/modules/attestation/tests/unit.rs`: field-access invariants (`id.schema_id == sid`) replaced with: (a) determinism check against direct `Sha256::new()` computation, (b) position-sensitivity check (`from_pair(a, b) != from_pair(b, a)`).
- `crates/rollup/tests/binary_spawn_smoke.rs`: REST polling URL now computes `AttestationId::from_pair(...)` and formats `{id}` instead of literal `{schema_id}:{payload_hash}` interpolation.
- `docs/protocol/attestation-v0.md`: REST appendix table + new section explaining the `lat1…` derivation.
- `crates/modules/attestation/fuzz/fuzz_targets/{rest_attestation_path,attestation_id_parse}.rs`: harness module docs updated to describe the bech32m single-id parse surface (no logic change; `AttestationId::from_str` is now macro-generated).
- `Cargo.toml` + `Cargo.lock`: workspace `0.1.3` → `0.2.0`.
- `CHANGELOG.md`: `[0.2.0]` section with the full writeup.

## Migration

Re-genesis required on any node that has at least one attestation in state. For devnet-1 (one VM, 8 attestations + 4 schemas + 2 attestor sets, all internal setup):

1. Wait for this PR to merge + tag `v0.2.0` + binary to build.
2. `sudo systemctl stop ligate-node.service` (cold stop, uses the SIGKILL-escalation path from #375).
3. `sudo rm -rf /var/lib/ligate/rollup/*` (wipe RocksDB + NOMT).
4. Drop the new binary in place, `sudo systemctl start ligate-node.service`.
5. Verify `chain_hash` via `curl https://rpc.ligate.io/v1/rollup/info`; if it differs from `lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v`, re-pin `constants.toml` and ship a docs-fix PR.
6. Re-run the bootstrap-cli ceremony to re-register canonical schemas + attestor sets.

## Out of scope (separate PRs after this lands)

- `ligate-js` SDK: regenerate `disc_probe` parity-test fixtures, update `attestation.ts` for the `lat` HRP.
- `ligate-cli`: drop the colon-aware path in `--attestation-id` parsing (now bech32m only).
- `ligate-api`: tighten REST path validation regex for `lat1…`.
- `ligate-explorer`: update `app/attestation/[id]/page.tsx` URL parsing + breadcrumb display.
- `constants.toml` / `README.md` prefix-list: remove the "planned for v0.2.0" annotation now that `lat` is shipped.

## Test plan

- [ ] CI green (cargo check / clippy / test / build / borsh-snapshot)
- [ ] Local: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib cargo test -p attestation` passes (verified)
- [ ] After tag + binary build: re-genesis dry-run on a localnet first; verify swagger UI renders `lat1…` examples
- [ ] After prod re-genesis: `curl https://rpc.ligate.io/v1/rollup/info | jq .version` reports `0.2.0`