### PR TITLE
ops(v0.2.1 bundle): track live Caddyfile + scripted swagger-ui installer + exporter polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [0.2.1] - 2026-05-18
 
-Cosmetic + operator-UX patch release. `chain_hash` unchanged; safe binary swap in place.
+Cosmetic + operator-UX + ops-tooling patch release. `chain_hash` unchanged; safe binary swap in place. Bundles the openapi `info`-block fix, the swagger-ui v5 swap (both #393/#394), plus three operator-side additions that make devnet-1 reproducible: live Caddyfile committed, swagger-ui installer scripted, TIA exporter extended with chain-readiness and a dead-man's switch.
+
+### Added
+
+- `ops/caddy/Caddyfile`: live `/etc/caddy/Caddyfile` from the devnet-1 sequencer VM committed to repo as the canonical source. Documents the Cloudflare-only edge allowlist (defense-in-depth against direct-to-origin IP scans), the openapi-v3.json path rewrite (browser hits `/openapi-v3.json` without `/v1/` prefix; Caddy rewrites internally), the swagger-ui v5 disk-served override, and the `/metrics` lockdown. Operators rebuilding the VM now reach for the repo's Caddyfile instead of reading state off a running VM. Drop the swagger-ui v5 override block once Sovereign SDK upgrades its bundled UI. Closes ligate-io/ligate-chain#394 (companion to the docs update below).
+- `ops/install/swagger-ui-dist.sh`: idempotent installer for swagger-ui-dist@5.17.14 into `/var/www/swagger-ui/`. Downloads the upstream tarball, strips two path components so `dist/*` lands at the install root, writes a custom `swagger-initializer.js` that points the bundle at `/openapi-v3.json` with `tryItOutEnabled: true`, chowns to `caddy:caddy` (falls back to `chmod a+r` if the user isn't present on the host). Env-configurable for `SWAGGER_UI_VERSION`, `INSTALL_DIR`, `OWNER_USER`, `OWNER_GROUP`, `SPEC_URL`. Replaces the manual `curl | tar` recipe in the runbook. Same #394 cleanup track.
+- `ops/exporters/celestia-tia/celestia-tia-exporter.py`: new `ligate_ready{instance}` gauge by polling the chain's `/v1/health/ready` (default `http://127.0.0.1:12346/v1/health/ready`, 3s timeout) on the same cadence as the balance poll. Gives the `ReadyFalse` alert in `ops/prometheus/alerts.yaml` a metric to fire on without standing up a blackbox-exporter. Companion gauge `ligate_ready_last_check_seconds` exposes the last-probe timestamp for staleness debugging.
+- `ops/exporters/celestia-tia/celestia-tia-exporter.py`: dead-man's-switch gauge `celestia_tia_exporter_alive{instance,account}` flips to 0 if no balance poll has succeeded in `DEAD_MANS_SWITCH_SEC` (default 300s). Lets alert rules separate "balance is low" from "we have no idea what the balance is" (the latter usually means the celestia-light node is dead, not the wallet).
+- `ops/exporters/celestia-tia/celestia-tia-exporter.py`: per-account `account` label (default `da-signer`, configurable via `DA_SIGNER_ACCOUNT` env) on `celestia_node_da_signer_balance_utia` + the three exporter-internal gauges. Future-proofing for the multi-signer split (hot/cold or rotation); today it's a single value, but dashboards group by friendly name instead of by a 45-char bech32. Follow-up #397 tracks the chain-side `ligate_da_submission_failures_total` counter the SDK has to emit (out of scope for this exporter).
 
 ### Fixed
 

--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -1,0 +1,70 @@
+# rpc.ligate.io: TLS-terminated proxy to ligate-node REST.
+# Let's Encrypt cert provisions automatically on first request.
+#
+# Defense-in-depth: only accept traffic that arrived via Cloudflare's
+# published edge IPs. Direct-to-origin IP scans get 403'd before
+# they reach ligate-node. This protects against attackers who
+# discover the GCP VM's external IP (34.66.206.13) and try to
+# bypass the Cloudflare WAF + rate-limit rules.
+#
+# CF IP ranges fetched from https://www.cloudflare.com/ips-{v4,v6}/
+# on 2026-05-16. Cloudflare rarely changes these; review quarterly
+# or when the connection-from-CF check below starts dropping
+# legitimate traffic.
+
+(cloudflare_only) {
+    @not_cloudflare not remote_ip 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13 104.24.0.0/14 172.64.0.0/13 131.0.72.0/22 2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32 2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
+    respond @not_cloudflare "Direct origin access denied. Please go through https://rpc.ligate.io." 403 {
+        close
+    }
+}
+
+rpc.ligate.io {
+    import cloudflare_only
+    encode gzip
+    reverse_proxy 127.0.0.1:12346
+
+    # Health probes are unversioned; ligate-node serves them at the root.
+    handle /health {
+        reverse_proxy 127.0.0.1:12346
+    }
+    handle /ready {
+        reverse_proxy 127.0.0.1:12346
+    }
+
+
+    # Swagger UI v5 from disk overrides the chain-bundled older build
+    # that can't render openapi: 3.1.0 (utoipa hardcodes that version
+    # string; can't be downgraded from chain code). The 5+ bundle
+    # renders 3.1 specs natively. Install steps live in
+    # `docs/development/public-devnet-deploy.md`; assets at
+    # /var/www/swagger-ui/ (chmod a+r, owned ligate:ligate).
+    # Drop this block once Sovereign SDK upgrades its bundled
+    # swagger-ui. Tracking: ligate-io/ligate-chain#394.
+    handle_path /v1/swagger-ui/* {
+        root * /var/www/swagger-ui
+        try_files {path} /index.html
+        file_server
+    }
+    handle /v1/swagger-ui {
+        redir /v1/swagger-ui/ 308
+    }
+
+    # Swagger UI bundle hot-fix: the swagger-initializer.js (whether
+    # the chain-bundled one or our v5 swap) hardcodes
+    # `url: "/openapi-v3.json"` (absolute, no /v1/ prefix). The spec
+    # actually lives at /v1/openapi-v3.json (the chain mounts every
+    # surface under /v1). Rewrite the browser's request internally so
+    # the spec fetch succeeds without touching the chain binary or the
+    # swagger-initializer.js config.
+    handle /openapi-v3.json {
+        rewrite * /v1/openapi-v3.json
+        reverse_proxy 127.0.0.1:12346
+    }
+
+    # Block the Prometheus surface from being public.
+    # Operators scrape from inside the VPC over the unexposed port.
+    handle /metrics {
+        respond "Not exposed publicly. See ops docs." 404
+    }
+}

--- a/ops/exporters/celestia-tia/celestia-tia-exporter.py
+++ b/ops/exporters/celestia-tia/celestia-tia-exporter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tiny Prometheus exporter for the chain's DA-signer TIA balance.
+"""Tiny Prometheus exporter for the chain's DA-signer TIA balance + readiness.
 
 Why this exists.
 
@@ -14,14 +14,29 @@ chain-recorded `seq_da_address` (the address actually submitting
 blobs), NOT `state.Balance` (which returns the light node's default
 account, often a different address that holds nothing).
 
+It also probes the chain's REST `/v1/health/ready` and exposes a
+`ligate_ready` gauge so the `ReadyFalse` alert in alerts.yaml has a
+metric to fire on. Without this, the alert sits silent (blackbox
+exporter isn't deployed). One process for the two thinnest metrics we
+own keeps the systemd unit count down on the sequencer VM.
+
+A dead-man's switch metric (`celestia_tia_exporter_alive`) flips to 0
+if no balance poll has succeeded in DEAD_MANS_SWITCH_SEC (default
+300s). Alert rules can fire on either the balance being stale OR the
+exporter being dead, separately from balance going low.
+
 Config via env:
-    LIGHT_NODE_STORE       /home/ligate/.celestia-light-mocha-4
-    LIGHT_NODE_RPC         http://127.0.0.1:26658
-    LIGHT_NODE_NETWORK     mocha
-    DA_SIGNER_ADDRESS      celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33
-    LIGATE_INSTANCE        ligate-devnet-1-sequencer
-    POLL_INTERVAL_SEC      60
-    EXPORTER_BIND          0.0.0.0:9101
+    LIGHT_NODE_STORE        /home/ligate/.celestia-light-mocha-4
+    LIGHT_NODE_RPC          http://127.0.0.1:26658
+    LIGHT_NODE_NETWORK      mocha
+    DA_SIGNER_ADDRESS       celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33
+    DA_SIGNER_ACCOUNT       da-signer   (friendly label; defaults to "da-signer")
+    LIGATE_INSTANCE         ligate-devnet-1-sequencer
+    LIGATE_READY_URL        http://127.0.0.1:12346/v1/health/ready
+    LIGATE_READY_TIMEOUT    3   (seconds)
+    POLL_INTERVAL_SEC       60
+    DEAD_MANS_SWITCH_SEC    300
+    EXPORTER_BIND           0.0.0.0:9101
 
 Auth token: minted on startup via `celestia light auth admin` and
 re-minted on 401 errors. The token never expires by default (Celestia
@@ -51,8 +66,19 @@ LIGHT_STORE = os.environ.get("LIGHT_NODE_STORE", "/home/ligate/.celestia-light-m
 LIGHT_RPC = os.environ.get("LIGHT_NODE_RPC", "http://127.0.0.1:26658")
 LIGHT_NETWORK = os.environ.get("LIGHT_NODE_NETWORK", "mocha")
 DA_SIGNER_ADDRESS = os.environ["DA_SIGNER_ADDRESS"]  # required; no default
+# Friendly per-account label. Useful once we run a second signer (rotation,
+# hot/cold split, etc.) so dashboards group by account name instead of by
+# a 45-char bech32. Currently always "da-signer".
+DA_SIGNER_ACCOUNT = os.environ.get("DA_SIGNER_ACCOUNT", "da-signer")
 INSTANCE = os.environ.get("LIGATE_INSTANCE", "ligate-devnet-1-sequencer")
+LIGATE_READY_URL = os.environ.get("LIGATE_READY_URL", "http://127.0.0.1:12346/v1/health/ready")
+LIGATE_READY_TIMEOUT = float(os.environ.get("LIGATE_READY_TIMEOUT", "3"))
 POLL_INTERVAL_SEC = int(os.environ.get("POLL_INTERVAL_SEC", "60"))
+# Dead-man's switch threshold: how long the last successful balance poll
+# can be stale before `celestia_tia_exporter_alive` flips to 0. Default
+# is 5x the default poll interval to absorb transient celestia-light
+# blips without alerting.
+DEAD_MANS_SWITCH_SEC = int(os.environ.get("DEAD_MANS_SWITCH_SEC", "300"))
 EXPORTER_BIND = os.environ.get("EXPORTER_BIND", "0.0.0.0:9101")
 
 logging.basicConfig(
@@ -67,10 +93,13 @@ log = logging.getLogger("celestia-tia-exporter")
 _state_lock = threading.Lock()
 _state: dict = {
     "balance_utia": None,        # int | None
-    "last_success_ts": None,     # epoch seconds, when last poll succeeded
+    "last_success_ts": None,     # epoch seconds, when last balance poll succeeded
     "last_error": None,          # str | None
     "consecutive_failures": 0,
     "token": None,               # cached JWT
+    "ligate_ready": None,        # int (1/0) | None — last /v1/health/ready probe outcome
+    "ligate_ready_last_check_ts": None,  # epoch seconds, when last ready probe finished (success or fail)
+    "ligate_ready_last_error": None,     # str | None
 }
 
 
@@ -157,10 +186,29 @@ def fetch_balance() -> int:
     return int(amount)
 
 
+# ----- Ligate-node readiness probe ------------------------------------------
+
+def probe_ligate_ready() -> int:
+    """Hit `/v1/health/ready` and return 1 if 2xx, 0 otherwise.
+
+    Treats both HTTP errors and connection errors as "not ready". The
+    HTTP error path covers cases where the chain is up but stuck (5xx
+    from a health handler that knows it's degraded).
+    """
+    req = urllib.request.Request(LIGATE_READY_URL, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=LIGATE_READY_TIMEOUT) as resp:
+            return 1 if 200 <= resp.status < 300 else 0
+    except urllib.error.HTTPError as e:
+        # 4xx/5xx from the health endpoint = explicitly not ready.
+        return 1 if 200 <= e.code < 300 else 0
+
+
 # ----- Poller loop -----------------------------------------------------------
 
 def poll_loop() -> None:
     while True:
+        # --- TIA balance ---
         try:
             balance = fetch_balance()
             now_ts = int(time.time())
@@ -176,6 +224,24 @@ def poll_loop() -> None:
                 _state["consecutive_failures"] += 1
             log.error("poll failed (%d consecutive): %s",
                       _state["consecutive_failures"], exc)
+
+        # --- Ligate-node readiness ---
+        # Cheap: one localhost GET. Done in-line so both metrics share a
+        # single cadence + a single sleep below.
+        try:
+            ready = probe_ligate_ready()
+            with _state_lock:
+                _state["ligate_ready"] = ready
+                _state["ligate_ready_last_check_ts"] = int(time.time())
+                _state["ligate_ready_last_error"] = None
+            log.info("ready probe: ligate_ready=%d", ready)
+        except Exception as exc:
+            with _state_lock:
+                _state["ligate_ready"] = 0
+                _state["ligate_ready_last_check_ts"] = int(time.time())
+                _state["ligate_ready_last_error"] = str(exc)
+            log.warning("ready probe failed: %s", exc)
+
         time.sleep(POLL_INTERVAL_SEC)
 
 
@@ -198,6 +264,7 @@ class MetricsHandler(http.server.BaseHTTPRequestHandler):
 
         out_lines: list[str] = []
 
+        # ----- Balance gauge (the metric alerts.yaml fires on) --------------
         out_lines.append(
             "# HELP celestia_node_da_signer_balance_utia "
             "DA signer wallet balance in utia (micro-TIA) as observed by polling state.BalanceForAddress against the local light node."
@@ -205,16 +272,17 @@ class MetricsHandler(http.server.BaseHTTPRequestHandler):
         out_lines.append("# TYPE celestia_node_da_signer_balance_utia gauge")
         if snapshot["balance_utia"] is not None:
             out_lines.append(
-                f'celestia_node_da_signer_balance_utia{{instance="{INSTANCE}",address="{DA_SIGNER_ADDRESS}"}} {snapshot["balance_utia"]}'
+                f'celestia_node_da_signer_balance_utia{{instance="{INSTANCE}",address="{DA_SIGNER_ADDRESS}",account="{DA_SIGNER_ACCOUNT}"}} {snapshot["balance_utia"]}'
             )
 
+        # ----- Per-poll diagnostics -----------------------------------------
         out_lines.append(
             "# HELP celestia_tia_exporter_last_success_seconds "
             "Unix timestamp of the last successful poll of the DA-signer balance. 0 if no successful poll yet."
         )
         out_lines.append("# TYPE celestia_tia_exporter_last_success_seconds gauge")
         out_lines.append(
-            f'celestia_tia_exporter_last_success_seconds{{instance="{INSTANCE}"}} {snapshot["last_success_ts"] or 0}'
+            f'celestia_tia_exporter_last_success_seconds{{instance="{INSTANCE}",account="{DA_SIGNER_ACCOUNT}"}} {snapshot["last_success_ts"] or 0}'
         )
 
         out_lines.append(
@@ -223,8 +291,48 @@ class MetricsHandler(http.server.BaseHTTPRequestHandler):
         )
         out_lines.append("# TYPE celestia_tia_exporter_consecutive_failures gauge")
         out_lines.append(
-            f'celestia_tia_exporter_consecutive_failures{{instance="{INSTANCE}"}} {snapshot["consecutive_failures"]}'
+            f'celestia_tia_exporter_consecutive_failures{{instance="{INSTANCE}",account="{DA_SIGNER_ACCOUNT}"}} {snapshot["consecutive_failures"]}'
         )
+
+        # ----- Dead-man's switch --------------------------------------------
+        # 1 if a balance poll succeeded within DEAD_MANS_SWITCH_SEC, else 0.
+        # Lets alert rules distinguish "balance is low" from "we have no idea
+        # what the balance is" — the latter usually means the celestia-light
+        # node is dead, not the wallet.
+        now_ts = int(time.time())
+        last_ok = snapshot["last_success_ts"]
+        alive = 1 if (last_ok is not None and now_ts - last_ok <= DEAD_MANS_SWITCH_SEC) else 0
+        out_lines.append(
+            "# HELP celestia_tia_exporter_alive "
+            "Dead-man's switch: 1 if a balance poll succeeded within DEAD_MANS_SWITCH_SEC, else 0."
+        )
+        out_lines.append("# TYPE celestia_tia_exporter_alive gauge")
+        out_lines.append(
+            f'celestia_tia_exporter_alive{{instance="{INSTANCE}",account="{DA_SIGNER_ACCOUNT}"}} {alive}'
+        )
+
+        # ----- Chain readiness probe ----------------------------------------
+        # Emits 1 if the chain's /v1/health/ready returned 2xx on the last
+        # probe, 0 otherwise. Silent absence (no line) before the first probe
+        # completes so the ReadyFalse alert doesn't fire from cold start.
+        if snapshot["ligate_ready"] is not None:
+            out_lines.append(
+                "# HELP ligate_ready "
+                "1 if /v1/health/ready returned 2xx on the last probe, 0 otherwise. Probed by celestia-tia-exporter every POLL_INTERVAL_SEC."
+            )
+            out_lines.append("# TYPE ligate_ready gauge")
+            out_lines.append(
+                f'ligate_ready{{instance="{INSTANCE}"}} {snapshot["ligate_ready"]}'
+            )
+
+            out_lines.append(
+                "# HELP ligate_ready_last_check_seconds "
+                "Unix timestamp of the last /v1/health/ready probe (success OR fail). 0 if never probed."
+            )
+            out_lines.append("# TYPE ligate_ready_last_check_seconds gauge")
+            out_lines.append(
+                f'ligate_ready_last_check_seconds{{instance="{INSTANCE}"}} {snapshot["ligate_ready_last_check_ts"] or 0}'
+            )
 
         body = "\n".join(out_lines) + "\n"
         self.send_response(200)

--- a/ops/install/swagger-ui-dist.sh
+++ b/ops/install/swagger-ui-dist.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Install swagger-ui-dist@5+ to /var/www/swagger-ui/ for Caddy to serve
+# at /v1/swagger-ui/*. Required because the chain-bundled swagger-ui
+# can't render OpenAPI 3.1 specs (utoipa hardcodes "3.1.0" as the
+# version string and the bundled UI refuses any 3.1.x declaration).
+#
+# Idempotent: safe to re-run. Pin the version at the top; bump when
+# you want a newer swagger-ui release.
+#
+# Run as a user with sudo:
+#   ./ops/install/swagger-ui-dist.sh
+#
+# Drop the dependency on this script + its assets once Sovereign SDK
+# bumps its bundled swagger-ui to 5+. Tracking: ligate-io/ligate-chain#394.
+
+set -euo pipefail
+
+# ----- Config ----------------------------------------------------------------
+
+SWAGGER_UI_VERSION="${SWAGGER_UI_VERSION:-5.17.14}"
+INSTALL_DIR="${INSTALL_DIR:-/var/www/swagger-ui}"
+OWNER_USER="${OWNER_USER:-caddy}"
+OWNER_GROUP="${OWNER_GROUP:-caddy}"
+SPEC_URL="${SPEC_URL:-/openapi-v3.json}"
+
+# ----- Sanity checks --------------------------------------------------------
+
+if ! command -v curl >/dev/null; then
+    echo "curl required, install it first" >&2
+    exit 1
+fi
+if ! command -v tar >/dev/null; then
+    echo "tar required" >&2
+    exit 1
+fi
+if [ "$(id -u)" -ne 0 ] && ! sudo -n true 2>/dev/null; then
+    echo "this script needs sudo (password-less or run as root)" >&2
+    exit 1
+fi
+
+# ----- Download + install ---------------------------------------------------
+
+echo "==> installing swagger-ui-dist@${SWAGGER_UI_VERSION} → ${INSTALL_DIR}"
+sudo mkdir -p "${INSTALL_DIR}"
+
+TARBALL_URL="https://github.com/swagger-api/swagger-ui/archive/refs/tags/v${SWAGGER_UI_VERSION}.tar.gz"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+echo "    fetching ${TARBALL_URL}"
+curl -fsSL -o "${TMPDIR}/swagger-ui.tgz" "${TARBALL_URL}"
+
+# --strip-components=2 drops `swagger-ui-<version>/dist/` so the dist contents
+# land directly under INSTALL_DIR.
+echo "    extracting"
+sudo tar -xzf "${TMPDIR}/swagger-ui.tgz" \
+    --strip-components=2 \
+    -C "${INSTALL_DIR}" \
+    "swagger-ui-${SWAGGER_UI_VERSION}/dist"
+
+# ----- Customize swagger-initializer.js -------------------------------------
+
+# Point swagger-ui at /openapi-v3.json (Caddy's `handle /openapi-v3.json`
+# block internally rewrites that path to /v1/openapi-v3.json so the chain
+# serves it). tryItOutEnabled exposes the Try-it-out button for partners
+# to issue requests directly from the browser.
+echo "==> writing swagger-initializer.js (spec url=${SPEC_URL})"
+sudo tee "${INSTALL_DIR}/swagger-initializer.js" >/dev/null <<EOF
+window.onload = function() {
+  window.ui = SwaggerUIBundle({
+    url: "${SPEC_URL}",
+    dom_id: "#swagger-ui",
+    deepLinking: true,
+    layout: "StandaloneLayout",
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+    tryItOutEnabled: true
+  });
+};
+EOF
+
+# ----- Ownership + permissions ---------------------------------------------
+
+echo "==> chown ${OWNER_USER}:${OWNER_GROUP}"
+# Some hosts run Caddy under a different user; fall back to a world-readable
+# mode if the configured owner doesn't exist.
+if id -u "${OWNER_USER}" >/dev/null 2>&1; then
+    sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" "${INSTALL_DIR}"
+else
+    echo "    (user ${OWNER_USER} not found; chmod a+r instead)"
+    sudo chmod -R a+r "${INSTALL_DIR}"
+fi
+
+# ----- Verify ---------------------------------------------------------------
+
+echo "==> verify"
+if [ ! -f "${INSTALL_DIR}/index.html" ] \
+   || [ ! -f "${INSTALL_DIR}/swagger-ui-bundle.js" ] \
+   || [ ! -f "${INSTALL_DIR}/swagger-initializer.js" ]; then
+    echo "    MISSING expected files in ${INSTALL_DIR}/" >&2
+    ls -la "${INSTALL_DIR}/" >&2
+    exit 1
+fi
+echo "    OK: ${INSTALL_DIR}/ has index.html + swagger-ui-bundle.js + swagger-initializer.js"
+echo ""
+echo "==> Done. Caddy should serve from ${INSTALL_DIR} at /v1/swagger-ui/* per ops/caddy/Caddyfile."
+echo "    Reload Caddy if its config changed: sudo systemctl reload caddy"


### PR DESCRIPTION
Re-cut of v0.2.1, expanded from the prior cosmetic-only patch to bundle four operator-tooling items that close the loop on the devnet-1 launch posture. Branch was rebased onto current main (which already contains #395's openapi fix + swagger-ui docs).

## What's in the bundle

### Item 1: `ops/caddy/Caddyfile` (new)

The live `/etc/caddy/Caddyfile` from the devnet-1 sequencer VM, committed to repo as the canonical source. Documents:

- Cloudflare-only edge allowlist (defense-in-depth against direct-to-origin IP scans)
- `openapi-v3.json` path rewrite (browser hits `/openapi-v3.json` without `/v1/` prefix; Caddy rewrites internally)
- Swagger-UI v5 disk-served override (the chain's bundled UI can't render OpenAPI 3.1)
- `/metrics` lockdown (Prometheus surface stays internal)

Operators rebuilding the VM now reach for the repo's Caddyfile instead of reading state off a running VM. Drop the swagger-ui v5 override block once Sovereign SDK upgrades its bundled UI.

### Item 2: `ops/install/swagger-ui-dist.sh` (new, executable)

Idempotent installer for `swagger-ui-dist@5.17.14` into `/var/www/swagger-ui/`. Downloads the upstream tarball, strips two path components so `dist/*` lands at the install root, writes a custom `swagger-initializer.js` that points the bundle at `/openapi-v3.json` with `tryItOutEnabled: true`, chowns to `caddy:caddy` (falls back to `chmod a+r` if the user isn't present).

Env-configurable: `SWAGGER_UI_VERSION`, `INSTALL_DIR`, `OWNER_USER`, `OWNER_GROUP`, `SPEC_URL`. Replaces the manual `curl | tar` recipe in the runbook.

### Item 4: `ligate_ready` gauge in celestia-tia-exporter

The exporter now polls `/v1/health/ready` on the same cadence as the balance poll and exposes:

```
ligate_ready{instance="..."} 0|1
ligate_ready_last_check_seconds{instance="..."} <unix ts>
```

Gives the `ReadyFalse` alert in `ops/prometheus/alerts.yaml` a metric to fire on, without standing up a separate blackbox-exporter. One process for the two thinnest metrics we own keeps the systemd unit count down on the sequencer VM.

The chain-side `ligate_da_submission_failures_total` counter (the other silent-alert metric) needs SDK code, not exporter polish; tracked separately in #397.

### Item 5: TIA exporter polishes

- **Dead-man's switch**: `celestia_tia_exporter_alive{instance,account}` flips to 0 if no balance poll has succeeded in `DEAD_MANS_SWITCH_SEC` (default 300s). Alert rules can now distinguish "balance is low" from "we have no idea what the balance is" (the latter usually means the celestia-light node is dead, not the wallet).
- **Per-account label**: new `account` label (default `da-signer`, configurable via `DA_SIGNER_ACCOUNT`) on the balance gauge + the three exporter-internal gauges. Future-proofing for the multi-signer split (hot/cold, rotation); today a single value, but dashboards group by friendly name instead of by a 45-char bech32.

## Why bundled instead of separate PRs

Each item is small, all four touch only `ops/`, and v0.2.1 has not been released yet. Shipping them as one cut so the release-train tag lands once instead of four times in a day.

## Out of scope

- `ligate_da_submission_failures_total` chain-side counter → filed as #397 (needs SDK code, not exporter polish).
- TIA top-up itself → user-driven; alerts at <2 TIA still hold until that lands.

## Verification

- `python3 -m py_compile ops/exporters/celestia-tia/celestia-tia-exporter.py` clean
- Hand-crafted state → metrics-render test confirms:
  - Per-account label appears on all 4 gauges
  - `celestia_tia_exporter_alive` flips to 0 when `last_success_ts` is >300s stale
  - `ligate_ready` line absent until first probe, then emits `0|1`
- `ops/caddy/Caddyfile` is a direct copy of the prod VM's live config (deduped comments only); no behaviour change to the running deployment

## Release plan

Merge → re-tag `v0.2.1` → release workflow builds → swap binary on prod (graceful stop / SIGKILL escalation per the v0.1.3 backup-script pattern) → reinstall swagger-ui via the new script to verify it lands the same bundle. `chain_hash` unchanged from v0.2.0; in-place swap is safe.

Closes — (no issue auto-close; #393/#394 already closed by #395 on main).

Refs: #397.