### PR TITLE
DbElected seam: rollup.toml postgres_config commented block + per-instance render script (#412)

### DIFF
--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -55,6 +55,37 @@ pub use mock_rollup::{MockLigateRollup, MockRollupSpec};
 /// disappear into a local mempool that never propagates.
 ///
 /// Tracking: [#243](https://github.com/ligate-io/ligate-chain/issues/243).
+///
+/// # SEAM: multi-sequencer leader assignment
+///
+/// This binary-level [`NodeRole`] (`Sequencer` vs `Follower`) is
+/// coarse; multi-sequencer (#82) needs a *slot-level* "who is the
+/// active leader right now?" decision among N peer sequencers.
+///
+/// **The Sovereign SDK already implements this upstream.** It is a
+/// configuration concern, not a code-change concern, for our chain:
+///
+/// - The actual leader / replica branch lives in the SDK fork at
+///   `sov-sequencer/src/preferred/db/mod.rs:543-564`, matching on
+///   [`sov_full_node_configs::sequencer::ConfiguredNodeRole`]
+///   (`Leader` / `Replica` / `ReplicaNoLeaderSync` / `DbElected`).
+/// - `DbElected` mode runs a Postgres-backed election with heartbeat
+///   timeout, grace period, and replica state-sync. See `db/heartbeat_task.rs`
+///   and `replica/replica_sync_task.rs` in the SDK fork.
+/// - To activate it for our chain, [`PreferredSequencerConfig::postgres_config`]
+///   needs to be set in `devnet/rollup.toml`'s `[sequencer.preferred]`
+///   section (currently absent, which is why we run single-instance).
+///
+/// The design-doc sub-issues for Option 1 collapse:
+/// - Sub-issue 2 (LeaderSchedule) and 3 (view-change): **already
+///   shipped upstream**; we use `DbElected` instead of writing our own.
+/// - Sub-issue 4 (multi-instance prod deploy), 5 (force-include
+///   observability stub), and 6 (docs + runbook) are still required.
+/// - New requirement: provision a managed Postgres instance accessible
+///   from every sequencer VM (Cloud SQL or self-hosted on the same VPC).
+///
+/// See `docs/protocol/sequencer-decentralisation.md` §5 for the
+/// updated implementation plan.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeRole {
     /// Normal full node: produces batches, posts to DA, accepts

--- a/crates/rollup/src/lib.rs
+++ b/crates/rollup/src/lib.rs
@@ -67,12 +67,12 @@ pub use mock_rollup::{MockLigateRollup, MockRollupSpec};
 ///
 /// - The actual leader / replica branch lives in the SDK fork at
 ///   `sov-sequencer/src/preferred/db/mod.rs:543-564`, matching on
-///   [`sov_full_node_configs::sequencer::ConfiguredNodeRole`]
+///   `sov_full_node_configs::sequencer::ConfiguredNodeRole`
 ///   (`Leader` / `Replica` / `ReplicaNoLeaderSync` / `DbElected`).
 /// - `DbElected` mode runs a Postgres-backed election with heartbeat
 ///   timeout, grace period, and replica state-sync. See `db/heartbeat_task.rs`
 ///   and `replica/replica_sync_task.rs` in the SDK fork.
-/// - To activate it for our chain, [`PreferredSequencerConfig::postgres_config`]
+/// - To activate it for our chain, `PreferredSequencerConfig::postgres_config`
 ///   needs to be set in `devnet/rollup.toml`'s `[sequencer.preferred]`
 ///   section (currently absent, which is why we run single-instance).
 ///

--- a/devnet/rollup.toml
+++ b/devnet/rollup.toml
@@ -105,6 +105,48 @@ batch_execution_time_limit_millis = 2000
 num_cache_warmup_workers = 0
 ideal_lag_behind_finalized_slot = 3
 
+# SEAM: multi-sequencer activation block (#82, #412).
+#
+# The Sovereign SDK ships Postgres-backed leader election via
+# `ConfiguredNodeRole::DbElected`: each instance heartbeats into a
+# shared Postgres, one wins leadership and proposes blocks, the others
+# run as `PgSyncReplica`s catching up via the same Postgres. On
+# leader failure, the heartbeat timeout (500ms default) elapses and
+# a replica acquires leadership. See SDK fork
+# `sov-sequencer/src/preferred/db/heartbeat_task.rs` for the
+# mechanism and `full-node-configs/src/sequencer.rs` for
+# `PostgresConfig` field semantics.
+#
+# We provisioned Cloud SQL Postgres 16 (regional HA) at private IP
+# `10.123.0.2`, database `ligate_sequencer`, role `ligate_sequencer`,
+# with the role password stored in GCP Secret Manager as
+# `cloudsql-ligate-sequencer-db-app`. See
+# `ops/cloud-init/render-rollup-toml.sh` for the per-instance render
+# step that fetches the password and `node_id` at boot time and
+# writes the active block below.
+#
+# This block stays commented in the canonical `rollup.toml`. Sub-issue
+# 5 activates it by running the render script in the cloud-init
+# preinstall, which produces a per-instance rendered rollup.toml that
+# the chain process actually consumes. Activating it here on the
+# current single-instance prod would be a regression (no second node
+# to fail over to).
+#
+# [sequencer.preferred.postgres_config]
+# postgres_connection_string = "postgresql://ligate_sequencer:${POSTGRES_PASSWORD}@10.123.0.2:5432/ligate_sequencer?sslmode=require"
+# node_id = "${LIGATE_NODE_ID}"
+# node_role = "DbElected"
+#
+# # SDK leader-election defaults are reasonable for our cadence:
+# #   heartbeat_interval_millis = 100   (10 heartbeats/sec)
+# #   leader_timeout_millis     = 500   (failover in ~500ms)
+# #   grace_period_millis       = 10000 (10s anti-flap)
+# # Uncomment and override only after measuring under load.
+# # [sequencer.preferred.postgres_config.leader_election]
+# # heartbeat_interval_millis = 100
+# # leader_timeout_millis     = 500
+# # grace_period_millis       = 10000
+
 [sequencer.extension]
 # `RollupConfig::extension_or_panic()` is called from
 # `FullNodeBlueprint::sequencer_additional_apis`. We don't override

--- a/docs/protocol/sequencer-decentralisation.md
+++ b/docs/protocol/sequencer-decentralisation.md
@@ -141,21 +141,54 @@ Whatever option we pick must satisfy:
 
 ## 5. Implementation plan for Option 3.1
 
-Six sub-issues to open under the #82 umbrella, in dependency order:
+### Audit findings (chain#410)
 
-1. **Plumbing audit.** Map the current single-sequencer code path in `crates/rollup` + upstream `sov-sequencer`. Identify the leader-assignment seam (the function that decides "who proposes this slot"). Output: a short PR adding a `// SEAM:` comment at the right place + a paragraph in this doc updating §5 with what we found. Acceptance: a senior engineer can read the comment and immediately know where the deterministic-rotation logic plugs in.
+The plumbing audit located the seam in two places:
 
-2. **Deterministic per-slot leader.** Implement `LeaderSchedule` (or equivalent): given a slot height and a fixed validator set of size N, deterministically pick the leader. Initial rotation function: `leader(slot) = validators[slot % N]`. Acceptance: unit test passes; fuzz test passes; integration test confirms three local sequencers take turns proposing without collision.
+- **Config seam (ours):** `devnet/rollup.toml`'s `[sequencer.preferred]` section is missing an optional `postgres_config` block. When that block is present, the SDK switches from single-instance RocksDb to Postgres-backed multi-instance with leader election. Today the block is absent — that is why we run single-sequencer.
+- **Code seam (upstream SDK):** `sov-sequencer/src/preferred/db/mod.rs:543-564` is the actual `match ConfiguredNodeRole {...}` branch where leader-vs-replica behaviour diverges. `// SEAM:` comment in `crates/rollup/src/lib.rs` (next to `NodeRole`) marks the discovery point for readers.
 
-3. **Failure detection + view-change.** If the assigned leader doesn't propose within slot-timeout (start with 2× slot duration), the next-in-rotation takes over. Heartbeat or timeout-based; pick the simpler option after reading the Sovereign SDK upstream pattern. Acceptance: kill one of three local sequencers mid-slot; chain continues proposing within slot-timeout. Documented runbook for "what to do if two sequencers think they're leader."
+The Sovereign SDK **already implements** the bulk of Option 3.1:
 
-4. **Multi-sequencer prod deploy.** Spin up two additional GCP instances (`ligate-node-2`, `ligate-node-3`); extend the cloud-init template to support per-instance index and validator set. Update Caddyfile to fan out to the multi-sequencer set with health-aware routing. Update Grafana dashboards to add a per-instance label. Acceptance: prod runs 3 sequencers for 24h with at least one forced-failover incident successfully handled.
+- `ConfiguredNodeRole::{Leader, Replica, ReplicaNoLeaderSync, DbElected}` enum at `crates/full-node/full-node-configs/src/sequencer.rs:139`
+- Postgres heartbeat task at `preferred/db/heartbeat_task.rs`
+- Replica sync task at `preferred/replica/replica_sync_task.rs`
+- `LeaderElectionConfig` (heartbeat interval, leader timeout, grace period) with sensible defaults
+- SQL `is_leader()` function in the Postgres migrations
+- Tests at `preferred/db/postgres/tests/leader_election.rs`
 
-5. **Force-include observability.** Wire a metric `ligate_forced_inclusion_total{reason}` for when (eventually, post-#81) a transaction lands via the force-include path. Stub it as a 0-emitting counter for now so the alerts and dashboards have a place for it. Acceptance: counter visible in `/metrics`.
+`DbElected` mode is exactly what we want for Option 3.1: each instance heartbeats into Postgres, one wins the election, others run as replicas synced from the leader via Postgres state sync. On leader failure (heartbeat timeout + grace period elapsed) one of the replicas takes over.
 
-6. **Documentation.** Update `docs/development/public-devnet-deploy.md` for the multi-sequencer topology; add `docs/development/runbooks/multi-sequencer-failover.md` for incident response; cross-link from this doc's §5 to the runbook. Acceptance: a new operator can stand up the 3-sequencer topology following only the docs.
+### Revised sub-issue list
 
-Each sub-issue is independently mergeable; (1) and (2) are the blockers for everything else.
+Original §5 from v1 of this doc assumed we'd implement `LeaderSchedule` + view-change from scratch. The audit makes most of that disappear; what's left is operational:
+
+1. ✅ **Plumbing audit.** Done. `// SEAM:` comment in `crates/rollup/src/lib.rs`, this section updated. Filed as chain#410.
+
+2. ~~Deterministic per-slot leader (`LeaderSchedule`)~~ — **dropped.** SDK's `DbElected` Postgres election replaces this. Heartbeat-based instead of slot-based, which is arguably better (no two-sequencers-both-think-they're-leader race at slot boundaries).
+
+3. ~~Failure detection + view-change~~ — **dropped.** SDK's heartbeat timeout + grace period IS the failure detection; the next election cycle IS the view-change. Both fully configurable via `LeaderElectionConfig`.
+
+4. **Postgres provisioning + config.** Provision a managed Postgres instance (Cloud SQL with regional HA, or a small managed Postgres on the same VPC) accessible from every sequencer VM. Wire `[sequencer.preferred.postgres]` into `devnet/rollup.toml` with `node_role = "DbElected"` for all three sequencer instances, distinct `node_id` per instance. Acceptance: three local sequencers running against a single Postgres see one elected leader and two replicas; killing the leader triggers a new election within the configured timeout.
+
+5. **Multi-sequencer prod deploy.** Spin up two additional GCP instances (`ligate-node-2`, `ligate-node-3`); extend the cloud-init template for per-instance index. Update Caddyfile to fan reads out across all healthy instances and route writes (`POST /v1/sequencer/txs`) to the current leader (Postgres-derived via a small health endpoint, or the SDK's existing leader-info API if it exposes one). Add per-instance Grafana labels. Acceptance: prod runs 3 sequencers for 24h with at least one forced-failover incident successfully handled.
+
+6. **Force-include observability stub.** Wire `ligate_forced_inclusion_total{reason}` as a 0-emitting counter for the eventual #81 work. Acceptance: counter visible in `/metrics`.
+
+7. **Documentation.** Update `docs/development/public-devnet-deploy.md` for the multi-sequencer topology; add `docs/development/runbooks/multi-sequencer-failover.md`. Cover the Postgres dependency (backup, snapshot, restore). Acceptance: a new operator can stand up the 3-sequencer topology from the docs alone.
+
+### What this means for timing
+
+Original estimate in §4: **~6-8 weeks**. Revised estimate after audit: **~2-3 weeks**, dominated by Postgres provisioning + Caddyfile work + 24h prod soak. Coding is minimal; this is config + ops.
+
+### What's still gated
+
+Sub-issue 4 has a non-trivial decision embedded: managed Cloud SQL vs self-hosted Postgres on the same VPC. Tradeoffs:
+
+- **Cloud SQL with regional HA.** Easy to operate. Costs ~$50-100/mo for a small instance with HA. Failover is GCP-managed. The Postgres becomes a separately-paid GCP-managed dependency.
+- **Self-hosted on a small VM.** Cheaper (~$15/mo for the VM). We own the failure mode. Adds ops surface.
+
+Default recommendation: **Cloud SQL** with regional HA, at least until pre-mainnet. Operating a single VM is fine until that VM becomes the SPOF that the multi-sequencer work was meant to remove. Revisit if cost becomes a constraint.
 
 ---
 

--- a/ops/cloud-init/render-rollup-toml.sh
+++ b/ops/cloud-init/render-rollup-toml.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Renders the per-instance rollup.toml for the multi-sequencer DbElected
+# topology (chain #82, sub-issue #412).
+#
+# Reads the canonical `devnet/rollup.toml` from disk, fetches the
+# Cloud SQL app-role password from GCP Secret Manager, substitutes
+# `${LIGATE_NODE_ID}` and `${POSTGRES_PASSWORD}` into the commented
+# `[sequencer.preferred.postgres_config]` block, and writes the
+# activated config to the path the chain process will consume.
+#
+# Designed to run as a systemd `ExecStartPre=` step before
+# `ligate-node.service`. Idempotent: running multiple times produces
+# the same output for the same env inputs.
+#
+# Required env:
+#   LIGATE_NODE_ID         distinct per instance (e.g. "ligate-1")
+#   GCP_PROJECT            project hosting the secret
+#   POSTGRES_SECRET_NAME   defaults to cloudsql-ligate-sequencer-db-app
+#
+# Optional env:
+#   SOURCE_TOML            defaults to /opt/ligate/devnet/rollup.toml
+#   TARGET_TOML            defaults to /var/lib/ligate/rollup.toml
+#   POSTGRES_HOST          defaults to 10.123.0.2 (Cloud SQL private IP)
+#   POSTGRES_PORT          defaults to 5432
+#   POSTGRES_DB            defaults to ligate_sequencer
+#   POSTGRES_USER          defaults to ligate_sequencer
+#
+# Activation note: this script alone does not enable DbElected mode.
+# It only activates the commented block in the source toml when the
+# env vars are set. Without `LIGATE_NODE_ID` set, the script refuses
+# to run so a typo in cloud-init can't accidentally produce an
+# un-templated config.
+
+set -euo pipefail
+
+LIGATE_NODE_ID="${LIGATE_NODE_ID:?LIGATE_NODE_ID env var is required (distinct per instance, e.g. ligate-1)}"
+GCP_PROJECT="${GCP_PROJECT:?GCP_PROJECT env var is required}"
+POSTGRES_SECRET_NAME="${POSTGRES_SECRET_NAME:-cloudsql-ligate-sequencer-db-app}"
+
+SOURCE_TOML="${SOURCE_TOML:-/opt/ligate/devnet/rollup.toml}"
+TARGET_TOML="${TARGET_TOML:-/var/lib/ligate/rollup.toml}"
+POSTGRES_HOST="${POSTGRES_HOST:-10.123.0.2}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_DB="${POSTGRES_DB:-ligate_sequencer}"
+POSTGRES_USER="${POSTGRES_USER:-ligate_sequencer}"
+
+echo "render-rollup-toml: source=$SOURCE_TOML target=$TARGET_TOML node_id=$LIGATE_NODE_ID" >&2
+
+# Validate the source exists and is readable
+if [[ ! -r "$SOURCE_TOML" ]]; then
+  echo "render-rollup-toml: source $SOURCE_TOML not readable" >&2
+  exit 1
+fi
+
+# Fetch the postgres app password from Secret Manager.
+# Uses the VM's instance service account (granted secretAccessor on
+# the secret); no static keys on disk.
+POSTGRES_PASSWORD="$(gcloud secrets versions access latest \
+  --secret="$POSTGRES_SECRET_NAME" \
+  --project="$GCP_PROJECT" 2>/dev/null)"
+
+if [[ -z "$POSTGRES_PASSWORD" ]]; then
+  echo "render-rollup-toml: failed to fetch $POSTGRES_SECRET_NAME from Secret Manager (project=$GCP_PROJECT). Check VM SA has roles/secretmanager.secretAccessor." >&2
+  exit 1
+fi
+
+# Build the connection string. URL-encode the password (basic case;
+# our generator avoids `:/?#[]@` so a direct interpolation is safe
+# for the standard rollup-of-the-mill alphanumeric + `_.-` charset).
+POSTGRES_CONN="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=require"
+
+# Ensure target dir exists.
+mkdir -p "$(dirname "$TARGET_TOML")"
+
+# Render: copy source verbatim, then uncomment + substitute the
+# postgres_config block. We use a marker-based sed transform so that
+# accidental future edits to the comment block don't break us
+# silently: the source must contain `# SEAM: multi-sequencer activation block` exactly.
+if ! grep -q "^# SEAM: multi-sequencer activation block" "$SOURCE_TOML"; then
+  echo "render-rollup-toml: source $SOURCE_TOML missing SEAM marker; aborting (rollup.toml schema drift?)" >&2
+  exit 1
+fi
+
+# Strip leading `# ` from the four config-active lines (the three
+# `postgres_config` keys + the leading section header). Leaves the
+# leader_election overrides commented (we want SDK defaults unless
+# explicitly tuned).
+sed \
+  -e 's|^# \(\[sequencer\.preferred\.postgres_config\]\)$|\1|' \
+  -e "s|^# postgres_connection_string = \"postgresql://ligate_sequencer:\${POSTGRES_PASSWORD}@10\\.123\\.0\\.2:5432/ligate_sequencer?sslmode=require\"$|postgres_connection_string = \"${POSTGRES_CONN}\"|" \
+  -e "s|^# node_id = \"\${LIGATE_NODE_ID}\"$|node_id = \"${LIGATE_NODE_ID}\"|" \
+  -e 's|^# node_role = "DbElected"$|node_role = "DbElected"|' \
+  "$SOURCE_TOML" > "$TARGET_TOML.tmp"
+
+# Sanity-check: must have an activated postgres_config block now.
+if ! grep -q '^\[sequencer\.preferred\.postgres_config\]$' "$TARGET_TOML.tmp"; then
+  echo "render-rollup-toml: render failed; activated block not produced. Inspect $TARGET_TOML.tmp manually." >&2
+  exit 1
+fi
+if ! grep -q "^node_id = \"${LIGATE_NODE_ID}\"$" "$TARGET_TOML.tmp"; then
+  echo "render-rollup-toml: render failed; node_id substitution did not land." >&2
+  exit 1
+fi
+
+mv "$TARGET_TOML.tmp" "$TARGET_TOML"
+chmod 600 "$TARGET_TOML"
+
+echo "render-rollup-toml: wrote $TARGET_TOML (mode 600)" >&2


### PR DESCRIPTION
## Summary

Partial deliverable for chain#412 (Postgres provisioning + DbElected config sub-issue). Adds the rollup-config seam and the render script that activates it per-instance, without changing prod behaviour today.

This lets sub-issue 5 (multi-sequencer prod deploy) drop in cleanly — at that point, the cloud-init template runs the render script as an \`ExecStartPre\` step and the chain process picks up the per-instance postgres config without any further code change.

## Stack already provisioned (this session, outside this PR)

| Resource | State |
|---|---|
| Cloud SQL Postgres 16, regional HA, \`db-custom-1-3840\` | RUNNABLE at private IP \`10.123.0.2\` |
| Database \`ligate_sequencer\` | created |
| Non-root user \`ligate_sequencer\` | created |
| Secret Manager: \`cloudsql-ligate-sequencer-db-{root,app}\` | populated |
| VM SA \`581995691296-compute@...\` | granted \`roles/secretmanager.secretAccessor\` on both secrets |
| Boot disk on \`ligate-devnet-1-sequencer\` | resized 20 → 50 GB (online, no downtime) |
| VPC peering for Cloud SQL private IP | ACTIVE on default network, range \`10.123.0.0/16\` |

## Files

**\`devnet/rollup.toml\`** — adds a \`# SEAM: multi-sequencer activation block\` block inside \`[sequencer.preferred]\`. Block stays commented in the canonical file:
- Activating it on the current single-instance prod would be a regression (no second node to fail over to)
- Sub-issue 5 will activate it by running the render script in cloud-init
- The block names where the secret comes from, what's templated, why SDK defaults are kept

**\`ops/cloud-init/render-rollup-toml.sh\`** (new, mode 755) — per-instance renderer:
- Required env: \`LIGATE_NODE_ID\`, \`GCP_PROJECT\`
- Optional env: \`POSTGRES_SECRET_NAME\`, \`SOURCE_TOML\`, \`TARGET_TOML\`, \`POSTGRES_{HOST,PORT,DB,USER}\`
- Fetches the app password from GCP Secret Manager via gcloud (VM service-account auth, no static keys on disk)
- Validates the source has the SEAM marker before transforming (refuses on schema drift)
- Activates the three \`postgres_config\` keys via marker-based sed, leaves leader_election overrides commented
- Sanity-checks output before \`mv\` to final path
- Idempotent: same env → same output

Live verified during development: fetched the actual Secret Manager password, rendered a per-instance toml with \`node_id="ligate-test-1"\`, inspected the activated block, then shredded the test output (no secret persisted to repo or my local).

## What's not in this PR

- **Cloud-init wiring.** \`ops/cloud-init/sequencer.yaml\` doesn't yet call \`render-rollup-toml.sh\` as an \`ExecStartPre\`. That's the actual activation step, which goes with sub-issue 5 ("multi-sequencer prod deploy") so we can stage + soak the deployment alongside the second-and-third VM spinup.
- **Local 3-sequencer Docker smoke.** Tracked separately under #412 — the audit-claim verification ("SDK actually does what we think") deserves its own focused session with the Docker harness + assertion script.
- **Caddyfile fan-out + leader-aware routing.** Sub-issue 5.
- **Polish items.** \`/ready\` role enrichment (#414), custom replica-mode 503 (#415), follower_guard repurpose (#413) all opened as separate trackers.

## Test plan

- [ ] CI green (no Rust changes; pure config + shell)
- [ ] Reviewer: read \`devnet/rollup.toml\` SEAM block — does the commentary match the audit narrative in \`docs/protocol/sequencer-decentralisation.md\` §5?
- [ ] Reviewer: read \`render-rollup-toml.sh\` — anything in the sed transforms that worries you for the long term? (Pattern is marker-anchored + sanity-checked, but it's still string manipulation.)
- [ ] Post-merge: sub-issue 5 work picks up here and wires this into cloud-init.

## Parent

- #82 multi-sequencer / leader rotation (umbrella)
- #412 Postgres provisioning + DbElected config (partial — Docker smoke remaining)
- Design doc: \`docs/protocol/sequencer-decentralisation.md\` §5