### PR TITLE
chore(docs): repin chain_hash + version after v0.2.0 re-genesis (PLACEHOLDER)

### DIFF
--- a/docs/development/quickstart-partner.md
+++ b/docs/development/quickstart-partner.md
@@ -40,8 +40,8 @@ Verify the binary speaks to the public devnet:
 ```bash
 $ ligate --rpc https://rpc.ligate.io info
 chain_id:   ligate-devnet-1
-chain_hash: lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v
-version:    0.1.3
+chain_hash: __NEW_CHAIN_HASH_PENDING_REGENESIS__
+version:    0.2.0
 ```
 
 Set `LIGATE_RPC=https://rpc.ligate.io` in your shell so subsequent commands don't need `--rpc`.


### PR DESCRIPTION
**DRAFT — placeholder PR. Don't merge until the placeholder is replaced with the real post-re-genesis chain_hash.**

## Why this PR exists

v0.2.0 (chain#381) ships the `lat1` AttestationId wire-format change. The associated re-genesis on devnet-1 MAY shift the chain_hash (depends on whether the state-tree empty-map type identity participates in the genesis root computation). This PR pre-stages the docs update so we can ship it with one push after the new hash is captured from `/v1/rollup/info`.

## Replace-and-ship workflow (post-re-genesis)

```bash
NEW_HASH=$(curl -sf https://rpc.ligate.io/v1/rollup/info | jq -r .chain_hash)
echo "New chain_hash: ${NEW_HASH}"

# If different from the old hash (lsch1amq80arn…heqe5c70v), apply:
cd /Users/stefdev/Desktop/ligate-chain
git checkout chore/repin-chain-hash-v0.2.0
sed -i.bak "s|__NEW_CHAIN_HASH_PENDING_REGENESIS__|${NEW_HASH}|g" docs/development/quickstart-partner.md
rm docs/development/quickstart-partner.md.bak
git add -u
git commit --amend --no-edit
git push --force-with-lease
gh pr ready 382 --repo ligate-io/ligate-chain   # adjust PR # if different
```

If chain_hash is UNCHANGED, close this PR without merging (delete the branch).

## Scope

One file: `docs/development/quickstart-partner.md`. The chain has no source-pinned `chain_hash` (`constants.toml`'s `CHAIN_HASH_OVERRIDES` is empty by design; the value is computed at boot). So this is a pure docs/copy update.

## Test plan

- [ ] Placeholder replaced with the real new chain_hash
- [ ] PR marked ready (no longer draft)
- [ ] CI green