### PR TITLE
chore(release): cut v0.2.4 (ops + docs patch; chain_hash unchanged from v0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-05-20
+
+Ops + docs patch. No chain code changes; `chain_hash` unchanged from `v0.2.3`; safe binary swap in place. Cuts a tagged release so the multi-sequencer activation artifacts (design doc + plumbing audit findings + rollup.toml config seam + per-instance render script + Docker smoke harness) ship as a pinned point-in-time bundle alongside the Dependabot bumps that landed since `v0.2.3`. Sub-issue 5 (multi-sequencer prod deploy) consumes the `v0.2.4` artifacts (release tarball + GHCR image) rather than tracking a moving `main`.
+
+### Added
+
+- `docs/protocol/sequencer-decentralisation.md` — design doc deciding the multi-sequencer path: Option 1 (internal Postgres-elected leader rotation) → Option 2 (federated validator set, pre-mainnet). Out of scope: shared sequencer (Astria/Espresso/Skip, fails the PoUA-compatibility requirement) and based rollup (Celestia validators sequence, latency-bound). 5 open questions explicitly deferred; revisit triggers named. (#409)
+- Plumbing-audit findings folded into the same doc's §5: the Sovereign SDK pin (`ligate-io/sovereign-sdk@4b4a313b7`) already implements `ConfiguredNodeRole::DbElected` end-to-end (heartbeat task, replica sync, Postgres-backed election, SQL `is_leader()` function). What was originally a 6-sub-issue plan over 6-8 weeks collapses to a 4-sub-issue plan over ~2-3 weeks; the bulk of remaining work is provisioning + Caddyfile + Grafana labels, not Rust. `crates/rollup/src/lib.rs` gains a `// SEAM:` doc-comment block pointing readers at the SDK's existing implementation. (#410, #411)
+- `devnet/rollup.toml`: commented `# SEAM:` block under `[sequencer.preferred]` documenting how to activate `DbElected` multi-instance mode by uncommenting and supplying `postgres_connection_string` + `node_id` + `node_role = "DbElected"`. Block stays commented in the canonical prod config (single-instance) until sub-issue 5 spins up the second and third VMs. (#416)
+- `ops/cloud-init/render-rollup-toml.sh`: per-instance render script. Reads the canonical `devnet/rollup.toml`, fetches the Cloud SQL app-role password from GCP Secret Manager (`cloudsql-ligate-sequencer-db-app`) via the VM service account, substitutes `${LIGATE_NODE_ID}` + `${POSTGRES_PASSWORD}` into the SEAM block, writes the activated config to `/var/lib/ligate/rollup.toml` at mode 600. Marker-anchored sed transforms refuse to run on a source toml that's missing the `# SEAM:` header (schema-drift guard). Idempotent: same env in → same output. Designed to run as a systemd `ExecStartPre=` step. (#416)
+- `tests/smoke/multi-sequencer/`: Docker Compose smoke harness validating the SDK's DbElected mechanism. Postgres + 3× chain instances (`ghcr.io/ligate-io/ligate-chain:0.2.3`) booting against shared MockDa SQLite and shared Postgres. Live-verified: exactly one `BatchProducer` + two `PgSyncReplica` per run, `GET /v1/sequencer/role` returns the correct value on each endpoint, leader-kill is observed by survivors via the SDK's heartbeat task. Failover capture (survivor flipping to `BatchProducer`) is best-effort on MockDa due to multi-writer SQLite contention — the audit-claim core (election + heartbeat-observation) is fully verified; survivor-takeover is tracked separately for upgrade to local-celestia-devnet (#420). Five macOS-Docker gotchas hit and documented inline: GHCR tag drops the `v` prefix, minimal image lacks `envsubst`/`wget`/`curl` (sed + host-side polling instead), named volumes are root-owned (`user: "0:0"`), io_uring blocked by default seccomp (`seccomp=unconfined`), SDK 10s grace period races MockDa crash (smoke-only override to 500ms). (#419)
+
+### Deps
+
+- `Sovereign-Labs/sovereign-sdk` rev pin in `[patch]` block unchanged from `v0.2.3` (`4b4a313b7`). All DbElected machinery already in that pin; no SDK bump needed. Workspace pins in `[workspace.dependencies]` stay at `f6cd64749e…`.
+- `getrandom` bumped from `0.3.4` to `0.4.2` (Dependabot #402). Transitive dep; no code path changes needed. `cargo audit` / `cargo deny` / `cargo test` all green.
+- `actions/upload-artifact` bumped `4` → `7`, `actions/download-artifact` bumped `4` → `8`, `docker/login-action` bumped `3` → `4` in CI workflows (Dependabot #399, #400, #401). CI surface only; no chain binary effect.
+- `cargo audit` ignore list extended with `RUSTSEC-2026-0145` (`astral-tokio-tar` 0.6.1 PAX header desync; transitive via `testcontainers` in `sov-test-utils` dev-deps; test-only path, not reachable from production code; solution upgrade to >= 0.6.2 — clears when SDK testcontainers bumps).
+
+### Compatibility
+
+`chain_hash` unchanged from `v0.2.3`. No state changes. No re-genesis required. Operators deploying this binary to an existing `devnet-1` VM keep their RocksDB state intact across the swap.
+
 ## [0.2.3] - 2026-05-18
 
 Patch release. Adds `da_block_height` to the batch receipt JSON for explorer-side Celenium deep-links. Backward-compatible additive change; `chain_hash` unchanged; safe binary swap in place.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]


### PR DESCRIPTION
## Summary

Ops + docs patch release. No chain code changes; \`chain_hash\` unchanged from \`v0.2.3\`; safe binary swap.

This release exists to pin all the multi-sequencer-prep artifacts (design doc, audit findings, rollup.toml seam, render script, smoke harness) plus the Dependabot bumps that landed since v0.2.3 as a single tagged bundle. Sub-issue 5 (multi-sequencer prod deploy) consumes the \`v0.2.4\` release tarball + GHCR image rather than tracking a moving \`main\`.

## What changed (full CHANGELOG entry in this PR)

- \`docs/protocol/sequencer-decentralisation.md\` — Option 1 → Option 2 decision doc (PR #409)
- Plumbing audit findings + \`// SEAM:\` comment in \`crates/rollup/src/lib.rs\` (PR #411)
- \`devnet/rollup.toml\` commented \`postgres_config\` SEAM block + \`ops/cloud-init/render-rollup-toml.sh\` per-instance render script (PR #416)
- \`tests/smoke/multi-sequencer/\` Docker Compose harness validating the SDK's DbElected election (PR #419, live-verified)
- Dependabot bumps: getrandom 0.3.4 → 0.4.2; actions/upload-artifact 4 → 7; actions/download-artifact 4 → 8; docker/login-action 3 → 4 (PRs #399-#402)
- \`cargo audit\` ignore: RUSTSEC-2026-0145 (\`astral-tokio-tar\` 0.6.1 PAX desync via testcontainers dev-dep)

## Compatibility

\`chain_hash\` unchanged. No state changes. No re-genesis required. Operators deploying this binary to existing \`devnet-1\` VMs keep their RocksDB state intact across the swap.

## What this unlocks

Sub-issue 5 (multi-sequencer prod deploy) opens immediately after this merges + the v0.2.4 tag is pushed (triggers \`release.yml\` for the binary tarball + \`docker.yml\` for the GHCR image). The prod cloud-init for the second + third sequencer VMs pulls v0.2.4 artifacts, not moving-\`main\`.

## Test plan

- [ ] CI green on all 12 checks
- [ ] After merge: tag \`v0.2.4\` + push triggers the release + docker workflows
- [ ] Verify GHCR has \`ghcr.io/ligate-io/ligate-chain:0.2.4\` + \`:latest\` updated
- [ ] Verify the GitHub release page includes the CHANGELOG \`[0.2.4]\` section