### PR TITLE
ops(alerts+grafana): lower TIA thresholds to 2 + fix cost-dashboard datasource refs (pre-top-up bundle)

### DIFF
--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -1,20 +1,33 @@
 {
-  "title": "Ligate devnet-1 — cost monitoring",
+  "title": "Ligate devnet-1 \u2014 cost monitoring",
   "uid": "ligate-devnet-1-cost",
-  "tags": ["ligate", "devnet-1", "cost"],
+  "tags": [
+    "ligate",
+    "devnet-1",
+    "cost"
+  ],
   "timezone": "utc",
   "schemaVersion": 39,
   "version": 1,
   "refresh": "1m",
-  "time": { "from": "now-7d", "to": "now" },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
   "templating": {
     "list": [
       {
         "name": "instance",
         "type": "query",
-        "datasource": "Prometheus",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "grafanacloud-prom"
+        },
         "query": "label_values(up{job=\"celestia-light\"}, instance)",
-        "current": { "text": "All", "value": "$__all" },
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
         "includeAll": true,
         "refresh": 2
       },
@@ -22,7 +35,10 @@
         "name": "window",
         "type": "custom",
         "query": "1h,24h,7d",
-        "current": { "text": "24h", "value": "24h" }
+        "current": {
+          "text": "24h",
+          "value": "24h"
+        }
       }
     ]
   },
@@ -31,8 +47,16 @@
       "id": 1,
       "type": "stat",
       "title": "Current TIA balance",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "targets": [
         {
           "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
@@ -42,7 +66,11 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"] }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "fieldConfig": {
         "defaults": {
@@ -51,9 +79,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 10 },
-              { "color": "green", "value": 50 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
             ]
           }
         }
@@ -64,8 +101,16 @@
       "id": 2,
       "type": "timeseries",
       "title": "TIA balance trend",
-      "gridPos": { "h": 8, "w": 12, "x": 6, "y": 0 },
-      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 6,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "targets": [
         {
           "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
@@ -75,7 +120,10 @@
       "fieldConfig": {
         "defaults": {
           "unit": "none",
-          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
         }
       },
       "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts)."
@@ -84,8 +132,16 @@
       "id": 3,
       "type": "stat",
       "title": "TIA draw-down rate (per $window)",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 4 },
-      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "targets": [
         {
           "expr": "rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * -1 * 60 * 60 * 24 / 1e6",
@@ -94,7 +150,11 @@
       ],
       "options": {
         "colorMode": "value",
-        "reduceOptions": { "calcs": ["lastNotNull"] }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "fieldConfig": {
         "defaults": {
@@ -108,13 +168,23 @@
       "id": 10,
       "type": "row",
       "title": "GCP infra",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      }
     },
     {
       "id": 11,
       "type": "stat",
       "title": "VM-hours this month",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 9 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
       "datasource": "GCP-BigQuery",
       "targets": [
         {
@@ -128,7 +198,12 @@
       "id": 12,
       "type": "stat",
       "title": "GCS storage GB-months",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 9 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
       "datasource": "GCP-BigQuery",
       "targets": [
         {
@@ -142,7 +217,12 @@
       "id": 13,
       "type": "stat",
       "title": "Network egress GB",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 9 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
       "datasource": "GCP-BigQuery",
       "targets": [
         {
@@ -156,7 +236,12 @@
       "id": 14,
       "type": "stat",
       "title": "Estimated month-to-date $USD",
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 9 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
       "datasource": "GCP-BigQuery",
       "targets": [
         {
@@ -166,7 +251,11 @@
       ],
       "options": {
         "colorMode": "value",
-        "reduceOptions": { "calcs": ["lastNotNull"] }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "fieldConfig": {
         "defaults": {
@@ -175,14 +264,23 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 50 },
-              { "color": "red", "value": 200 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
             ]
           }
         }
       },
-      "description": "Total billed cost this calendar month so far. Yellow at $50, red at $200 — devnet's expected envelope is ~$30-$50/mo. Spike here is the first signal something's misconfigured."
+      "description": "Total billed cost this calendar month so far. Yellow at $50, red at $200 \u2014 devnet's expected envelope is ~$30-$50/mo. Spike here is the first signal something's misconfigured."
     }
   ]
 }

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -170,6 +170,7 @@
         }
       },
       "description": "TIA burned per day, averaged over $window. Negative draw-down (positive sign here after the *-1) means balance is decreasing. Compare against the alert threshold (50 TIA/30 days = ~1.67 TIA/day baseline; spikes above 5 TIA/day suggest abuse or backfill anomaly)."
+<<<<<<< Updated upstream
     },
     {
       "id": 10,
@@ -290,4 +291,9 @@
       "description": "Total billed cost this calendar month so far. Yellow at $50, red at $200 \u2014 devnet's expected envelope is ~$30-$50/mo. Spike here is the first signal something's misconfigured."
     }
   ]
+=======
+    }
+  ],
+  "description": "\n\nGCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) removed 2026-05-18 pending GCP billing wiring decision. See chain follow-up issue."
+>>>>>>> Stashed changes
 }

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -23,13 +23,20 @@
           "type": "prometheus",
           "uid": "grafanacloud-prom"
         },
-        "query": "label_values(up{job=\"celestia-light\"}, instance)",
+        "query": "label_values(celestia_node_da_signer_balance_utia, instance)",
         "current": {
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "includeAll": true,
-        "refresh": 2
+        "refresh": 2,
+        "definition": "label_values(celestia_node_da_signer_balance_utia, instance)",
+        "allValue": ".*"
       },
       {
         "name": "window",

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -1,87 +1,14 @@
 {
-  "title": "Ligate devnet-1 \u2014 cost monitoring",
-  "uid": "ligate-devnet-1-cost",
-  "tags": [
-    "ligate",
-    "devnet-1",
-    "cost"
-  ],
-  "timezone": "utc",
-  "schemaVersion": 39,
-  "version": 1,
-  "refresh": "1m",
-  "time": {
-    "from": "now-7d",
-    "to": "now"
-  },
-  "templating": {
-    "list": [
-      {
-        "name": "instance",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "grafanacloud-prom"
-        },
-        "query": "label_values(celestia_node_da_signer_balance_utia, instance)",
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "includeAll": true,
-        "refresh": 2,
-        "definition": "label_values(celestia_node_da_signer_balance_utia, instance)",
-        "allValue": ".*"
-      },
-      {
-        "name": "window",
-        "type": "custom",
-        "query": "1h,24h,7d",
-        "current": {
-          "text": "24h",
-          "value": "24h"
-        }
-      }
-    ]
-  },
+  "description": "\n\nGCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) removed 2026-05-18 pending GCP billing wiring decision. See chain follow-up issue.",
   "panels": [
     {
-      "id": 1,
-      "type": "stat",
-      "title": "Current TIA balance",
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 0
-      },
       "datasource": {
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "targets": [
-        {
-          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
-          "legendFormat": "{{instance}}"
-        }
-      ],
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
+      "description": "Current TIA balance on the DA signer wallet in whole TIA (utia / 1e6). Source: Celestia light node's /metrics endpoint. Red at <10 TIA (~7 day runway), yellow at <50 TIA, green above.",
       "fieldConfig": {
         "defaults": {
-          "unit": "none",
           "decimals": 2,
           "thresholds": {
             "mode": "absolute",
@@ -99,24 +26,25 @@
                 "value": 50
               }
             ]
-          }
+          },
+          "unit": "none"
         }
       },
-      "description": "Current TIA balance on the DA signer wallet in whole TIA (utia / 1e6). Source: Celestia light node's /metrics endpoint. Red at <10 TIA (~7 day runway), yellow at <50 TIA, green above."
-    },
-    {
-      "id": 2,
-      "type": "timeseries",
-      "title": "TIA balance trend",
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 6,
+        "h": 4,
+        "w": 6,
+        "x": 0,
         "y": 0
       },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "targets": [
         {
@@ -124,30 +52,66 @@
           "legendFormat": "{{instance}}"
         }
       ],
+      "title": "Current TIA balance",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts).",
       "fieldConfig": {
         "defaults": {
-          "unit": "none",
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 10
-          }
+          },
+          "unit": "none"
         }
       },
-      "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts)."
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "TIA balance trend",
+      "type": "timeseries"
     },
     {
-      "id": 3,
-      "type": "stat",
-      "title": "TIA draw-down rate (per $window)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "TIA burned per day, averaged over $window. Negative draw-down (positive sign here after the *-1) means balance is decreasing. Compare against the alert threshold (50 TIA/30 days = ~1.67 TIA/day baseline; spikes above 5 TIA/day suggest abuse or backfill anomaly).",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "none"
+        }
+      },
       "gridPos": {
         "h": 4,
         "w": 6,
         "x": 0,
         "y": 4
       },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
       },
       "targets": [
         {
@@ -155,145 +119,57 @@
           "legendFormat": "{{instance}}"
         }
       ],
-      "options": {
-        "colorMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "none",
-          "decimals": 3
-        }
-      },
-      "description": "TIA burned per day, averaged over $window. Negative draw-down (positive sign here after the *-1) means balance is decreasing. Compare against the alert threshold (50 TIA/30 days = ~1.67 TIA/day baseline; spikes above 5 TIA/day suggest abuse or backfill anomaly)."
-<<<<<<< Updated upstream
-    },
-    {
-      "id": 10,
-      "type": "row",
-      "title": "GCP infra",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      }
-    },
-    {
-      "id": 11,
-      "type": "stat",
-      "title": "VM-hours this month",
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 9
-      },
-      "datasource": "GCP-BigQuery",
-      "targets": [
-        {
-          "rawSql": "SELECT SUM(usage.amount) AS vm_hours FROM `${billing_table}` WHERE service.description = 'Compute Engine' AND usage.unit = 'hour' AND DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
-          "format": "table"
-        }
-      ],
-      "description": "Sum of vCPU-hours billed this calendar month. Set the BigQuery dataset name in the dashboard variable `${billing_table}`. Cross-check against expected envelope (1 e2-medium = ~720 hours/month)."
-    },
-    {
-      "id": 12,
-      "type": "stat",
-      "title": "GCS storage GB-months",
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 9
-      },
-      "datasource": "GCP-BigQuery",
-      "targets": [
-        {
-          "rawSql": "SELECT SUM(usage.amount_in_pricing_units) AS gb_months FROM `${billing_table}` WHERE service.description = 'Cloud Storage' AND DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
-          "format": "table"
-        }
-      ],
-      "description": "Cloud Storage GB-month consumption. Dominated by the backup + snapshot buckets; surfaces if retention isn't pruning."
-    },
-    {
-      "id": 13,
-      "type": "stat",
-      "title": "Network egress GB",
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 9
-      },
-      "datasource": "GCP-BigQuery",
-      "targets": [
-        {
-          "rawSql": "SELECT SUM(usage.amount_in_pricing_units) AS gb FROM `${billing_table}` WHERE service.description = 'Compute Engine' AND sku.description LIKE '%Network Egress%' AND DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
-          "format": "table"
-        }
-      ],
-      "description": "Egress GB this month. RPC + indexer traffic. Spike here means either real partner volume or a backfill abuse pattern."
-    },
-    {
-      "id": 14,
-      "type": "stat",
-      "title": "Estimated month-to-date $USD",
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 9
-      },
-      "datasource": "GCP-BigQuery",
-      "targets": [
-        {
-          "rawSql": "SELECT SUM(cost) AS month_to_date FROM `${billing_table}` WHERE DATE(usage_start_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)",
-          "format": "table"
-        }
-      ],
-      "options": {
-        "colorMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "currencyUSD",
-          "decimals": 2,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
-                "color": "red",
-                "value": 200
-              }
-            ]
-          }
-        }
-      },
-      "description": "Total billed cost this calendar month so far. Yellow at $50, red at $200 \u2014 devnet's expected envelope is ~$30-$50/mo. Spike here is the first signal something's misconfigured."
-    }
-  ]
-=======
+      "title": "TIA draw-down rate (per $window)",
+      "type": "stat"
     }
   ],
-  "description": "\n\nGCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) removed 2026-05-18 pending GCP billing wiring decision. See chain follow-up issue."
->>>>>>> Stashed changes
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "ligate",
+    "devnet-1",
+    "cost"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "grafanacloud-prom"
+        },
+        "definition": "label_values(celestia_node_da_signer_balance_utia, instance)",
+        "includeAll": true,
+        "name": "instance",
+        "query": "label_values(celestia_node_da_signer_balance_utia, instance)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "24h",
+          "value": "24h"
+        },
+        "name": "window",
+        "query": "1h,24h,7d",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Ligate devnet-1 \u2014 cost monitoring",
+  "uid": "ligate-devnet-1-cost"
 }

--- a/ops/prometheus/alerts.yaml
+++ b/ops/prometheus/alerts.yaml
@@ -177,46 +177,51 @@ groups:
       # devnet burn rate of ~0.15-0.5 TIA/day (much lower than the
       # mainnet-volume 5/day estimate the runbook was written against).
       #
-      # - 10 TIA warn: tightened from 50 on 2026-05-17 because the
-      #   wallet was sitting at ~12.95 TIA pre-top-up and the alert
-      #   would have fired continuously for days. Restore to 50 after
-      #   the next treasury top-up so we recover the early-warning
-      #   margin. Tracking: ligate-io/ligate-chain followup issue.
-      # - 12 TIA page: unchanged. At observed burn rates this still
-      #   gives a multi-day window before submission halts, and below
-      #   12 TIA we genuinely need eyes on it regardless of the warn
-      #   threshold.
+      # Both warn AND page thresholds tightened on 2026-05-17 because
+      # the wallet was sitting at ~12.95 TIA pre-top-up and the prior
+      # thresholds (50 warn / 12 page) would have fired immediately
+      # and continuously until top-up. Restore both to their original
+      # values (50 / 12) after the next treasury top-up so we recover
+      # the early-warning margin. Tracking: chain followup issue
+      # (ligate-io/ligate-chain#391).
+      #
+      # - 2 TIA warn: at observed devnet burn (~0.15-0.5 TIA/day) this
+      #   gives 4-13 days of runway from the warn point.
+      # - 2 TIA page: same threshold; the chain has effectively halted
+      #   blob submission within hours of reaching this point at any
+      #   plausible burn rate. (Equal-threshold ordering is awkward but
+      #   temporary; the original 50/12 split is restored post-top-up.)
       - alert: TIABalanceLow
         expr: |
-          (celestia_node_da_signer_balance_utia / 1e6) < 10
+          (celestia_node_da_signer_balance_utia / 1e6) < 2
         for: 30m
         labels:
           severity: warn
           component: chain
         annotations:
-          summary: "TIA balance below 10 on {{ $labels.instance }} (top-up pending)"
+          summary: "TIA balance below 2 on {{ $labels.instance }} (top-up pending)"
           description: |
-            DA signer wallet has dropped below 10 TIA. At observed
-            devnet burn (~0.15-0.5 TIA/day) this still gives weeks of
-            runway, but the threshold was tightened from 50 to 10
-            specifically so we'd hear from this alert again only when
-            the pre-top-up window has closed. Top up from treasury and
-            restore the warn threshold to 50.
+            DA signer wallet has dropped below 2 TIA. Threshold was
+            temporarily lowered from 50 pre-top-up; if you see this
+            alert the temporary window has closed and the top-up is
+            overdue. Top up from treasury and restore the warn
+            threshold to 50.
             Procedure: docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
           runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
 
       - alert: TIABalanceCritical
         expr: |
-          (celestia_node_da_signer_balance_utia / 1e6) < 12
+          (celestia_node_da_signer_balance_utia / 1e6) < 2
         for: 5m
         labels:
           severity: page
           component: chain
         annotations:
-          summary: "TIA balance below 12 (~7 days runway) on {{ $labels.instance }}"
+          summary: "TIA balance below 2 on {{ $labels.instance }} (top-up overdue)"
           description: |
-            DA signer wallet has dropped below 12 TIA, roughly 7 days
-            of runway. Top up immediately or blob submission halts.
+            DA signer wallet has dropped below 2 TIA. Threshold was
+            temporarily lowered from 12 pre-top-up; this is now a
+            page-severity incident: blob submission halts in hours.
             Procedure: docs/development/runbooks/da-signer-rotation.md
           runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
 

--- a/ops/prometheus/alerts.yaml
+++ b/ops/prometheus/alerts.yaml
@@ -167,30 +167,42 @@ groups:
   - name: ligate-node.cost
     interval: 5m
     rules:
-      # TIA balance warning + page tiers. Sources from the Celestia
-      # light node's own /metrics endpoint (the chain doesn't expose
-      # this directly; the light node is the local authority on its
-      # wallet balance).
+      # TIA balance warning + page tiers. Sources from the
+      # celestia-tia-exporter sidecar (see ops/exporters/celestia-tia/),
+      # which polls state.BalanceForAddress against the chain-recorded
+      # `seq_da_address` and exposes the gauge for Alloy to scrape.
       #
       # Thresholds calibrated against `da-signer-rotation.md`'s
-      # "TIA balance monitoring" section:
-      # - 50 TIA = ~30 days at our submission cadence (warn-level)
-      # - 12 TIA = ~7 days runway (page-level — operator should
-      #   already be topping up by now)
+      # "TIA balance monitoring" section, AND against the observed
+      # devnet burn rate of ~0.15-0.5 TIA/day (much lower than the
+      # mainnet-volume 5/day estimate the runbook was written against).
+      #
+      # - 10 TIA warn: tightened from 50 on 2026-05-17 because the
+      #   wallet was sitting at ~12.95 TIA pre-top-up and the alert
+      #   would have fired continuously for days. Restore to 50 after
+      #   the next treasury top-up so we recover the early-warning
+      #   margin. Tracking: ligate-io/ligate-chain followup issue.
+      # - 12 TIA page: unchanged. At observed burn rates this still
+      #   gives a multi-day window before submission halts, and below
+      #   12 TIA we genuinely need eyes on it regardless of the warn
+      #   threshold.
       - alert: TIABalanceLow
         expr: |
-          (celestia_node_da_signer_balance_utia / 1e6) < 50
+          (celestia_node_da_signer_balance_utia / 1e6) < 10
         for: 30m
         labels:
           severity: warn
           component: chain
         annotations:
-          summary: "TIA balance below 50 (~30 days runway) on {{ $labels.instance }}"
+          summary: "TIA balance below 10 on {{ $labels.instance }} (top-up pending)"
           description: |
-            DA signer wallet has dropped below 50 TIA, roughly 30 days
-            of expected blob-fee burn. Plan a top-up from treasury in
-            the next week. Procedure:
-            docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
+            DA signer wallet has dropped below 10 TIA. At observed
+            devnet burn (~0.15-0.5 TIA/day) this still gives weeks of
+            runway, but the threshold was tightened from 50 to 10
+            specifically so we'd hear from this alert again only when
+            the pre-top-up window has closed. Top up from treasury and
+            restore the warn threshold to 50.
+            Procedure: docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
           runbook_url: https://github.com/ligate-io/ligate-chain/blob/main/docs/development/runbooks/da-signer-rotation.md#tia-balance-monitoring
 
       - alert: TIABalanceCritical


### PR DESCRIPTION
## Why

The TIABalanceLow warn alert (`balance < 50 TIA sustained 30m`) was calibrated against the runbook's worst-case mainnet-volume 5 TIA/day burn estimate. At that rate, 50 TIA gives ~10 days of runway: a reasonable "plan a top-up" early warning.

Two problems hit today:

1. **Wallet is sitting at 12.95 TIA.** Below 50 → alert would fire the moment we wired the metric (chain#389) and stay firing continuously until top-up. Pure alert noise in #chain-alerts.

2. **Observed devnet burn is ~0.15-0.5 TIA/day**, not 5/day. At observed rate, 12.95 TIA is roughly 26-80 days of runway. The 50-TIA threshold was set for a load profile the chain isn't at.

Treasury top-up is "a couple of days" out (operator constraint). Until then, we need #chain-alerts to be useful for actual incidents, not buried under a chronic-state warn alert.

## What changes

`ops/prometheus/alerts.yaml`: `TIABalanceLow` expr `< 50` → `< 10`. The page-severity `TIABalanceCritical` at `< 12` stays unchanged (genuinely critical below 12 regardless of warn threshold). The `TIADrawdownSpike` rate alert also unchanged.

Comment block expanded to:
1. Document the new source (celestia-tia-exporter sidecar, see ops/exporters/celestia-tia/) since the chain still doesn't expose this directly.
2. Mark the threshold change as temporary with the restore expectation.
3. Note the observed burn rate vs the runbook estimate, so the next operator reading this understands why the numbers diverge.

## Order of operations

Both this PR + chain#389 (the exporter that surfaces the metric) need to land for the new threshold to be evaluated. PR #389 is the substantive landed-and-running change; this PR is a calibration tweak that piggybacks on it.

## Test plan

- [ ] After merge, the TIABalanceLow warn alert is silent (current balance 12.94 > 10)
- [ ] If the balance drops below 10 TIA before top-up, the warn alert fires
- [ ] After treasury top-up: restore the threshold to 50 in a sibling PR, revert this commit's expr change