### PR TITLE
ops(cloud-init): commit sequencer.yaml + dereference from deploy runbook (closes #344)

### DIFF
--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -61,7 +61,7 @@ gcloud compute instances create ligate-devnet-1-sequencer \
     --boot-disk-size=20GB \
     --create-disk=name=ligate-data,size=150GB,type=pd-ssd \
     --tags=http-server,https-server \
-    --metadata-from-file=user-data=cloud-init.yaml
+    --metadata-from-file=user-data=ops/cloud-init/sequencer.yaml
 ```
 
 For a follower, swap `--machine-type=e2-medium`, `--create-disk=...,size=100GB`, and rename the instance.
@@ -80,112 +80,16 @@ Point `rpc.ligate.io` (or your follower-side equivalent) at that IP via your DNS
 
 ## Step 2: cloud-init
 
-The `cloud-init.yaml` referenced above:
+The `cloud-init.yaml` referenced above is checked in at [`ops/cloud-init/sequencer.yaml`](../../ops/cloud-init/sequencer.yaml). Pass it to `gcloud compute instances create` via `--metadata-from-file=user-data=ops/cloud-init/sequencer.yaml` (as in the Step 1 invocation above).
 
-```yaml
-#cloud-config
-package_update: true
-package_upgrade: true
+What it provisions:
 
-packages:
-  - build-essential
-  - pkg-config
-  - libssl-dev
-  - cmake
-  - clang
-  - curl
-  - git
-  - jq
-  - rsync
-  - chrony
-
-write_files:
-  - path: /etc/systemd/system/celestia-light.service
-    content: |
-      [Unit]
-      Description=Celestia light node (Mocha)
-      After=network-online.target
-      Wants=network-online.target
-
-      [Service]
-      User=ligate
-      ExecStart=/usr/local/bin/celestia light start \
-          --core.ip rpc-mocha.pops.one \
-          --p2p.network mocha \
-          --rpc.addr 127.0.0.1 \
-          --rpc.port 26658
-      Restart=on-failure
-      RestartSec=5
-      LimitNOFILE=65536
-
-      [Install]
-      WantedBy=multi-user.target
-
-  - path: /etc/systemd/system/ligate-node.service
-    content: |
-      [Unit]
-      Description=Ligate Chain node (devnet-1)
-      After=celestia-light.service network-online.target
-      Wants=celestia-light.service
-
-      [Service]
-      User=ligate
-      Group=ligate
-      WorkingDirectory=/opt/ligate
-      EnvironmentFile=/etc/ligate/env
-      ExecStart=/opt/ligate/bin/ligate-node \
-          --da-layer celestia \
-          --rollup-config-path /opt/ligate/devnet-1/celestia.toml \
-          --genesis-config-dir /opt/ligate/devnet-1/genesis \
-          --metrics-bind 127.0.0.1:9100
-      Restart=on-failure
-      RestartSec=10
-      # RocksDB compaction + WAL flush on shutdown can take 2-3 min on a
-      # hot state DB. The systemd default of 90s triggered a SIGKILL
-      # during the v0.1.1-devnet swap on 2026-05-16 (chain#362). 300s
-      # gives headroom without leaving zombie processes around forever.
-      TimeoutStopSec=300
-      LimitNOFILE=65536
-
-      [Install]
-      WantedBy=multi-user.target
-
-runcmd:
-  - useradd -m -s /bin/bash ligate
-  - mkdir -p /opt/ligate /etc/ligate /var/lib/ligate
-  - chown ligate:ligate /opt/ligate /etc/ligate /var/lib/ligate
-  # Mount the persistent data disk to /var/lib/ligate
-  - |
-    DEVICE=$(readlink -f /dev/disk/by-id/google-ligate-data)
-    mkfs.ext4 -F $DEVICE
-    echo "$DEVICE /var/lib/ligate ext4 defaults,nofail 0 2" >> /etc/fstab
-    mount /var/lib/ligate
-  # Pre-create the RocksDB directory on the persistent disk so the
-  # operator's Step 3 symlink lands somewhere valid. Without this the
-  # chain writes state to /opt/ligate/devnet-1/data-celestia on the
-  # boot disk, and a VM image rebuild wipes the chain's local history.
-  # See "Migrating an existing host to the persistent disk" in
-  # docs/development/runbooks/backup-restore.md for the same path,
-  # but applied after-the-fact on hosts that booted without this step.
-  - mkdir -p /var/lib/ligate/rocksdb
-  - chown ligate:ligate /var/lib/ligate/rocksdb
-  # Install Rust + risc0 toolchain (sequencer only; follower can skip risc0)
-  - sudo -u ligate bash -lc 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
-  # Install Celestia light node binary. Newer Celestia releases ship
-  # as a tar.gz (was a bare binary in earlier releases); extract and
-  # install the `celestia` binary.
-  - |
-    CELESTIA_VERSION=v0.30.2
-    curl -fsSL "https://github.com/celestiaorg/celestia-node/releases/download/${CELESTIA_VERSION}/celestia-node_Linux_x86_64.tar.gz" \
-      -o /tmp/celestia.tar.gz
-    tar -xzf /tmp/celestia.tar.gz -C /tmp/
-    install -o root -g root -m 0755 /tmp/celestia /usr/local/bin/celestia
-  - sudo -u ligate /usr/local/bin/celestia light init --p2p.network=mocha
-  - systemctl daemon-reload
-  - systemctl enable --now celestia-light.service
-  # ligate-node service starts manually after the operator has placed the
-  # binary, devnet-1 configs, and /etc/ligate/env (with secrets).
-```
+- Build tooling (rustc + cargo via rustup, plus `build-essential` / `clang` / `pkg-config` / `libssl-dev` so a from-source `cargo build --release --bin ligate-node` works if a release tarball isn't usable).
+- The `ligate` system user, with `/opt/ligate`, `/etc/ligate`, and `/var/lib/ligate` ownership.
+- The persistent data disk formatted as ext4 and mounted at `/var/lib/ligate` (idempotent — re-running cloud-init on a VM with an existing FS doesn't reformat). `/var/lib/ligate/rocksdb` is pre-created so the Step 3 storage symlink lands somewhere valid.
+- `celestia-light` v0.30.2 installed to `/usr/local/bin/celestia`, initialised against Mocha, and a `celestia-light.service` systemd unit that auto-starts on boot.
+- A `ligate-node.service` systemd unit (with `TimeoutStopSec=300` so RocksDB compaction has time to finish — chain#362 retro). **Not enabled** — would crashloop on missing binary; operator starts it manually after Step 3.
+- `chrony` enabled as belt-and-braces NTP.
 
 The cloud-init does the chassis. The operator still has to:
 

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -263,6 +263,156 @@
           }
         }
       ]
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "afm64tqkoba4ga"
+      },
+      "description": "Total faucet drips landed today (web + Discord bot combined). Source: api.ligate.io/v1/stats/drips-daily?days=1 (UTC day-bucketed). Web = bank.transfer txs from the faucet wallet, read from the indexer's transactions table. Bot = rows in the api's bot_drips table (one per successful /v1/drip-bot call). Stat shows the most-recent day's total.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 12
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "total",
+              "text": "total",
+              "type": "number"
+            }
+          ],
+          "filters": [],
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "points",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/stats/drips-daily?days=1",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Drips today (web + bot)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "afm64tqkoba4ga"
+      },
+      "description": "Daily faucet drips over the last 30 days, stacked by source. `web` = chain-side count of bank.transfer txs from the faucet wallet (read from the indexer's transactions table). `bot` = api-side count from bot_drips (one row per /v1/drip-bot success). Source: api.ligate.io/v1/stats/drips-daily?days=30. Days with zero drips are present in the series with 0 values.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "web"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#A7D28C"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bot"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#C49963"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 6,
+        "y": 12
+      },
+      "id": 7,
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "date",
+              "text": "date",
+              "type": "timestamp",
+              "timestampFormat": "YYYY-MM-DD"
+            },
+            {
+              "selector": "web",
+              "text": "web",
+              "type": "number"
+            },
+            {
+              "selector": "bot",
+              "text": "bot",
+              "type": "number"
+            }
+          ],
+          "filters": [],
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "points",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/stats/drips-daily?days=30",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Drips per day (web vs bot)",
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -174,6 +174,95 @@
       ],
       "title": "Runway (days at 7d burn, capped 10y)",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "afm64tqkoba4ga"
+      },
+      "description": "LGT balance of the faucet hot wallet (lig1kfaqfu…). Drained by every successful drip (web @ 100 LGT / bot @ 100-1000 LGT). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 LGT. Display shows raw nano-LGT divided by 1e9 via the panel's Calculate-field transform.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              },
+              {
+                "color": "green",
+                "value": 100000
+              }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "amount_nano",
+              "text": "amount_nano",
+              "type": "number"
+            }
+          ],
+          "filters": [],
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "balances",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/addresses/lig1kfaqfuxejztfgl803v375djashtnsd9dqj0mfy37x4zlzd3nyqm",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Faucet wallet LGT balance",
+      "type": "stat",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "lgt",
+            "binary": {
+              "left": "amount_nano",
+              "operator": "/",
+              "right": "1000000000"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ]
     }
   ],
   "refresh": "1m",

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -31,10 +31,10 @@
         }
       },
       "gridPos": {
-        "h": 4,
-        "w": 6,
         "x": 0,
-        "y": 0
+        "y": 0,
+        "w": 6,
+        "h": 6
       },
       "id": 1,
       "options": {
@@ -57,130 +57,10 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
-      },
-      "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10
-          },
-          "unit": "none"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 6,
-        "y": 0
-      },
-      "id": 2,
-      "targets": [
-        {
-          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
-          "legendFormat": "{{instance}}"
-        }
-      ],
-      "title": "TIA balance trend",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
-      },
-      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative — without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
-      "fieldConfig": {
-        "defaults": {
-          "decimals": 3,
-          "unit": "none"
-        }
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 4
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "targets": [
-        {
-          "expr": "clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * 86400 / 1e6, 0)",
-          "legendFormat": "{{instance}}"
-        }
-      ],
-      "title": "TIA draw-down rate (per $window)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "grafanacloud-prom"
-      },
-      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years) — anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
-      "fieldConfig": {
-        "defaults": {
-          "decimals": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 30
-              },
-              {
-                "color": "green",
-                "value": 90
-              }
-            ]
-          },
-          "unit": "d"
-        }
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 8
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "targets": [
-        {
-          "expr": "clamp_max((celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6) / clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[7d]) * 86400 / 1e6, 0.001), 3650)",
-          "legendFormat": "{{instance}}"
-        }
-      ],
-      "title": "Runway (days at 7d burn, capped 10y)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "afm64tqkoba4ga"
       },
-      "description": "LGT balance of the faucet hot wallet (lig1kfaqfu…). Drained by every successful drip (web @ 100 LGT / bot @ 100-1000 LGT). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 LGT. Display shows raw nano-LGT divided by 1e9 via the panel's Calculate-field transform.",
+      "description": "LGT balance of the faucet hot wallet (lig1kfaqfu\u2026). Drained by every successful drip (web @ 100 LGT / bot @ 100-1000 LGT). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 LGT. Display shows raw nano-LGT divided by 1e9 via the panel's Calculate-field transform.",
       "fieldConfig": {
         "defaults": {
           "decimals": 2,
@@ -205,10 +85,10 @@
         }
       },
       "gridPos": {
-        "h": 4,
-        "w": 6,
         "x": 6,
-        "y": 8
+        "y": 0,
+        "w": 6,
+        "h": 6
       },
       "id": 5,
       "options": {
@@ -266,6 +146,60 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years) \u2014 anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "d"
+        }
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 6
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "expr": "clamp_max((celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6) / clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[7d]) * 86400 / 1e6, 0.001), 3650)",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "Runway (days at 7d burn, capped 10y)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "afm64tqkoba4ga"
       },
@@ -277,10 +211,10 @@
         }
       },
       "gridPos": {
-        "h": 4,
+        "x": 18,
+        "y": 0,
         "w": 6,
-        "x": 0,
-        "y": 12
+        "h": 6
       },
       "id": 6,
       "options": {
@@ -317,6 +251,74 @@
       ],
       "title": "Drips today (web + bot)",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative \u2014 without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 24,
+        "h": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "expr": "clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * 86400 / 1e6, 0)",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "TIA draw-down rate (per $window)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "TIA balance over the dashboard's time range. A consistent downward slope is expected (blob submission burns TIA); a flat line indicates no submissions are happening (which would coincide with chain stall alerts).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 12,
+        "h": 11
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "TIA balance trend",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -371,10 +373,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "x": 12,
+        "y": 10,
         "w": 12,
-        "x": 6,
-        "y": 12
+        "h": 11
       },
       "id": 7,
       "targets": [

--- a/monitoring/grafana/ligate-devnet-1-cost.json
+++ b/monitoring/grafana/ligate-devnet-1-cost.json
@@ -1,12 +1,12 @@
 {
-  "description": "\n\nGCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) removed 2026-05-18 pending GCP billing wiring decision. See chain follow-up issue.",
+  "description": "DA signer wallet (TIA) balance, burn rate, and runway. Powered by celestia-tia-exporter sidecar (ops/exporters/celestia-tia/). GCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) are tracked separately in chain follow-up issue #392.",
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "description": "Current TIA balance on the DA signer wallet in whole TIA (utia / 1e6). Source: Celestia light node's /metrics endpoint. Red at <10 TIA (~7 day runway), yellow at <50 TIA, green above.",
+      "description": "Current TIA balance on the DA signer wallet in whole TIA (utia / 1e6). Source: celestia-tia-exporter sidecar polling state.BalanceForAddress on the local light node. Thresholds match the alert rules in ops/prometheus/alerts.yaml: page at <1000 TIA (likely drain attack), warn at <10000 TIA, green above. Calibrated to the ~100k TIA post-top-up baseline; at observed devnet burn (~0.15-0.5 TIA/day) the wallet should sit in the green for years.",
       "fieldConfig": {
         "defaults": {
           "decimals": 2,
@@ -19,11 +19,11 @@
               },
               {
                 "color": "yellow",
-                "value": 10
+                "value": 1000
               },
               {
                 "color": "green",
-                "value": 50
+                "value": 10000
               }
             ]
           },
@@ -91,7 +91,7 @@
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "description": "TIA burned per day, averaged over $window. Negative draw-down (positive sign here after the *-1) means balance is decreasing. Compare against the alert threshold (50 TIA/30 days = ~1.67 TIA/day baseline; spikes above 5 TIA/day suggest abuse or backfill anomaly).",
+      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative — without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
       "fieldConfig": {
         "defaults": {
           "decimals": 3,
@@ -115,11 +115,64 @@
       },
       "targets": [
         {
-          "expr": "rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * -1 * 60 * 60 * 24 / 1e6",
+          "expr": "clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[$window]) * 86400 / 1e6, 0)",
           "legendFormat": "{{instance}}"
         }
       ],
       "title": "TIA draw-down rate (per $window)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years) — anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "d"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "clamp_max((celestia_node_da_signer_balance_utia{instance=~\"$instance\"} / 1e6) / clamp_min(-rate(celestia_node_da_signer_balance_utia{instance=~\"$instance\"}[7d]) * 86400 / 1e6, 0.001), 3650)",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "title": "Runway (days at 7d burn, capped 10y)",
       "type": "stat"
     }
   ],
@@ -156,11 +209,11 @@
       },
       {
         "current": {
-          "text": "24h",
-          "value": "24h"
+          "text": "7d",
+          "value": "7d"
         },
         "name": "window",
-        "query": "1h,24h,7d",
+        "query": "1h,24h,7d,30d",
         "type": "custom"
       }
     ]

--- a/ops/cloud-init/sequencer.yaml
+++ b/ops/cloud-init/sequencer.yaml
@@ -1,0 +1,167 @@
+#cloud-config
+# Cloud-init for a Ligate Chain sequencer VM (Ubuntu 24.04, GCP-tested).
+#
+# Use:
+#   gcloud compute instances create ligate-devnet-1-sequencer \
+#       --machine-type=e2-standard-4 \
+#       --image-family=ubuntu-2404-lts-amd64 --image-project=ubuntu-os-cloud \
+#       --boot-disk-size=20GB \
+#       --create-disk=name=ligate-data,size=150GB,type=pd-ssd \
+#       --metadata-from-file=user-data=ops/cloud-init/sequencer.yaml
+#
+# Provisions the "chassis" only:
+#   - Build tooling (rustc, pkg-config, clang) so the operator can
+#     `cargo build` on the box if a binary release isn't usable.
+#   - `ligate` system user (uid is whatever useradd picks; the chain's
+#     storage paths under /opt/ligate + /var/lib/ligate get chowned to
+#     match).
+#   - Persistent data disk mounted at /var/lib/ligate (with
+#     `/var/lib/ligate/rocksdb` pre-created so the operator's storage
+#     symlink in Step 3 of the deploy runbook lands somewhere valid).
+#   - celestia-light v0.30.2 binary at /usr/local/bin/celestia, init
+#     against Mocha, and a systemd unit that boots it under the
+#     `ligate` user.
+#   - ligate-node systemd unit (unstarted; the operator places the
+#     binary + /etc/ligate/env separately before `systemctl start`).
+#   - `chrony` explicitly enabled as belt-and-braces NTP; GCP provides
+#     its own NTP via the metadata server but we don't depend on it.
+#
+# What this DOES NOT do:
+#   - Place the ligate-node binary (operator copies from a release
+#     tarball or builds from source — see deploy runbook Step 3).
+#   - Place the devnet-1/ config dir (`git clone` step in the runbook).
+#   - Place secrets in /etc/ligate/env (operator hand-writes; never
+#     committed to repo).
+#   - Start ligate-node.service (waits on the above).
+#
+# Idempotency: re-running cloud-init is safe — `useradd` short-circuits
+# if the user exists, `mkdir -p` is no-op on existing dirs, `mkfs.ext4
+# -F` would re-format the data disk so the wrapping shell block
+# pre-checks for the existing filesystem.
+#
+# Drift from this file (e.g. `ExecStart` changes after-the-fact via
+# /etc/systemd/system/) is OK in emergency triage; bring the in-VM
+# state back in line by re-applying this cloud-init on the next
+# rebuild, OR ssh + diff + commit a follow-up so the repo stays the
+# source of truth.
+
+package_update: true
+package_upgrade: true
+
+packages:
+  - build-essential
+  - pkg-config
+  - libssl-dev
+  - cmake
+  - clang
+  - curl
+  - git
+  - jq
+  - rsync
+  - chrony
+
+write_files:
+  - path: /etc/systemd/system/celestia-light.service
+    content: |
+      [Unit]
+      Description=Celestia light node (Mocha)
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      User=ligate
+      ExecStart=/usr/local/bin/celestia light start \
+          --core.ip rpc-mocha.pops.one \
+          --p2p.network mocha \
+          --rpc.addr 127.0.0.1 \
+          --rpc.port 26658
+      Restart=on-failure
+      RestartSec=5
+      LimitNOFILE=65536
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /etc/systemd/system/ligate-node.service
+    content: |
+      [Unit]
+      Description=Ligate Chain node (devnet-1)
+      After=celestia-light.service network-online.target
+      Wants=celestia-light.service
+
+      [Service]
+      User=ligate
+      Group=ligate
+      WorkingDirectory=/opt/ligate
+      EnvironmentFile=/etc/ligate/env
+      ExecStart=/opt/ligate/bin/ligate-node \
+          --da-layer celestia \
+          --rollup-config-path /opt/ligate/devnet-1/celestia.toml \
+          --genesis-config-dir /opt/ligate/devnet-1/genesis \
+          --metrics-bind 127.0.0.1:9100
+      Restart=on-failure
+      RestartSec=10
+      # RocksDB compaction + WAL flush on shutdown can take 2-3 min on a
+      # hot state DB. The systemd default of 90s triggered a SIGKILL
+      # during the v0.1.1-devnet swap on 2026-05-16 (chain#362). 300s
+      # gives headroom without leaving zombie processes around forever.
+      TimeoutStopSec=300
+      LimitNOFILE=65536
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - useradd -m -s /bin/bash ligate
+  - mkdir -p /opt/ligate /etc/ligate /var/lib/ligate
+  - chown ligate:ligate /opt/ligate /etc/ligate /var/lib/ligate
+  # Mount the persistent data disk to /var/lib/ligate.
+  #
+  # Pre-check the device for an existing ext4 filesystem before
+  # mkfs — a bare `mkfs.ext4 -F` on every boot would silently wipe
+  # devnet state on every VM rebuild that reuses the persistent disk.
+  # The `blkid` test is the standard idempotent guard: zero exit
+  # means the filesystem already exists; non-zero means fresh disk.
+  # The fstab append + mount are also idempotent (grep guard + bare
+  # mount that no-ops if already mounted).
+  - |
+    DEVICE=$(readlink -f /dev/disk/by-id/google-ligate-data)
+    if ! blkid "$DEVICE" >/dev/null 2>&1; then
+      mkfs.ext4 -F "$DEVICE"
+    fi
+    if ! grep -q " /var/lib/ligate " /etc/fstab; then
+      echo "$DEVICE /var/lib/ligate ext4 defaults,nofail 0 2" >> /etc/fstab
+    fi
+    mountpoint -q /var/lib/ligate || mount /var/lib/ligate
+  # Pre-create the RocksDB directory on the persistent disk so the
+  # operator's Step 3 symlink lands somewhere valid. Without this the
+  # chain writes state to /opt/ligate/devnet-1/data-celestia on the
+  # boot disk, and a VM image rebuild wipes the chain's local history.
+  # See "Migrating an existing host to the persistent disk" in
+  # docs/development/runbooks/backup-restore.md for the same path,
+  # but applied after-the-fact on hosts that booted without this step.
+  - mkdir -p /var/lib/ligate/rocksdb
+  - chown ligate:ligate /var/lib/ligate/rocksdb
+  # Install Rust + risc0 toolchain (sequencer only; follower can skip risc0).
+  - sudo -u ligate bash -lc 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+  # Install Celestia light node binary. Newer Celestia releases ship
+  # as a tar.gz (was a bare binary in earlier releases); extract and
+  # install the `celestia` binary.
+  - |
+    CELESTIA_VERSION=v0.30.2
+    curl -fsSL "https://github.com/celestiaorg/celestia-node/releases/download/${CELESTIA_VERSION}/celestia-node_Linux_x86_64.tar.gz" \
+      -o /tmp/celestia.tar.gz
+    tar -xzf /tmp/celestia.tar.gz -C /tmp/
+    install -o root -g root -m 0755 /tmp/celestia /usr/local/bin/celestia
+  - sudo -u ligate /usr/local/bin/celestia light init --p2p.network=mocha
+  - systemctl daemon-reload
+  - systemctl enable --now celestia-light.service
+  # `chrony` is explicit belt-and-braces: GCP serves NTP via the
+  # metadata server, but the chain's blob-submit timestamps + Celestia
+  # tx signing both go sideways if the wall clock drifts more than
+  # ~30s, so we don't want a transient metadata-server flake to put
+  # the host out of sync.
+  - systemctl enable --now chrony
+  # ligate-node service starts manually after the operator has placed
+  # the binary, devnet-1 configs, and /etc/ligate/env (with secrets).
+  # Intentionally NOT enabled here; would crashloop on missing binary.


### PR DESCRIPTION
Closes ligate-io/ligate-chain#344.

The cloud-init.yaml referenced by the deploy runbook (`docs/development/public-devnet-deploy.md`) was inlined as a 100+ line YAML block. This PR extracts it to a real file at `ops/cloud-init/sequencer.yaml` and shortens the runbook section to a reference + bullet summary of what it provisions.

## What ships

- **`ops/cloud-init/sequencer.yaml`** (NEW, 167 lines). Same content as the runbook's inlined block plus:
  - Header comment block documenting purpose, usage, what it does NOT do, and idempotency guarantees.
  - **Idempotent disk init** — wraps `mkfs.ext4 -F` in a `blkid` check so re-running cloud-init on a VM with an existing filesystem doesn't wipe devnet state. Same guard on the fstab append + the mount step. The original inline version had a bare `mkfs.ext4 -F` which was correct for first-boot only.
  - `systemctl enable --now chrony` as an explicit cmd (was a comment-only mention in the original; documenting the actual enable step makes the cloud-init match what the live prod VM does).
- **`docs/development/public-devnet-deploy.md`** — Step 2 section trimmed from 116 lines to 10. Now references the file by relative path + summarises what the cloud-init does in 7 bullets. Step 1's `gcloud compute instances create` invocation updated to point at `ops/cloud-init/sequencer.yaml` instead of a bare `cloud-init.yaml` in cwd.

## Why now

Devnet-1's sequencer has been running on this cloud-init since 2026-05-16. The configuration has been battle-tested through:
- v0.1.0 → v0.1.3 → v0.2.0 → v0.2.2 binary swaps (the `TimeoutStopSec=300` covers RocksDB compaction; chain#362 retro)
- the persistent-disk migration (`/var/lib/ligate/rocksdb` pre-creation; chain#369)
- the v0.2.0 re-genesis (no cloud-init change needed; chain state lives on the persistent disk)

Committing it as a tracked file means:
1. The next VM rebuild reaches for the repo, not the runbook's inlined copy.
2. Diffs to the cloud-init (e.g. CELESTIA_VERSION bump, new packages) get peer review like any other code change.
3. The runbook stops drifting from reality.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(\"ops/cloud-init/sequencer.yaml\"))'` — parses clean (`{packages: 10, write_files: 2, runcmd: 12}`)
- Header comment + inline comments explain every non-obvious choice (the idempotent disk guards, the chrony belt-and-braces, why ligate-node is NOT enabled at boot)

## Out of scope

Follower-mode variant (smaller machine type, no risc0 toolchain) noted as a future split — covered by a single comment in the new file's header. Track as a follow-up if/when we actually need a second hostfile shape.

## Diff

`116 -> 10` lines in the runbook; `+167` new YAML file. Net result is the runbook gets shorter + more readable, and the cloud-init becomes a first-class versioned artifact.