### PR TITLE
ops(grafana): fix cost dashboard for 100k TIA baseline (clamp draw-down, runway panel, bump thresholds)

### DIFF
--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -263,6 +263,156 @@
           }
         }
       ]
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "afm64tqkoba4ga"
+      },
+      "description": "Total faucet drips landed today (web + Discord bot combined). Source: api.ligate.io/v1/stats/drips-daily?days=1 (UTC day-bucketed). Web = bank.transfer txs from the faucet wallet, read from the indexer's transactions table. Bot = rows in the api's bot_drips table (one per successful /v1/drip-bot call). Stat shows the most-recent day's total.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 12
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "total",
+              "text": "total",
+              "type": "number"
+            }
+          ],
+          "filters": [],
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "points",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/stats/drips-daily?days=1",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Drips today (web + bot)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "afm64tqkoba4ga"
+      },
+      "description": "Daily faucet drips over the last 30 days, stacked by source. `web` = chain-side count of bank.transfer txs from the faucet wallet (read from the indexer's transactions table). `bot` = api-side count from bot_drips (one row per /v1/drip-bot success). Source: api.ligate.io/v1/stats/drips-daily?days=30. Days with zero drips are present in the series with 0 values.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "web"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#A7D28C"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bot"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#C49963"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 6,
+        "y": 12
+      },
+      "id": 7,
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "date",
+              "text": "date",
+              "type": "timestamp",
+              "timestampFormat": "YYYY-MM-DD"
+            },
+            {
+              "selector": "web",
+              "text": "web",
+              "type": "number"
+            },
+            {
+              "selector": "bot",
+              "text": "bot",
+              "type": "number"
+            }
+          ],
+          "filters": [],
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "points",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/stats/drips-daily?days=30",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Drips per day (web vs bot)",
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -174,6 +174,95 @@
       ],
       "title": "Runway (days at 7d burn, capped 10y)",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "afm64tqkoba4ga"
+      },
+      "description": "LGT balance of the faucet hot wallet (lig1kfaqfu…). Drained by every successful drip (web @ 100 LGT / bot @ 100-1000 LGT). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 LGT. Display shows raw nano-LGT divided by 1e9 via the panel's Calculate-field transform.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              },
+              {
+                "color": "green",
+                "value": 100000
+              }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "amount_nano",
+              "text": "amount_nano",
+              "type": "number"
+            }
+          ],
+          "filters": [],
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "balances",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/addresses/lig1kfaqfuxejztfgl803v375djashtnsd9dqj0mfy37x4zlzd3nyqm",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Faucet wallet LGT balance",
+      "type": "stat",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "lgt",
+            "binary": {
+              "left": "amount_nano",
+              "operator": "/",
+              "right": "1000000000"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ]
     }
   ],
   "refresh": "1m",

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -31,10 +31,10 @@
         }
       },
       "gridPos": {
-        "h": 4,
-        "w": 6,
         "x": 0,
-        "y": 0
+        "y": 0,
+        "w": 6,
+        "h": 6
       },
       "id": 1,
       "options": {
@@ -57,130 +57,10 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
-      },
-      "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10
-          },
-          "unit": "none"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 6,
-        "y": 0
-      },
-      "id": 2,
-      "targets": [
-        {
-          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
-          "legendFormat": "{{instance}}"
-        }
-      ],
-      "title": "TIA balance trend",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
-      },
-      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative — without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
-      "fieldConfig": {
-        "defaults": {
-          "decimals": 3,
-          "unit": "none"
-        }
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 4
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "targets": [
-        {
-          "expr": "clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * 86400 / 1e6, 0)",
-          "legendFormat": "{{instance}}"
-        }
-      ],
-      "title": "TIA draw-down rate (per $window)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
-      },
-      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years) — anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
-      "fieldConfig": {
-        "defaults": {
-          "decimals": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 30
-              },
-              {
-                "color": "green",
-                "value": 90
-              }
-            ]
-          },
-          "unit": "d"
-        }
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 8
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "targets": [
-        {
-          "expr": "clamp_max((celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6) / clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[7d]) * 86400 / 1e6, 0.001), 3650)",
-          "legendFormat": "{{instance}}"
-        }
-      ],
-      "title": "Runway (days at 7d burn, capped 10y)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "afm64tqkoba4ga"
       },
-      "description": "LGT balance of the faucet hot wallet (lig1kfaqfu…). Drained by every successful drip (web @ 100 LGT / bot @ 100-1000 LGT). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 LGT. Display shows raw nano-LGT divided by 1e9 via the panel's Calculate-field transform.",
+      "description": "LGT balance of the faucet hot wallet (lig1kfaqfu\u2026). Drained by every successful drip (web @ 100 LGT / bot @ 100-1000 LGT). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 LGT. Display shows raw nano-LGT divided by 1e9 via the panel's Calculate-field transform.",
       "fieldConfig": {
         "defaults": {
           "decimals": 2,
@@ -205,10 +85,10 @@
         }
       },
       "gridPos": {
-        "h": 4,
-        "w": 6,
         "x": 6,
-        "y": 8
+        "y": 0,
+        "w": 6,
+        "h": 6
       },
       "id": 5,
       "options": {
@@ -266,6 +146,60 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years) \u2014 anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "d"
+        }
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 6
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "expr": "clamp_max((celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6) / clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[7d]) * 86400 / 1e6, 0.001), 3650)",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "Runway (days at 7d burn, capped 10y)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "afm64tqkoba4ga"
       },
@@ -277,10 +211,10 @@
         }
       },
       "gridPos": {
-        "h": 4,
+        "x": 18,
+        "y": 0,
         "w": 6,
-        "x": 0,
-        "y": 12
+        "h": 6
       },
       "id": 6,
       "options": {
@@ -317,6 +251,74 @@
       ],
       "title": "Drips today (web + bot)",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative \u2014 without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 24,
+        "h": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "expr": "clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * 86400 / 1e6, 0)",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "TIA draw-down rate (per $window)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 12,
+        "h": 11
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "TIA balance trend",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -371,10 +373,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
+        "y": 10,
         "w": 12,
-        "x": 6,
-        "y": 12
+        "h": 11
       },
       "id": 7,
       "targets": [

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -1,12 +1,12 @@
 {
-  "description": "\n\nGCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) removed 2026-05-18 pending GCP billing wiring decision. See chain follow-up issue.",
+  "description": "DA signer wallet (TIA) balance, burn rate, and runway. Powered by celestia-tia-exporter sidecar (ops/exporters/celestia-tia/). GCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) are tracked separately in chain follow-up issue #392.",
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "description": "Current TIA balance on the DA signer wallet in whole TIA (utia / 1e6). Source: Celestia light node's /metrics endpoint. Red at <10 TIA (~7 day runway), yellow at <50 TIA, green above.",
+      "description": "Current TIA balance on the DA signer wallet in whole TIA (utia / 1e6). Source: celestia-tia-exporter sidecar polling state.BalanceForAddress on the local light node. Thresholds match the alert rules in ops/prometheus/alerts.yaml: page at <1000 TIA (likely drain attack), warn at <10000 TIA, green above. Calibrated to the ~100k TIA post-top-up baseline; at observed devnet burn (~0.15-0.5 TIA/day) the wallet should sit in the green for years.",
       "fieldConfig": {
         "defaults": {
           "decimals": 2,
@@ -19,11 +19,11 @@
               },
               {
                 "color": "yellow",
-                "value": 10
+                "value": 1000
               },
               {
                 "color": "green",
-                "value": 50
+                "value": 10000
               }
             ]
           },
@@ -91,7 +91,7 @@
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "description": "TIA burned per day, averaged over $window. Negative draw-down (positive sign here after the *-1) means balance is decreasing. Compare against the alert threshold (50 TIA/30 days = ~1.67 TIA/day baseline; spikes above 5 TIA/day suggest abuse or backfill anomaly).",
+      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative — without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
       "fieldConfig": {
         "defaults": {
           "decimals": 3,
@@ -115,11 +115,64 @@
       },
       "targets": [
         {
-          "expr": "rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * -1 * 60 * 60 * 24 / 1e6",
+          "expr": "clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * 86400 / 1e6, 0)",
           "legendFormat": "{{instance}}"
         }
       ],
       "title": "TIA draw-down rate (per $window)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years) — anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "d"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "clamp_max((celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6) / clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[7d]) * 86400 / 1e6, 0.001), 3650)",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "Runway (days at 7d burn, capped 10y)",
       "type": "stat"
     }
   ],
@@ -156,11 +209,11 @@
       },
       {
         "current": {
-          "text": "24h",
-          "value": "24h"
+          "text": "7d",
+          "value": "7d"
         },
         "name": "window",
-        "query": "1h,24h,7d",
+        "query": "1h,24h,7d,30d",
         "type": "custom"
       }
     ]


### PR DESCRIPTION
Dashboard was returning useless values post the 100k TIA top-up. Fixed live on Grafana already (`https://ligate.grafana.net/d/ligate-devnet-1-cost`); this PR catches the repo up.

## What was broken

### 1. Draw-down rate panel showing `-144,015,682 TIA/day`

`rate(celestia_node_da_signer_balance_utia[1h])` over a window that includes the 100k top-up event computes the slope of that step jump. Then `*-1` to express drawdown-as-positive flips it to a massively negative number. Mathematically correct (balance IS increasing at 144M TIA/day during the 1-hour window that contains the top-up) but operationally useless — you can't tell whether the chain is burning normally or wedged.

Fix: wrap in `clamp_min(..., 0)`. Top-ups now show 0 burn (since "receiving TIA" isn't "burning TIA"). Real burn periods show the positive rate. Bumped default window 24h → 7d so single top-up events don't dominate the visualization.

### 2. Balance-stat thresholds calibrated to a ~50 TIA wallet

Red < 10 TIA, yellow < 50, green > 50 made sense pre-top-up. With ~100k TIA the panel is permanently dark green — no useful signal.

Fix: thresholds now mirror the alert rules in `ops/prometheus/alerts.yaml` (which were bumped in #405):
- red < 1,000 TIA (likely drain attack)
- yellow < 10,000 TIA (investigate)
- green ≥ 10,000 TIA

### 3. No runway panel

With a 100k baseline, "TIA/day burn" is interesting but "how many days until I'm broke" is what the operator actually wants to see.

Fix: new stat panel `Runway (days at 7d burn, capped 10y)`:

```promql
clamp_max(
  (celestia_node_da_signer_balance_utia / 1e6)
  / clamp_min(-rate(celestia_node_da_signer_balance_utia[7d]) * 86400 / 1e6, 0.001),
  3650
)
```

`clamp_min` floor of 0.001 TIA/day prevents div-by-zero when burn is exactly 0 (which it is right now post-top-up until the 7d window slides past the step). `clamp_max` cap at 3650 days (10 years) prevents the "100M days runway" cosmetic glitch when burn clamps to floor. Thresholds: red < 30d, yellow 30-90d, green > 90d.

### 4. Stale description

Removed the "GCP panels removed pending wiring decision" header note since that's repo history now. Refs back to chain#392 for the GCP cost wiring follow-up.

## Verified live

Pulled live values from Prom right after upload:
- balance: **100,010.87 TIA** ✓
- draw-down (7d window, clamped): **0 TIA/day** ✓ (correct — 7d window still contains the top-up step, will start showing real burn ~7 days from now)
- runway (capped): **3,650 d** ✓ (display cap; actual runway against current near-zero clamped burn is effectively unbounded)

## Scope

`monitoring/grafana/ligate-devnet-1-cost.json` only. Single file, +62/-9. Already applied to live Grafana (version 8 in the version history); this PR is the audit trail. GCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) still tracked separately as ligate-chain#392 — they need BigQuery billing export + Grafana BigQuery datasource setup before they're reachable.