### PR TITLE
ops(caddy): fix /v1/swagger-ui no-slash redirect + wrap catch-all in handle{}

### DIFF
--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -22,7 +22,6 @@
 rpc.ligate.io {
     import cloudflare_only
     encode gzip
-    reverse_proxy 127.0.0.1:12346
 
     # Health probes are unversioned; ligate-node serves them at the root.
     handle /health {
@@ -32,7 +31,6 @@ rpc.ligate.io {
         reverse_proxy 127.0.0.1:12346
     }
 
-
     # Swagger UI v5 from disk overrides the chain-bundled older build
     # that can't render openapi: 3.1.0 (utoipa hardcodes that version
     # string; can't be downgraded from chain code). The 5+ bundle
@@ -41,13 +39,28 @@ rpc.ligate.io {
     # /var/www/swagger-ui/ (chmod a+r, owned ligate:ligate).
     # Drop this block once Sovereign SDK upgrades its bundled
     # swagger-ui. Tracking: ligate-io/ligate-chain#394.
+    #
+    # IMPORTANT: the `redir /v1/swagger-ui/ 308` only fires when this
+    # block routes ahead of the catch-all `reverse_proxy` at the end.
+    # That's the whole reason the catch-all is wrapped in handle{} —
+    # a bare `reverse_proxy` at the site-block level would compete with
+    # these handle{} blocks and could win the routing race, sending
+    # /v1/swagger-ui to the chain's broken bundled UI instead.
     handle_path /v1/swagger-ui/* {
         root * /var/www/swagger-ui
         try_files {path} /index.html
         file_server
     }
     handle /v1/swagger-ui {
-        redir /v1/swagger-ui/ 308
+        # Explicit `*` matcher is required: Caddy's `redir` directive
+        # treats its first argument as a path matcher if it starts with
+        # `/`. So `redir /v1/swagger-ui/ 308` was being parsed as
+        # `redir <matcher=/v1/swagger-ui/> <to=308>`, producing a route
+        # that 302'd to literal "308" only when the path was already
+        # `/v1/swagger-ui/`. With `*` (matches anything in this
+        # subroute's scope) Caddy parses correctly:
+        # `redir <matcher=*> <to=/v1/swagger-ui/> <code=308>`.
+        redir * /v1/swagger-ui/ 308
     }
 
     # Swagger UI bundle hot-fix: the swagger-initializer.js (whether
@@ -66,5 +79,18 @@ rpc.ligate.io {
     # Operators scrape from inside the VPC over the unexposed port.
     handle /metrics {
         respond "Not exposed publicly. See ops docs." 404
+    }
+
+    # Catch-all: every other path proxies to ligate-node.
+    # MUST be wrapped in handle{} — a bare directive at the site-block
+    # level competes with the explicit handle{} blocks above and can
+    # win the routing race. The original Caddyfile had `reverse_proxy
+    # 127.0.0.1:12346` as a bare directive, which is exactly why the
+    # `/v1/swagger-ui` (no trailing slash) redirect wasn't firing:
+    # the bare proxy was winning over `handle /v1/swagger-ui { redir }`.
+    # Empty matcher (handle without a path) = fallback for any request
+    # not matched by a more specific handle block above.
+    handle {
+        reverse_proxy 127.0.0.1:12346
     }
 }


### PR DESCRIPTION
Two related Caddyfile fixes; both already hot-patched on prod (rpc.ligate.io) and verified.

## Bug 1: `/v1/swagger-ui` (no trailing slash) returned the chain's broken UI

`redir /v1/swagger-ui/ 308` was being parsed by Caddy as `redir <matcher=/v1/swagger-ui/> <to=308>` (Caddy's `redir` directive treats a `/`-prefixed first argument as a path matcher). The compiled config:

```json
{
  "handler": "static_response",
  "headers": { "Location": ["308"] },        // ← literal "308"
  "status_code": 302                          // ← default
},
"match": [{ "path": ["/v1/swagger-ui/"] }]   // ← redirect target became the matcher
```

So the redirect only fired when the path was already `/v1/swagger-ui/` (with slash), at which point it tried to redirect to literal `"308"`.

Fix: explicit `*` matcher → `redir * /v1/swagger-ui/ 308`. Caddy now parses correctly:

```json
{
  "handler": "static_response",
  "headers": { "Location": ["/v1/swagger-ui/"] },
  "status_code": 308
}
```

## Bug 2: bare `reverse_proxy` raced the handle blocks

`reverse_proxy 127.0.0.1:12346` at the site-block level (line 25 of the previous Caddyfile) was a bare directive sitting outside any `handle` block. Caddy's `handle` blocks are mutually-exclusive routes — but bare directives compete with them based on directive ordering, and can win the race.

This is why `/v1/swagger-ui` (no slash) was proxying through to the chain's broken bundled UI even when bug #1 above hadn't fired yet: the bare `reverse_proxy` was matching before `handle /v1/swagger-ui {…}` could.

Fix: wrap the catch-all in `handle { reverse_proxy 127.0.0.1:12346 }` (empty matcher = fallback for any path not matched by an earlier handle). Canonical Caddy v2 idiom.

## Verification

```bash
$ curl -sIv https://rpc.ligate.io/v1/swagger-ui 2>&1 | grep -iE '< (HTTP|location)'
< HTTP/2 308
< location: /v1/swagger-ui/
```

Before: `HTTP/2 200` (returned the chain's broken text/html). After: `HTTP/2 308` → browser follows to `/v1/swagger-ui/` and gets the v5 swagger-ui-dist bundle from disk rendering the v0.2.2 OpenAPI spec.

## Scope

`ops/caddy/Caddyfile` only. Single file, +29/-3. Comments explain the failure modes for future maintainers.

`chain_hash` unchanged; no binary deploy. Caddy `systemctl reload` already done on prod.