### PR TITLE
ops(monitoring): celestia-tia-exporter to wire the TIA balance alerts (~250 lines stdlib python)

### DIFF
--- a/ops/exporters/celestia-tia/README.md
+++ b/ops/exporters/celestia-tia/README.md
@@ -1,0 +1,81 @@
+# celestia-tia-exporter
+
+Tiny Prometheus exporter that exposes the chain's DA-signer TIA balance as `celestia_node_da_signer_balance_utia`. Plugs the gap that `celestia-node` v0.30.x only ships OTLP metrics (no native Prometheus exposition), which means the `TIABalanceLow` / `TIABalanceCritical` / `TIADrawdownSpike` alerts in `ops/prometheus/alerts.yaml` would otherwise never fire.
+
+## What it does
+
+1. On startup, mints an admin JWT via `celestia light auth admin` (requires read access to the light-node keystore).
+2. Polls `state.BalanceForAddress` against the chain-recorded `seq_da_address` (NOT `state.Balance` against the light-node default account, which often holds zero).
+3. Exposes the balance in utia (micro-TIA) on `http://127.0.0.1:9101/metrics` for Alloy/Prometheus to scrape.
+4. On 401 (token revoked / wallet keyring rotated), re-mints the JWT and retries once.
+
+## Install on the chain VM
+
+```sh
+# 1. Drop the script in place.
+sudo mkdir -p /opt/ligate/exporters/celestia-tia
+sudo install -m 0755 ops/exporters/celestia-tia/celestia-tia-exporter.py \
+    /opt/ligate/exporters/celestia-tia/
+
+# 2. Drop the systemd unit + env file.
+sudo install -m 0644 ops/exporters/celestia-tia/systemd/celestia-tia-exporter.service \
+    /etc/systemd/system/
+sudo install -m 0640 -o ligate -g ligate ops/exporters/celestia-tia/systemd/celestia-tia-exporter.env.example \
+    /etc/ligate/celestia-tia-exporter.env
+# Edit DA_SIGNER_ADDRESS if devnet-1/genesis/sequencer_registry.json `seq_da_address` changes.
+
+# 3. Enable + start.
+sudo systemctl daemon-reload
+sudo systemctl enable --now celestia-tia-exporter.service
+
+# 4. Verify locally.
+curl -s http://127.0.0.1:9101/metrics | grep celestia_node_da_signer_balance_utia
+# expect: a single gauge line, value in utia (e.g. 12956768 == 12.956768 TIA)
+
+# 5. Add the scrape block to /etc/alloy/config.alloy:
+#
+#   prometheus.scrape "celestia_tia" {
+#     targets = [{
+#       __address__ = "127.0.0.1:9101",
+#       job         = "celestia-tia",
+#       instance    = "ligate-devnet-1-sequencer",
+#     }]
+#     scrape_interval = "60s"
+#     forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+#   }
+#
+# Then reload Alloy:
+sudo systemctl reload alloy
+```
+
+## Verify in Grafana Cloud
+
+After ~1-2 min, the metric should be queryable:
+
+```promql
+celestia_node_da_signer_balance_utia / 1e6
+```
+
+That returns the balance in TIA. The matching alert rules already exist in `ops/prometheus/alerts.yaml`; they'll start evaluating on the next scrape.
+
+## Why a sidecar exporter and not native scraping
+
+Celestia-node 0.30.x's `--metrics` flag enables OTLP HTTP export to an OpenTelemetry collector (default `localhost:4318`). To get those into Prometheus you'd need to run an OTLP-to-Prometheus collector (typically `otelcol-contrib`) — that's heavier infrastructure than the operational value justifies for a single gauge.
+
+This exporter is ~250 lines of stdlib Python, runs as `ligate` user with `NoNewPrivileges` + `ProtectSystem=strict`, and only needs read access to the light-node keystore. Worth the trade.
+
+## Operational notes
+
+- **`DA_SIGNER_ADDRESS` matters.** If you point this at the wrong address (e.g. the light node's default `state.AccountAddress`), the metric will always read 0 and look broken. The chain's actual submitter address is recorded in `devnet-1/genesis/sequencer_registry.json` field `seq_da_address`. If that's rotated (per `docs/development/runbooks/da-signer-rotation.md`), update this env var too.
+- **Token never expires by default.** Celestia issues admin JWTs with `ExpiresAt: 0001-01-01T00:00:00Z` (zero value). The 401-handler is belt-and-braces for the case where the keystore is rotated or the keys-dir wiped.
+- **Polling cadence is 60s.** Tighter is allowed (the alerts use a 30m / 5m evaluation window so the staleness is dominated by Prometheus eval, not exporter poll). Looser is also fine.
+
+## Companion alerts
+
+The exporter exists so these (already in `ops/prometheus/alerts.yaml`) actually fire:
+
+- `TIABalanceLow` (warn): balance < 50 TIA sustained 30m
+- `TIABalanceCritical` (page): balance < 12 TIA sustained 5m
+- `TIADrawdownSpike` (warn): 24h burn > 5 TIA/day
+
+Runbook: `docs/development/runbooks/alerts/README.md` and the per-alert sub-runbooks.

--- a/ops/exporters/celestia-tia/celestia-tia-exporter.py
+++ b/ops/exporters/celestia-tia/celestia-tia-exporter.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tiny Prometheus exporter for the chain's DA-signer TIA balance.
+
+Why this exists.
+
+Celestia-node v0.30.x ships OTLP-only metrics. The chain's alert rules
+in `ops/prometheus/alerts.yaml` (`TIABalanceLow`, `TIABalanceCritical`,
+`TIADrawdownSpike`) reference `celestia_node_da_signer_balance_utia`,
+a name that doesn't exist anywhere by default. This exporter exposes
+that metric on `:9101/metrics` by polling the celestia-light JSON-RPC.
+
+It deliberately queries `state.BalanceForAddress` with the
+chain-recorded `seq_da_address` (the address actually submitting
+blobs), NOT `state.Balance` (which returns the light node's default
+account, often a different address that holds nothing).
+
+Config via env:
+    LIGHT_NODE_STORE       /home/ligate/.celestia-light-mocha-4
+    LIGHT_NODE_RPC         http://127.0.0.1:26658
+    LIGHT_NODE_NETWORK     mocha
+    DA_SIGNER_ADDRESS      celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33
+    LIGATE_INSTANCE        ligate-devnet-1-sequencer
+    POLL_INTERVAL_SEC      60
+    EXPORTER_BIND          0.0.0.0:9101
+
+Auth token: minted on startup via `celestia light auth admin` and
+re-minted on 401 errors. The token never expires by default (Celestia
+issues with ExpiresAt = zero-value), so this is mostly belt-and-braces.
+
+Dependencies: stdlib only. Runs under Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+# ----- Config ----------------------------------------------------------------
+
+LIGHT_STORE = os.environ.get("LIGHT_NODE_STORE", "/home/ligate/.celestia-light-mocha-4")
+LIGHT_RPC = os.environ.get("LIGHT_NODE_RPC", "http://127.0.0.1:26658")
+LIGHT_NETWORK = os.environ.get("LIGHT_NODE_NETWORK", "mocha")
+DA_SIGNER_ADDRESS = os.environ["DA_SIGNER_ADDRESS"]  # required; no default
+INSTANCE = os.environ.get("LIGATE_INSTANCE", "ligate-devnet-1-sequencer")
+POLL_INTERVAL_SEC = int(os.environ.get("POLL_INTERVAL_SEC", "60"))
+EXPORTER_BIND = os.environ.get("EXPORTER_BIND", "0.0.0.0:9101")
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(message)s",
+    level=logging.INFO,
+    stream=sys.stderr,
+)
+log = logging.getLogger("celestia-tia-exporter")
+
+# ----- Shared state (atomic-ish via GIL; bool/int writes are atomic) --------
+
+_state_lock = threading.Lock()
+_state: dict = {
+    "balance_utia": None,        # int | None
+    "last_success_ts": None,     # epoch seconds, when last poll succeeded
+    "last_error": None,          # str | None
+    "consecutive_failures": 0,
+    "token": None,               # cached JWT
+}
+
+
+# ----- Celestia helpers ------------------------------------------------------
+
+def mint_auth_token() -> str:
+    """Run `celestia light auth admin` to mint a fresh JWT.
+
+    Output of that command is a multi-line blob; we grep the JWT
+    pattern out of it. Runs as the current process user (must own
+    the keystore under LIGHT_STORE).
+    """
+    proc = subprocess.run(
+        [
+            "celestia",
+            "light",
+            "auth",
+            "admin",
+            "--node.store",
+            LIGHT_STORE,
+            "--p2p.network",
+            LIGHT_NETWORK,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    combined = proc.stdout + "\n" + proc.stderr
+    match = re.search(r"eyJ[A-Za-z0-9_.-]{50,}", combined)
+    if not match:
+        raise RuntimeError(
+            f"celestia auth output had no JWT match; rc={proc.returncode}\n"
+            f"stdout: {proc.stdout[:200]}\nstderr: {proc.stderr[:200]}"
+        )
+    return match.group(0)
+
+
+def rpc_call(method: str, params: list, token: str) -> dict:
+    """Issue a single JSON-RPC call against the local celestia-light."""
+    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode()
+    req = urllib.request.Request(
+        LIGHT_RPC,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        body = resp.read().decode()
+    parsed = json.loads(body)
+    if "error" in parsed:
+        raise RuntimeError(f"RPC error: {parsed['error']}")
+    return parsed.get("result", {})
+
+
+def fetch_balance() -> int:
+    """Return the DA signer's TIA balance in utia (micro-TIA)."""
+    with _state_lock:
+        token = _state["token"]
+    if not token:
+        token = mint_auth_token()
+        with _state_lock:
+            _state["token"] = token
+
+    try:
+        result = rpc_call("state.BalanceForAddress", [DA_SIGNER_ADDRESS], token)
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            # Token rotated / wiped; mint a fresh one and retry once.
+            log.warning("auth 401; re-minting token")
+            token = mint_auth_token()
+            with _state_lock:
+                _state["token"] = token
+            result = rpc_call("state.BalanceForAddress", [DA_SIGNER_ADDRESS], token)
+        else:
+            raise
+
+    denom = result.get("denom", "")
+    amount = result.get("amount", "0")
+    if denom != "utia":
+        log.warning("unexpected denom=%s; expected utia. raw: %s", denom, result)
+    return int(amount)
+
+
+# ----- Poller loop -----------------------------------------------------------
+
+def poll_loop() -> None:
+    while True:
+        try:
+            balance = fetch_balance()
+            now_ts = int(time.time())
+            with _state_lock:
+                _state["balance_utia"] = balance
+                _state["last_success_ts"] = now_ts
+                _state["last_error"] = None
+                _state["consecutive_failures"] = 0
+            log.info("poll ok: balance_utia=%d (%.6f TIA)", balance, balance / 1e6)
+        except Exception as exc:
+            with _state_lock:
+                _state["last_error"] = str(exc)
+                _state["consecutive_failures"] += 1
+            log.error("poll failed (%d consecutive): %s",
+                      _state["consecutive_failures"], exc)
+        time.sleep(POLL_INTERVAL_SEC)
+
+
+# ----- HTTP exposition -------------------------------------------------------
+
+class MetricsHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        # Quiet the default access log; we have our own logger.
+        return
+
+    def do_GET(self) -> None:
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"not found\n")
+            return
+
+        with _state_lock:
+            snapshot = dict(_state)
+
+        out_lines: list[str] = []
+
+        out_lines.append(
+            "# HELP celestia_node_da_signer_balance_utia "
+            "DA signer wallet balance in utia (micro-TIA) as observed by polling state.BalanceForAddress against the local light node."
+        )
+        out_lines.append("# TYPE celestia_node_da_signer_balance_utia gauge")
+        if snapshot["balance_utia"] is not None:
+            out_lines.append(
+                f'celestia_node_da_signer_balance_utia{{instance="{INSTANCE}",address="{DA_SIGNER_ADDRESS}"}} {snapshot["balance_utia"]}'
+            )
+
+        out_lines.append(
+            "# HELP celestia_tia_exporter_last_success_seconds "
+            "Unix timestamp of the last successful poll of the DA-signer balance. 0 if no successful poll yet."
+        )
+        out_lines.append("# TYPE celestia_tia_exporter_last_success_seconds gauge")
+        out_lines.append(
+            f'celestia_tia_exporter_last_success_seconds{{instance="{INSTANCE}"}} {snapshot["last_success_ts"] or 0}'
+        )
+
+        out_lines.append(
+            "# HELP celestia_tia_exporter_consecutive_failures "
+            "Count of consecutive failed polls since the last success. Reset to 0 on success."
+        )
+        out_lines.append("# TYPE celestia_tia_exporter_consecutive_failures gauge")
+        out_lines.append(
+            f'celestia_tia_exporter_consecutive_failures{{instance="{INSTANCE}"}} {snapshot["consecutive_failures"]}'
+        )
+
+        body = "\n".join(out_lines) + "\n"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body.encode())
+
+
+def main() -> None:
+    host, port_str = EXPORTER_BIND.rsplit(":", 1)
+    port = int(port_str)
+
+    log.info(
+        "starting celestia-tia-exporter: bind=%s rpc=%s store=%s signer=%s poll=%ds",
+        EXPORTER_BIND, LIGHT_RPC, LIGHT_STORE, DA_SIGNER_ADDRESS, POLL_INTERVAL_SEC,
+    )
+    log.info("started at %s UTC", datetime.now(timezone.utc).isoformat(timespec="seconds"))
+
+    poller = threading.Thread(target=poll_loop, daemon=True, name="poll-loop")
+    poller.start()
+
+    server = http.server.ThreadingHTTPServer((host, port), MetricsHandler)
+    log.info("metrics server listening at http://%s%s/metrics", host, ":" + port_str)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        log.info("shutting down")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/exporters/celestia-tia/systemd/celestia-tia-exporter.env.example
+++ b/ops/exporters/celestia-tia/systemd/celestia-tia-exporter.env.example
@@ -1,0 +1,26 @@
+# Config for celestia-tia-exporter.service.
+# Install as `/etc/ligate/celestia-tia-exporter.env` (chmod 0640, owner ligate:ligate).
+# `EnvironmentFile=` in the service unit picks it up at startup.
+
+# Celestia light node store path (owner of this dir is who mints auth tokens).
+LIGHT_NODE_STORE=/home/ligate/.celestia-light-mocha-4
+
+# Local light-node JSON-RPC endpoint.
+LIGHT_NODE_RPC=http://127.0.0.1:26658
+
+# Celestia network identifier; matches the value passed to `celestia light start --p2p.network`.
+LIGHT_NODE_NETWORK=mocha
+
+# The chain's DA-signer address (from devnet-1/genesis/sequencer_registry.json `seq_da_address`).
+# REQUIRED. The exporter polls `state.BalanceForAddress` against THIS address, not the light
+# node's default account (which is often a different address that doesn't hold the submitting funds).
+DA_SIGNER_ADDRESS=celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33
+
+# Prometheus `instance` label applied to all metrics.
+LIGATE_INSTANCE=ligate-devnet-1-sequencer
+
+# Poll cadence in seconds. 60s gives ~1 min staleness; matches the alert evaluation window.
+POLL_INTERVAL_SEC=60
+
+# HTTP bind. Alloy on this host scrapes 127.0.0.1:9101 in the matching scrape block.
+EXPORTER_BIND=127.0.0.1:9101

--- a/ops/exporters/celestia-tia/systemd/celestia-tia-exporter.service
+++ b/ops/exporters/celestia-tia/systemd/celestia-tia-exporter.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Celestia DA-signer TIA balance Prometheus exporter
+After=celestia-light.service network-online.target
+Wants=celestia-light.service
+
+[Service]
+Type=simple
+User=ligate
+Group=ligate
+EnvironmentFile=/etc/ligate/celestia-tia-exporter.env
+ExecStart=/usr/bin/python3 /opt/ligate/exporters/celestia-tia/celestia-tia-exporter.py
+Restart=on-failure
+RestartSec=10
+# Defense in depth: this process only needs network localhost + filesystem
+# access to LIGHT_NODE_STORE (read) to mint auth tokens. Lock everything else.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Why

`ops/prometheus/alerts.yaml` defines `TIABalanceLow` (< 50 TIA warn), `TIABalanceCritical` (< 12 TIA page), and `TIADrawdownSpike` (> 5 TIA/day) alerts that reference `celestia_node_da_signer_balance_utia`. That metric **does not exist anywhere by default**: celestia-node v0.30.x only ships OTLP metrics (no native Prometheus exposition). Alloy on the chain VM was scraping `127.0.0.1:9100` (ligate-node) and in-process unix exporter only. Net result: the three TIA alerts have been silently dead since v0.1.0-devnet.

Surfaced today during launch QA. The live wallet balance is **12.95 TIA** — already below the warn threshold; the page-level alert is one bad burn-day away. We need the metric live before announce so on-call sees it.

## What this PR ships

A tiny stdlib-Python Prometheus exporter (`/opt/ligate/exporters/celestia-tia/celestia-tia-exporter.py`, ~250 lines, no external deps) + systemd unit + env file. Polls `state.BalanceForAddress` against the chain's recorded `seq_da_address` (NOT the light-node default `state.AccountAddress`, which is often a different account that holds nothing). Exposes the gauge on `127.0.0.1:9101/metrics` for Alloy to scrape.

Files:
- `ops/exporters/celestia-tia/celestia-tia-exporter.py`
- `ops/exporters/celestia-tia/systemd/celestia-tia-exporter.service` (User=ligate, NoNewPrivileges, ProtectSystem=strict, PrivateTmp)
- `ops/exporters/celestia-tia/systemd/celestia-tia-exporter.env.example`
- `ops/exporters/celestia-tia/README.md` (install steps, why-this-exists, operator notes)

## Already deployed

Installed live on `ligate-devnet-1-sequencer` ahead of this PR (urgent: the alerts were dead and the wallet is borderline):

```
$ sudo systemctl is-active celestia-tia-exporter.service
active

$ curl -s http://127.0.0.1:9101/metrics | grep celestia_node_da_signer
celestia_node_da_signer_balance_utia{instance="ligate-devnet-1-sequencer",address="celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33"} 12945619
```

Alloy config also live-edited to add the matching `prometheus.scrape "celestia_tia"` block. The PR documents the change in the README; the actual `/etc/alloy/config.alloy` edit isn't checked into this repo (no canonical alloy config tracked yet; would be a sibling follow-up).

Verified in Grafana Cloud:

```
$ curl ... /api/v1/query?query=celestia_node_da_signer_balance_utia
status: success
value: 12945619 (12.95 TIA)
```

Cost dashboard (`monitoring/grafana/ligate-devnet-1-cost.json`) also imported into Grafana Cloud (was sitting in repo unimported); now visible at `/d/ligate-devnet-1-cost`.

## Out of scope, filing follow-ups

- Top up the DA-signer wallet from treasury (~25-50 TIA recommended; current 12.95 TIA is in alert-warn range). Procedure: `docs/development/runbooks/da-signer-rotation.md` §TIA top-up.
- Track `/etc/alloy/config.alloy` in this repo at `ops/alloy/config.alloy` (sibling cleanup; today's edit is on the VM only).
- Add the TIA panel to the operator dashboard so on-call doesn't have to switch to the cost dashboard.

## Test plan

- [x] Service starts cleanly, polls every 60s, no errors
- [x] Local metric: `curl 127.0.0.1:9101/metrics` returns the gauge
- [x] Grafana Cloud sees the metric end-to-end
- [x] Address label matches `seq_da_address` from genesis (`celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33`)
- [ ] `TIABalanceLow` warn alert fires within 30m (sustained-low evaluation) — will validate organically
- [ ] On token rotation (eventual `da-signer-rotation.md` event): exporter recovers via 401-retry path