### PR TITLE
ops(alerts): wire chain alerts to Discord via Grafana Cloud contact point (chain#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+### Added
+
+- `docs/development/runbooks/alerts/discord-setup.md`: paste-and-go wiring for chain alerts to the `#chain-alerts` channel in the Ligate Labs Discord via Grafana Cloud Alerting's native Discord contact point. Covers the webhook creation flow, the Grafana Cloud contact-point + notification-policy setup, the rule-import path from `ops/prometheus/alerts.yaml` (worked example for `BlockHeightStall`), a `curl` smoke test against the webhook, and a `systemctl stop ligate-node` end-to-end test that exercises the full Prometheus rule → Grafana contact point → Discord path. Page-severity alerts fire `@here` mentions; warn-severity is channel-only. Documents the `alertmanager-discord` bridge sidecar as the fallback path for operators running their own Alertmanager (followers, third-party partners). Tracks [#268](https://github.com/ligate-io/ligate-chain/issues/268).
+
+### Changed
+
+- `ops/prometheus/alertmanager.yaml`: adds a Discord receiver via `webhook_configs` pointing at the `alertmanager-discord` bridge sidecar (`http://127.0.0.1:9094/`), wired into both the `default` and `info-only` receivers so Discord posts ride alongside the existing Slack posts. Slack + email receivers retained as alternates; no behaviour change for operators not running the bridge. Header comment now flags the file as the SELF-HOSTED FALLBACK path and points readers at `discord-setup.md` for the canonical Grafana Cloud route.
+- `docs/development/runbooks/alerts/README.md`: notification-wiring section now points at `discord-setup.md`; per-alert table extended with the three TIA alerts (`TIABalanceLow`, `TIABalanceCritical`, `TIADrawdownSpike`) that were already in `alerts.yaml` but missing from the table; deploy section split into Grafana Cloud (canonical) and self-hosted Alertmanager (fallback) tracks. Each per-alert runbook header now links to `discord-setup.md` and notes whether the alert mentions `@here`.
+
 ## [0.2.0] - 2026-05-17
 
 **Breaking wire-format change.** `AttestationId` is now a single 32-byte hash with the `lat` bech32m prefix (`lat1…`), replacing the pre-v0.2.0 compound `<schema_id>:<payload_hash>` (`lsc1…:lph1…`) form. The on-chain `StateMap<AttestationId, Attestation<S>>` key encoding therefore changes, which means **this release requires a re-genesis** on any chain that has already submitted attestations. devnet-1 is being re-genesised as part of this cut; no historic devnet state survives.

--- a/docs/development/runbooks/alerts/README.md
+++ b/docs/development/runbooks/alerts/README.md
@@ -11,7 +11,7 @@ One file per Prometheus alert defined in [`ops/prometheus/alerts.yaml`](../../..
 6. Escalation      — when + how to wake someone up
 ```
 
-The `runbook_url` annotation on each alert points the on-call at the right file via the firing Slack/email notification.
+The `runbook_url` annotation on each alert points the on-call at the right file via the firing Discord / Slack / email notification.
 
 ## Alert catalog
 
@@ -24,16 +24,28 @@ The `runbook_url` annotation on each alert points the on-call at the right file 
 | `DiskFillingFast` | warn | [`disk-filling-fast.md`](./disk-filling-fast.md) |
 | `DASubmissionFailures` | page | [`da-submission-failures.md`](./da-submission-failures.md) |
 | `DAFinalizationLatencyHigh` | warn | [`da-finalization-latency-high.md`](./da-finalization-latency-high.md) |
+| `TIABalanceLow` | warn | (covered in [`da-signer-rotation.md`](../da-signer-rotation.md#tia-balance-monitoring)) |
+| `TIABalanceCritical` | page | (covered in [`da-signer-rotation.md`](../da-signer-rotation.md#tia-balance-monitoring)) |
+| `TIADrawdownSpike` | warn | (covered in [`cost-monitoring.md`](../../cost-monitoring.md)) |
+
+## Notification wiring
+
+How firings reach an operator is documented in [`discord-setup.md`](./discord-setup.md): the canonical path is Grafana Cloud Alerting → native Discord contact point → `#chain-alerts` in the Ligate Labs Discord. Page-severity alerts get an `@here` mention; warn-severity is channel-only. For self-hosted Alertmanager deploys (followers, third-party partners), [`discord-setup.md`](./discord-setup.md#self-hosted-alertmanager-fallback) covers the `alertmanager-discord` bridge pattern that pairs with `ops/prometheus/alertmanager.yaml`.
 
 ## On-call rota (pre-devnet)
 
-Stefan is the single point of contact. Phone + email always reachable. Slack channel `#devnet-ops` is the primary incident surface. Mainnet rota expansion deferred until a second operator exists.
+Stefan is the single point of contact. Phone + email always reachable. Discord channel `#chain-alerts` is the primary incident surface; `#devnet-ops` Slack stays in the routing tree as a secondary surface. Mainnet rota expansion deferred until a second operator exists.
 
 ## Deploying these rules + receivers
 
-1. Render `ops/prometheus/alertmanager.yaml` with the secrets (Slack webhook, SMTP password) injected at the file paths the config expects. The repo's copy is the template; the deployed copy is the rendered version.
+Canonical path (Grafana Cloud): follow [`discord-setup.md`](./discord-setup.md) Steps 1-4 to wire the webhook, contact point, notification policy, and import the rules from `ops/prometheus/alerts.yaml`. Step 5 covers end-to-end test fire.
+
+Self-hosted fallback (own Prometheus + Alertmanager stack):
+
+1. Render `ops/prometheus/alertmanager.yaml` with the secrets (Slack webhook, SMTP password, Discord bridge URL) injected at the file paths the config expects. The repo's copy is the template; the deployed copy is the rendered version.
 2. Set `--config.file=alerts.yaml` on the Prometheus server (or include via `rule_files:` in the main config).
 3. Set `--config.file=alertmanager.yaml` on the Alertmanager.
-4. Confirm Prometheus's `Alerts` tab lists each rule + shows `Inactive`. Then test the wiring by killing `ligate-node` and confirming `HealthDown` fires within 90s + the Slack notification arrives.
+4. If routing to Discord, stand up the `alertmanager-discord` bridge sidecar with `DISCORD_WEBHOOK=$DISCORD_ALERTS_WEBHOOK_URL` per [`discord-setup.md` §Self-hosted Alertmanager fallback](./discord-setup.md#self-hosted-alertmanager-fallback).
+5. Confirm Prometheus's `Alerts` tab lists each rule + shows `Inactive`. Then test the wiring by killing `ligate-node` and confirming `HealthDown` fires within 90s + the Discord notification arrives.
 
 The actual deploy of Prometheus + Alertmanager lives outside this repo (operator's monitoring stack, e.g. on the same GCP VM as `ligate-node` or on a separate ops VM). [`public-devnet-deploy.md`](../../public-devnet-deploy.md) covers the broader monitoring story.

--- a/docs/development/runbooks/alerts/block-height-stall.md
+++ b/docs/development/runbooks/alerts/block-height-stall.md
@@ -1,6 +1,6 @@
 # `BlockHeightStall`
 
-**Severity: page**
+**Severity: page** (page-severity alerts post to `#chain-alerts` with an `@here` mention; wiring details in [`discord-setup.md`](./discord-setup.md))
 
 ## What fired
 

--- a/docs/development/runbooks/alerts/da-finalization-latency-high.md
+++ b/docs/development/runbooks/alerts/da-finalization-latency-high.md
@@ -1,6 +1,6 @@
 # `DAFinalizationLatencyHigh`
 
-**Severity: warn**
+**Severity: warn** (warn-severity alerts post to `#chain-alerts` without a mention; wiring details in [`discord-setup.md`](./discord-setup.md))
 
 ## What fired
 

--- a/docs/development/runbooks/alerts/da-submission-failures.md
+++ b/docs/development/runbooks/alerts/da-submission-failures.md
@@ -1,6 +1,6 @@
 # `DASubmissionFailures`
 
-**Severity: page**
+**Severity: page** (page-severity alerts post to `#chain-alerts` with an `@here` mention; wiring details in [`discord-setup.md`](./discord-setup.md))
 
 ## What fired
 

--- a/docs/development/runbooks/alerts/discord-setup.md
+++ b/docs/development/runbooks/alerts/discord-setup.md
@@ -1,0 +1,157 @@
+# Discord alert wiring
+
+How to wire `ops/prometheus/alerts.yaml` firings into the Ligate Labs Discord (`#chain-alerts`) via Grafana Cloud's native Discord contact point. This is the canonical path for the public devnet operator; the self-hosted Alertmanager flow at `ops/prometheus/alertmanager.yaml` stays in the repo as a fallback (see [§Self-hosted Alertmanager fallback](#self-hosted-alertmanager-fallback)).
+
+Tracking issue: [#268](https://github.com/ligate-io/ligate-chain/issues/268).
+
+## Why Discord
+
+Pre-mainnet, we are not paying for PagerDuty. The Ligate Labs Discord (permanent invite `https://discord.gg/ZWUeJ8k3eP`) is already where the team hangs out; the same surface gets partner DMs, devnet status posts, and now ops alerts. A Discord webhook is free, has no per-seat cost, and Grafana Cloud Alerting ships a native Discord contact point so we do not need to run a bridge process. Mainnet escalation (PagerDuty rotas, severity-specific paging policies) is future work; this wiring keeps the same `severity=page|warn|info` labels so the routing rules carry forward.
+
+The chain VM already pushes metrics to Grafana Cloud via `/etc/alloy/config.alloy`'s `prometheus.remote_write "grafana_cloud"`; alert evaluation happens Grafana-side, which is why we do not currently run our own Alertmanager (the in-repo `ops/prometheus/alertmanager.yaml` is documentation + fallback only).
+
+## Step 1: Create the webhook in Discord
+
+In the Ligate Labs Discord server:
+
+1. Server Settings (top of the server list, the down-arrow next to the server name).
+2. Integrations (left sidebar).
+3. Webhooks (panel on the right) → New Webhook.
+4. Name: `chain-alerts`.
+5. Channel: `#chain-alerts`. If the channel does not exist yet, create it first (Server Settings → cancel back to the server, right-click in the channel list → Create Channel → Text → `chain-alerts` → Create; private to the `@chain-ops` role if you want operator-only visibility, public otherwise).
+6. Copy Webhook URL. You will not see it again without clicking "Copy" on the webhook entry; rotate it via "Reset" if it leaks.
+7. Store at `~/.config/ligate/secrets.env`:
+
+   ```sh
+   DISCORD_ALERTS_WEBHOOK_URL=https://discord.com/api/webhooks/<id>/<token>
+   ```
+
+   `chmod 600 ~/.config/ligate/secrets.env`. Never paste the URL into chat, a Slack message, or a PR description; the URL itself is the credential.
+
+## Step 2: Grafana Cloud contact point
+
+Grafana Cloud Alerting ships a native Discord contact point; no bridge process needed.
+
+1. Grafana Cloud → Alerting (bell icon in the left sidebar) → Contact points.
+2. + Add contact point.
+3. Name: `discord-chain-alerts`.
+4. Integration: Discord.
+5. Webhook URL: paste from `DISCORD_ALERTS_WEBHOOK_URL` (Step 1).
+6. Message template (optional but recommended; pastes inline rather than using a separate template file):
+
+   ```
+   **{{ .CommonLabels.alertname }}** ({{ .CommonLabels.severity }})
+
+   {{ range .Alerts }}
+   - Instance: `{{ .Labels.instance }}`
+   - Summary: {{ .Annotations.summary }}
+   - Runbook: {{ .Annotations.runbook_url }}
+   {{ end }}
+   ```
+
+7. Avatar URL (optional): point at the Ligate mark on the marketing site, e.g. `https://ligate.io/og-default.png`.
+8. Save contact point → Test (sends a synthetic firing alert to the channel; if `#chain-alerts` does not receive it within ~10s, re-check the webhook URL).
+
+## Step 3: Notification policy
+
+Three severity tiers map to three notification behaviours:
+
+1. Grafana Cloud → Alerting → Notification policies.
+2. + New nested policy.
+3. **`severity=page` policy** (operator must look):
+   - Matching labels: `severity = page`
+   - Contact point: `discord-chain-alerts`
+   - Override grouping: by `alertname, instance` (matches `alertmanager.yaml`'s `group_by`).
+   - Override timings: group wait 30s, group interval 5m, repeat interval 4h.
+   - Mute timings: none.
+   - **Mention**: under "Override message template" or the contact-point-level template, add `@here` to the prefix. Grafana's Discord integration sends the template body as the message content, so `@here` in the template body resolves correctly in the channel.
+4. **`severity=warn` policy** (business-hours):
+   - Matching labels: `severity = warn`
+   - Same contact point, same grouping.
+   - No `@here` mention; just the alert body.
+   - Repeat interval 4h.
+5. **`severity=info` policy** (channel-only):
+   - Matching labels: `severity = info`
+   - Same contact point.
+   - No mention.
+   - "Send resolved" toggled OFF (skip the auto-resolve "OK" message; info-tier does not need closure noise).
+
+## Step 4: Import alert rules from `ops/prometheus/alerts.yaml`
+
+Grafana Cloud's alert rules editor accepts Prometheus-format expressions directly; the rules in `ops/prometheus/alerts.yaml` paste in as-is. The `runbook_url` annotation flows through to the Discord message via the template above.
+
+Walkthrough for `BlockHeightStall` (the cheapest one to verify against; the others follow the same shape):
+
+1. Alerting → Alert rules → + New alert rule.
+2. Rule name: `BlockHeightStall`.
+3. Rule type: Grafana-managed alert (the rules-section UI; not the data-source-managed one).
+4. Define query → Data source: `grafanacloud-ligate-prom` (the Prometheus instance the chain VM remote-writes to).
+5. Expression (paste from `ops/prometheus/alerts.yaml`):
+
+   ```promql
+   changes(ligate_block_height[2m]) == 0
+   and on(instance) (ligate_block_height > 0)
+   ```
+
+6. Condition: `WHEN last() OF A IS ABOVE 0` (Grafana wraps the PromQL output in an `A` reference; threshold > 0 means "the expression returned at least one series", which is how Grafana models the Prometheus "the rule is firing" boolean).
+7. Folder: `Ligate Chain alerts` (create if missing). Evaluation group: `ligate-node.liveness` (mirror the group names from `alerts.yaml`). Evaluation interval: 30s. Pending period: 60s (matches the rule's `for: 60s`).
+8. Annotations:
+   - `summary`: `Block height unchanged for 60s on {{ $labels.instance }}`
+   - `description`: paste the multi-line description from `alerts.yaml`.
+   - `runbook_url`: `https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/alerts/block-height-stall.md`
+9. Labels:
+   - `severity = page`
+   - `component = chain`
+10. Save rule.
+
+Repeat for the remaining nine rules. The full set, with severities and per-rule runbook paths, is in [§What gets paged vs channel-only](#what-gets-paged-vs-channel-only) below.
+
+## Step 5: Test fire
+
+Synthetic fire to confirm the webhook → channel path (does NOT exercise the Grafana evaluation pipeline; this is the smoke test on the last hop):
+
+```sh
+source ~/.config/ligate/secrets.env
+curl -X POST "$DISCORD_ALERTS_WEBHOOK_URL" \
+  -H 'Content-Type: application/json' \
+  -d '{"content":"test fire from chain-alerts setup"}'
+```
+
+Expected: the message shows up in `#chain-alerts` within a couple of seconds. If not, re-check the URL is the full `https://discord.com/api/webhooks/<id>/<token>` form (not truncated), and that the webhook still exists in the Discord integration list (rotate / recreate if it was deleted).
+
+To exercise the full evaluation path (Prometheus rule → Grafana contact point → Discord), kill `ligate-node` on the dev VM and wait for `HealthDown` to trip:
+
+```sh
+sudo systemctl stop ligate-node
+# wait ~30-60s for the `for: 30s` to expire and the scrape to fail
+# `HealthDown` posts to `#chain-alerts` with the `@here` mention
+sudo systemctl start ligate-node
+# the OK auto-resolve fires once `up` returns to 1, ~30s after restart
+```
+
+## What gets paged vs channel-only
+
+Severity comes from `ops/prometheus/alerts.yaml`'s `labels.severity`. Page = `@here` mention; warn = channel only; info = channel only, no resolve message.
+
+| Alert | Severity | Behaviour in `#chain-alerts` | Runbook |
+|---|---|---|---|
+| `BlockHeightStall` | page | `@here` mention, repeats every 4h | [`block-height-stall.md`](./block-height-stall.md) |
+| `HealthDown` | page | `@here` mention, repeats every 4h | [`health-down.md`](./health-down.md) |
+| `DASubmissionFailures` | page | `@here` mention, repeats every 4h | [`da-submission-failures.md`](./da-submission-failures.md) |
+| `TIABalanceCritical` | page | `@here` mention, repeats every 4h | (covered in `da-signer-rotation.md`) |
+| `ReadyFalse` | warn | channel post, no mention | [`ready-false.md`](./ready-false.md) |
+| `MempoolDeep` | warn | channel post, no mention | [`mempool-deep.md`](./mempool-deep.md) |
+| `DiskFillingFast` | warn | channel post, no mention | [`disk-filling-fast.md`](./disk-filling-fast.md) |
+| `DAFinalizationLatencyHigh` | warn | channel post, no mention | [`da-finalization-latency-high.md`](./da-finalization-latency-high.md) |
+| `TIABalanceLow` | warn | channel post, no mention | (covered in `da-signer-rotation.md`) |
+| `TIADrawdownSpike` | warn | channel post, no mention | (covered in `cost-monitoring.md`) |
+
+No alerts ship at `info` today; the tier is reserved for future "interesting but not actionable" signals (e.g. attestor-set rotation completed, scheduled re-genesis cutover hit).
+
+## Self-hosted Alertmanager fallback
+
+For operators running their own monitoring stack (follower nodes, third-party partners spinning up their own attestor sets, anyone who does not want a Grafana Cloud account), the canonical path is the `ops/prometheus/alertmanager.yaml` config in this repo. That file ships with three receivers: the default Slack route, a page-severity email route, and (added by this change) a Discord webhook route.
+
+Alertmanager itself does not have a native Discord integration; the standard pattern is to point Alertmanager's `webhook_configs` at the [`alertmanager-discord`](https://github.com/benjojo/alertmanager-discord) Go binary running as a sidecar on the same host. The bridge reads `DISCORD_WEBHOOK` from its environment (set to the same URL Step 1 stored) and translates Alertmanager's JSON payload into a Discord-compatible message. The sidecar is ~5MB, has no persistent state, and runs as a systemd unit alongside Alertmanager.
+
+The receiver block added to `ops/prometheus/alertmanager.yaml` documents the `webhook_configs` shape and points at `http://127.0.0.1:9094/` (the bridge's default listen address). Operators wiring the fallback path should add an `alertmanager-discord.service` systemd unit, hydrate `DISCORD_WEBHOOK` from their secret store, and start it before Alertmanager. The canonical Grafana Cloud path above does not need any of this.

--- a/docs/development/runbooks/alerts/disk-filling-fast.md
+++ b/docs/development/runbooks/alerts/disk-filling-fast.md
@@ -1,6 +1,6 @@
 # `DiskFillingFast`
 
-**Severity: warn**
+**Severity: warn** (warn-severity alerts post to `#chain-alerts` without a mention; wiring details in [`discord-setup.md`](./discord-setup.md))
 
 ## What fired
 

--- a/docs/development/runbooks/alerts/health-down.md
+++ b/docs/development/runbooks/alerts/health-down.md
@@ -1,6 +1,6 @@
 # `HealthDown`
 
-**Severity: page**
+**Severity: page** (page-severity alerts post to `#chain-alerts` with an `@here` mention; wiring details in [`discord-setup.md`](./discord-setup.md))
 
 ## What fired
 

--- a/docs/development/runbooks/alerts/mempool-deep.md
+++ b/docs/development/runbooks/alerts/mempool-deep.md
@@ -1,6 +1,6 @@
 # `MempoolDeep`
 
-**Severity: warn**
+**Severity: warn** (warn-severity alerts post to `#chain-alerts` without a mention; wiring details in [`discord-setup.md`](./discord-setup.md))
 
 ## What fired
 

--- a/docs/development/runbooks/alerts/ready-false.md
+++ b/docs/development/runbooks/alerts/ready-false.md
@@ -1,6 +1,6 @@
 # `ReadyFalse`
 
-**Severity: warn**
+**Severity: warn** (warn-severity alerts post to `#chain-alerts` without a mention; wiring details in [`discord-setup.md`](./discord-setup.md))
 
 ## What fired
 

--- a/ops/prometheus/alertmanager.yaml
+++ b/ops/prometheus/alertmanager.yaml
@@ -1,8 +1,15 @@
 # Alertmanager config for ligate-devnet-1.
 #
+# NOTE: this file is the SELF-HOSTED FALLBACK path. The canonical wiring
+# for the public devnet operator is Grafana Cloud Alerting + the native
+# Discord contact point; see
+# `docs/development/runbooks/alerts/discord-setup.md`. Followers /
+# third-party partners running their own Prometheus + Alertmanager
+# should render and deploy THIS file instead.
+#
 # Receives firing alerts from Prometheus, deduplicates them, and routes
 # to notification targets. Pre-public-devnet, the routing tree is
-# deliberately simple: single operator, single Slack channel + email.
+# deliberately simple: single operator, Slack + email + Discord.
 # Mainnet routing (PagerDuty rotas, severity-specific escalation) is
 # future work.
 #
@@ -13,6 +20,14 @@
 #   alertmanager startup. NEVER check in.
 # - `SMTP_PASSWORD`: SMTP send password for the operator's mailbox.
 #   Same secret-injection pattern.
+# - `DISCORD_ALERTS_WEBHOOK_URL`: Discord webhook URL for #chain-alerts
+#   in the Ligate Labs server. Stored at `~/.config/ligate/secrets.env`
+#   on the operator workstation; exported into the alertmanager-discord
+#   sidecar's environment as `DISCORD_WEBHOOK`. Bridge listens on
+#   127.0.0.1:9094 and translates Alertmanager's webhook payload into
+#   Discord-compatible messages (Alertmanager has no native Discord
+#   integration). See discord-setup.md for the sidecar systemd unit
+#   pattern.
 #
 # Tracking issue: ligate-io/ligate-chain#268.
 
@@ -26,10 +41,10 @@ global:
   smtp_require_tls: true
   slack_api_url_file: '/run/secrets/slack_webhook_url'
 
-# Routing tree. All alerts hit `default`. `severity=page` also fans
-# out to email so the operator gets a phone-side notification even if
-# Slack is muted. `severity=info` is Slack-only (no point waking
-# anyone for an informational alert).
+# Routing tree. All alerts hit `default` (Slack + Discord). `severity=page`
+# also fans out to email so the operator gets a phone-side notification
+# even if Slack / Discord are muted. `severity=info` is channel-only
+# (no point waking anyone for an informational alert).
 route:
   receiver: default
   group_by: ['alertname', 'instance']
@@ -50,7 +65,12 @@ route:
       receiver: info-only
 
 receivers:
-  # Default receiver: Slack with full alert detail.
+  # Default receiver: Slack + Discord with full alert detail.
+  # The `webhook_configs` entry points at the alertmanager-discord
+  # bridge sidecar (see discord-setup.md "Self-hosted Alertmanager
+  # fallback" section); the bridge translates Alertmanager's JSON
+  # payload into a Discord webhook POST and reads its target URL
+  # from `DISCORD_WEBHOOK` in its own environment.
   - name: default
     slack_configs:
       - channel: '#devnet-ops'
@@ -64,10 +84,16 @@ receivers:
           - type: button
             text: 'View in Prometheus'
             url: '{{ (index .Alerts 0).GeneratorURL }}'
+    webhook_configs:
+      - url: 'http://127.0.0.1:9094/'
+        send_resolved: true
+        # Bridge does its own retry; no need for max_alerts here.
 
-  # Pager receiver: Slack + email. Phone notification surface for
-  # page-severity alerts. Pre-PagerDuty, the operator's email pipes
-  # into their phone's high-priority filter.
+  # Pager receiver: email only. Phone notification surface for
+  # page-severity alerts; the Slack + Discord posts are already
+  # delivered via the `default` route fan-out (`continue: true`).
+  # Pre-PagerDuty, the operator's email pipes into their phone's
+  # high-priority filter.
   - name: pager
     email_configs:
       - to: 'hello@ligate.io'
@@ -76,13 +102,16 @@ receivers:
           Subject: '[PAGE] {{ .GroupLabels.alertname }} on {{ .GroupLabels.instance }}'
         html: '{{ template "email.html" . }}'
 
-  # Info-only receiver: Slack with light formatting; no email.
+  # Info-only receiver: Slack + Discord with light formatting; no email.
   - name: info-only
     slack_configs:
       - channel: '#devnet-ops'
         send_resolved: false
         title: '[INFO] {{ .GroupLabels.alertname }}'
         text: '{{ range .Alerts }}{{ .Annotations.summary }}{{ end }}'
+    webhook_configs:
+      - url: 'http://127.0.0.1:9094/'
+        send_resolved: false
 
 # Inhibition rules: if a higher-severity alert is firing, suppress
 # lower-severity alerts for the same instance. Avoids alerting fatigue


### PR DESCRIPTION
## Summary

Wires `ops/prometheus/alerts.yaml` firings into the Ligate Labs Discord (`#chain-alerts`) via Grafana Cloud Alerting's native Discord contact point. This is the path the public-devnet operator actually uses today (Grafana Cloud is already doing alert evaluation against the metrics the chain VM's Alloy collector remote-writes; no self-hosted Alertmanager runs in prod). The in-repo `ops/prometheus/alertmanager.yaml` keeps the Slack + email receivers and gains a Discord webhook receiver so followers and third-party partners who run their own Prometheus stack can route to the same channel via the `alertmanager-discord` bridge. Closes the wiring half of [#268](https://github.com/ligate-io/ligate-chain/issues/268).

## What lands

- `docs/development/runbooks/alerts/discord-setup.md` (new): paste-and-go runbook with five steps: (1) Discord webhook creation, (2) Grafana Cloud contact point + inline message template, (3) notification policy per severity tier (page = `@here`, warn = channel-only, info = no resolves), (4) rule import from `alerts.yaml` with a worked example for `BlockHeightStall`, (5) end-to-end test fire. Includes the full per-alert severity table and a self-hosted Alertmanager fallback section.
- `ops/prometheus/alertmanager.yaml`: adds `webhook_configs` pointing at `http://127.0.0.1:9094/` (the `alertmanager-discord` bridge sidecar) on both the `default` and `info-only` receivers. Slack + email retained as alternates. Header comment now flags the file as the SELF-HOSTED FALLBACK and points at `discord-setup.md` for the canonical Grafana Cloud route. Pager receiver dropped its Slack duplicate (it was inheriting via the `continue: true` fan-out anyway); now email-only.
- `docs/development/runbooks/alerts/README.md`: extends the alert catalog with the three TIA alerts (`TIABalanceLow`, `TIABalanceCritical`, `TIADrawdownSpike`) that were already in `alerts.yaml` but missing from the table. Adds a Notification wiring section pointing at `discord-setup.md`. Deploy section now split into Grafana Cloud (canonical) and self-hosted (fallback) tracks.
- Per-alert runbooks (`block-height-stall`, `health-down`, `ready-false`, `mempool-deep`, `disk-filling-fast`, `da-submission-failures`, `da-finalization-latency-high`): severity line now links to `discord-setup.md` and notes whether the alert fires an `@here` mention.
- `CHANGELOG.md` `[Unreleased]`: Added + Changed entries.

## Why this shape

Grafana Cloud Alerting has a native Discord contact point, which means the operator does not need to run a bridge process for the canonical path; just paste the webhook URL into the contact-point UI. Self-hosted Alertmanager has no native Discord integration, so the `webhook_configs` route in `alertmanager.yaml` targets the small `alertmanager-discord` Go sidecar that translates Alertmanager's payload format into a Discord webhook POST. Two paths, one Discord channel.

Discord chosen over PagerDuty because we are pre-mainnet, the team already lives in the Ligate Labs Discord, and webhooks are free. Mainnet escalation will likely swap in PagerDuty for `severity=page`; the labels and the runbook structure carry forward.

## Out of scope

- Standing up the `alertmanager-discord` sidecar systemd unit (only relevant for self-hosted operators; documented but not deployed; happens follower-side, not in this repo).
- Migrating from Slack-only (`#devnet-ops`) to Discord-only. Both surfaces stay live during the cutover; once Discord is proved out in production, a follow-up PR can prune the Slack receiver.
- Mainnet escalation policy (PagerDuty rotas, severity-specific paging schedules). Tracked under #268 follow-ups.
- The full GitOps for Grafana-Cloud-side alert rules. Rules are imported through the UI today (Step 4 in the new runbook); a future `monitoring/grafana-alerts/` directory with Grizzly / Terraform-managed rule resources is the right long-term shape but out of scope here.

## Test plan

End-to-end verification the operator runs to confirm the wiring:

- [ ] Discord webhook created at `Server Settings -> Integrations -> Webhooks -> New Webhook -> chain-alerts -> #chain-alerts`; URL saved at `~/.config/ligate/secrets.env` as `DISCORD_ALERTS_WEBHOOK_URL`.
- [ ] Smoke test: `source ~/.config/ligate/secrets.env && curl -X POST "$DISCORD_ALERTS_WEBHOOK_URL" -H 'Content-Type: application/json' -d '{"content":"test fire from chain-alerts setup"}'` posts to `#chain-alerts` within ~2s.
- [ ] Grafana Cloud contact point `discord-chain-alerts` created with the webhook URL; built-in Test button posts a synthetic firing alert to `#chain-alerts`.
- [ ] Notification policies created for `severity=page` (with `@here`), `severity=warn` (no mention), `severity=info` (no resolves).
- [ ] At least one alert rule (`BlockHeightStall` per the worked example in `discord-setup.md` Step 4) imported into Grafana Cloud Alerting from `ops/prometheus/alerts.yaml`. Rule visible in the Alerting -> Alert rules list as `Normal` (not firing).
- [ ] Full path exercised by `sudo systemctl stop ligate-node` on the dev VM; `HealthDown` fires in `#chain-alerts` with `@here` mention within ~30s of the `for: 30s` expiring; `sudo systemctl start ligate-node` and the auto-resolve "OK" follows ~30s after restart.
- [ ] Markdown render of `discord-setup.md` checked on GitHub (anchors resolve, table renders, code fences correct).