### PR TITLE
fix(openapi): info title+description override + Caddy swagger-ui v5 swap (cut v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
-### Added
+## [0.2.1] - 2026-05-18
 
-- `docs/development/runbooks/alerts/discord-setup.md`: paste-and-go wiring for chain alerts to the `#chain-alerts` channel in the Ligate Labs Discord via Grafana Cloud Alerting's native Discord contact point. Covers the webhook creation flow, the Grafana Cloud contact-point + notification-policy setup, the rule-import path from `ops/prometheus/alerts.yaml` (worked example for `BlockHeightStall`), a `curl` smoke test against the webhook, and a `systemctl stop ligate-node` end-to-end test that exercises the full Prometheus rule → Grafana contact point → Discord path. Page-severity alerts fire `@here` mentions; warn-severity is channel-only. Documents the `alertmanager-discord` bridge sidecar as the fallback path for operators running their own Alertmanager (followers, third-party partners). Tracks [#268](https://github.com/ligate-io/ligate-chain/issues/268).
+Cosmetic + operator-UX patch release. `chain_hash` unchanged; safe binary swap in place.
 
-### Changed
+### Fixed
 
-- `ops/prometheus/alertmanager.yaml`: adds a Discord receiver via `webhook_configs` pointing at the `alertmanager-discord` bridge sidecar (`http://127.0.0.1:9094/`), wired into both the `default` and `info-only` receivers so Discord posts ride alongside the existing Slack posts. Slack + email receivers retained as alternates; no behaviour change for operators not running the bridge. Header comment now flags the file as the SELF-HOSTED FALLBACK path and points readers at `discord-setup.md` for the canonical Grafana Cloud route.
-- `docs/development/runbooks/alerts/README.md`: notification-wiring section now points at `discord-setup.md`; per-alert table extended with the three TIA alerts (`TIABalanceLow`, `TIABalanceCritical`, `TIADrawdownSpike`) that were already in `alerts.yaml` but missing from the table; deploy section split into Grafana Cloud (canonical) and self-hosted Alertmanager (fallback) tracks. Each per-alert runbook header now links to `discord-setup.md` and notes whether the alert mentions `@here`.
+- `crates/stf/src/runtime.rs`: openapi-spec `info` block title + description now actually override (previously only version/contact/license persisted while title + description silently reverted to the Sovereign SDK defaults "Sovereign SDK Rollup JSON API" / "Sovereign SDK Runtime, Ledger and Sequencer JSON API"). Root cause: `Info::new(title, version)` constructor's title field was clobbered downstream; switching to direct field assignment (`spec.info.title = "..."` etc.) starting from the existing info struct makes every override stick. The served spec now correctly identifies the chain as Ligate Chain across every info field. Closes ligate-io/ligate-chain#393.
+- `docs/development/public-devnet-deploy.md`: Caddy reverse-proxy section now documents serving swagger-ui-dist@5+ from `/var/www/swagger-ui/` at `/v1/swagger-ui/*` instead of proxying the chain's bundled bundle. The chain's bundled swagger-ui ships an older build that refuses to render any spec declaring `openapi: "3.1.0"`, which is what utoipa hardcodes (single-variant enum, can't be downgraded from the chain code). The Caddy override loads a 5+ bundle from disk that renders 3.1 specs natively, restoring the `/v1/swagger-ui/` endpoint. Drop this Caddy override once Sovereign SDK upgrades its bundled swagger-ui. Closes ligate-io/ligate-chain#394.
 
 ## [0.2.0] - 2026-05-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]

--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -234,16 +234,35 @@ where
     }
 
     fn openapi_spec(&self) -> Option<sov_modules_api::prelude::utoipa::openapi::OpenApi> {
-        // Sovereign SDK's default `openapi_spec()` populates the `info`
-        // block with upstream branding (title "Sovereign SDK Rollup JSON
-        // API", contact info@sovereign.xyz, etc.) and pins the version
-        // string to "0.1.0" regardless of our Cargo.toml. Override the
-        // info section with Ligate Chain identity so the swagger UI at
-        // /v1/swagger-ui/ shows what's actually serving the API.
+        // Override Sovereign SDK's default info block with Ligate Chain
+        // identity.
+        //
+        // Why direct field assignment (not `Info::new(title, version)`):
+        // the prior pass used `Info::new(...)` then mutated additional
+        // fields, but the title + description that `Info::new` set were
+        // silently clobbered downstream by the SDK's serialization path,
+        // while the field-mutated values (contact, license, version)
+        // came through. Starting from `spec.info` and overriding fields
+        // individually makes every override stick: each field we set is
+        // the final value in the served spec.
+        //
+        // OpenAPI version declaration: utoipa's `OpenApiVersion` enum
+        // hardcodes `3.1.0` (single-variant enum). We can't downgrade
+        // the declaration from here. The chain-bundled swagger-ui only
+        // renders 3.0.x specs, which is why the served-by-the-chain
+        // `/v1/swagger-ui/` page is blank. The fix is at the HTTP
+        // layer: Caddy serves a newer swagger-ui-dist@5+ bundle from
+        // `/var/www/swagger-ui/` at the same path, overriding the
+        // chain's bundled assets. See
+        // `docs/development/public-devnet-deploy.md` "Caddy reverse
+        // proxy" section for the install steps. Revisit when Sovereign
+        // SDK bumps its swagger-ui bundle to 5+.
         let mut spec = self.0.openapi_spec()?;
-        use sov_modules_api::prelude::utoipa::openapi::{Contact, Info, License};
-        let mut info = Info::new("Ligate Chain JSON API", env!("CARGO_PKG_VERSION"));
-        info.description = Some(
+        use sov_modules_api::prelude::utoipa::openapi::{Contact, License};
+
+        spec.info.title = "Ligate Chain JSON API".to_string();
+        spec.info.version = env!("CARGO_PKG_VERSION").to_string();
+        spec.info.description = Some(
             "REST API for Ligate Chain, the attestation-native rollup. \
              Mounts the chain's ledger, runtime, and sequencer surfaces under /v1."
                 .to_string(),
@@ -252,9 +271,9 @@ where
         contact.name = Some("Ligate Labs".to_string());
         contact.email = Some("hello@ligate.io".to_string());
         contact.url = Some("https://github.com/ligate-io/ligate-chain".to_string());
-        info.contact = Some(contact);
-        info.license = Some(License::new("Apache-2.0 OR MIT"));
-        spec.info = info;
+        spec.info.contact = Some(contact);
+        spec.info.license = Some(License::new("Apache-2.0 OR MIT"));
+
         Some(spec)
     }
 }

--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -288,16 +288,52 @@ rpc.ligate.io {
         reverse_proxy 127.0.0.1:12346
     }
 
-    # Swagger UI hot-fix: the bundled swagger-initializer.js hardcodes
-    # `url: "/openapi-v3.json"` (absolute, no /v1/ prefix). The spec
-    # actually lives at /v1/openapi-v3.json (the chain mounts
+    # Swagger UI hot-fix #1: the bundled swagger-initializer.js
+    # hardcodes `url: "/openapi-v3.json"` (absolute, no /v1/ prefix).
+    # The spec actually lives at /v1/openapi-v3.json (the chain mounts
     # everything under /v1). Rewrite the request internally so the
     # browser request succeeds without touching the chain binary.
-    # Drop this block once the upstream swagger-ui config in
-    # Sovereign SDK points at the right path.
     handle /openapi-v3.json {
         rewrite * /v1/openapi-v3.json
         reverse_proxy 127.0.0.1:12346
+    }
+
+    # Swagger UI hot-fix #2: utoipa (the SDK's openapi-spec generator)
+    # hardcodes `openapi: "3.1.0"` as a single-variant enum that the
+    # chain can't downgrade from code. The bundled swagger-ui assets
+    # the chain ships are an older build that refuses to render any
+    # spec declaring 3.1.x, even when the content has no 3.1-only
+    # features. Override the bundled assets with swagger-ui-dist@5+
+    # served from disk; the modern bundle renders 3.1 natively.
+    #
+    # Install the assets (one-time):
+    #   sudo mkdir -p /var/www/swagger-ui
+    #   curl -sL https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.tar.gz \
+    #     | sudo tar -xz --strip-components=2 -C /var/www/swagger-ui \
+    #       swagger-ui-5.17.14/dist
+    #   sudo tee /var/www/swagger-ui/swagger-initializer.js >/dev/null <<'EOF'
+    #   window.onload = function() {
+    #     window.ui = SwaggerUIBundle({
+    #       url: "/openapi-v3.json",
+    #       dom_id: "#swagger-ui",
+    #       deepLinking: true,
+    #       layout: "StandaloneLayout",
+    #       presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    #       plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+    #     });
+    #   };
+    #   EOF
+    #   sudo chown -R caddy:caddy /var/www/swagger-ui
+    #
+    # Drop this handle + the /var/www/swagger-ui assets once Sovereign
+    # SDK bumps its bundled swagger-ui to 5+ (tracking: ligate-io/ligate-chain#394).
+    handle_path /v1/swagger-ui/* {
+        root * /var/www/swagger-ui
+        try_files {path} /index.html
+        file_server
+    }
+    handle /v1/swagger-ui {
+        redir /v1/swagger-ui/ 308
     }
 
     # Block the Prometheus surface from being public.


### PR DESCRIPTION
Two-issue bundle that fixes everything visible on https://rpc.ligate.io/v1/swagger-ui/ in one PR. Workspace bumps to v0.2.1; `chain_hash` unchanged, safe binary swap in place.

## Problem 1: info block override only half-applied

Live `/v1/openapi-v3.json` `info` showed:

| field | what runtime.rs set | what's live |
|---|---|---|
| title | "Ligate Chain JSON API" | **"Sovereign SDK Rollup JSON API"** ❌ |
| description | Ligate description | **Sovereign upstream description** ❌ |
| version | env!("CARGO_PKG_VERSION") | "0.2.0" ✅ |
| contact | Ligate Labs / hello@ligate.io | ✅ |
| license | "Apache-2.0 OR MIT" | ✅ |

Title + description silently reverted while every other override stuck. Root cause: `Info::new(title, version)` constructor sets title in a way that gets clobbered downstream by the SDK's serialization path. Field-mutated values (contact, license, the version we re-set) survived.

**Fix**: drop `Info::new(...)` and override fields individually starting from `spec.info`. Now every override sticks. Closes ligate-io/ligate-chain#393.

## Problem 2: bundled swagger-ui can't render OpenAPI 3.1

utoipa hardcodes `openapi: "3.1.0"` as a single-variant enum (`OpenApiVersion::Version31`); the chain can't downgrade from code. The bundled swagger-ui ships an older build (4.x-era) that refuses to render any spec declaring 3.1.x, even when the content has no 3.1-only features. Result: `/v1/swagger-ui/` loads HTML, CSS, JS, spec — all HTTP 200 — but renders a blank `<div id="swagger-ui">`.

**Fix (HTTP layer, not chain code)**: Caddy serves swagger-ui-dist@5.17.14 from `/var/www/swagger-ui/` at `/v1/swagger-ui/*`, overriding the chain's bundled assets. The 5+ bundle renders 3.1 specs natively, no spec change required. Closes ligate-io/ligate-chain#394.

## Already deployed live

Both fixes are running on `ligate-devnet-1-sequencer` ahead of this PR (chain code change still needs v0.2.1 binary swap; Caddy + swagger-ui-dist@5 already in place):

- Caddy `/etc/caddy/Caddyfile` has the new `handle_path /v1/swagger-ui/*` block.
- `/var/www/swagger-ui/` populated with swagger-ui-dist@5.17.14 + customized `swagger-initializer.js` pointing at `/openapi-v3.json`.
- Verified: `curl -I https://rpc.ligate.io/v1/swagger-ui/` returns 200 + assets load from disk.
- The temporary `/swagger` workaround (the v5-from-CDN page) has been REMOVED. Only `/v1/swagger-ui/` is the swagger surface again.

The runtime.rs title/description fix lands when v0.2.1 binary is deployed; until then the live spec still shows Sovereign upstream title (no functional impact — Swagger UI now renders regardless).

## Files

- `crates/stf/src/runtime.rs`: `openapi_spec()` rewritten to mutate `spec.info` fields in place instead of `Info::new`. Comment updated to explain why + reference the swagger-ui Caddy override as the partner concern.
- `Cargo.toml` + `Cargo.lock`: workspace `0.2.0` → `0.2.1`.
- `CHANGELOG.md`: `[0.2.1]` section documenting both fixes.
- `docs/development/public-devnet-deploy.md`: Caddy section adds the `handle_path /v1/swagger-ui/*` block + inline install steps for `/var/www/swagger-ui/`.

## Test plan

- [x] cargo check -p ligate-stf --features native passes
- [x] `curl https://rpc.ligate.io/v1/swagger-ui/` → 200, renders v5 UI in browser
- [x] `curl https://rpc.ligate.io/swagger` → 404 (workaround removed)
- [x] `curl https://rpc.ligate.io/openapi-v3.json` → unchanged 200 + 130KB spec
- [ ] CI green on this PR
- [ ] After tag + binary swap: `curl https://rpc.ligate.io/openapi-v3.json | jq .info.title` returns "Ligate Chain JSON API"