### PR TITLE
README: macOS first-build trifecta + advertise the published GHCR image (#417, #418)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 
 ## Quick start
 
+> **Just want to run a node, not build from source?**
+> Pre-built Linux x86_64 / Linux arm64 / macOS arm64 binaries ship on every release: <https://github.com/ligate-io/ligate-chain/releases>. A multi-arch container image is also published on every release tag at `ghcr.io/ligate-io/ligate-chain:<version>` (e.g. `:0.2.4`, plus `:latest`). See [docs.ligate.io/nodes](https://docs.ligate.io/nodes) for the operator-facing install + boot recipes.
+
 ### Build and test
 
 ```bash
@@ -28,7 +31,7 @@ cd ligate-chain
 
 # Build the workspace (Rust 1.93 auto-installs via rust-toolchain.toml).
 # Ubuntu / Debian first install: sudo apt install -y libclang-dev clang
-# macOS first install:           xcode-select --install
+# macOS first install:           xcode-select --install  (see "macOS first-build trifecta" below)
 cargo build --workspace
 
 # Run the workspace tests (lib + integration + doctests)
@@ -236,6 +239,25 @@ The SDK pulls in `librocksdb-sys`, which needs `libclang` at build time:
   export LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib
   ```
   Or set them per-invocation: `DYLD_FALLBACK_LIBRARY_PATH=/Library/Developer/CommandLineTools/usr/lib LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib cargo test ...`.
+
+#### macOS first-build trifecta
+
+A clean macOS dev machine hits three failure modes in sequence on the first `cargo check`. All three are documented in [`CONTRIBUTING.md`](CONTRIBUTING.md), but here's the one-shot recipe to get going:
+
+1. **`librocksdb-sys` link** — the two `export`s above.
+2. **Risc0 rustup toolchain override** — `cargo` errors with `override toolchain 'risc0' is not installed` before the workspace even compiles. Install the toolchain manager:
+   ```bash
+   curl -L https://risc0.com/install | bash
+   rzup install
+   ```
+   This is a ~1-2 GB one-time install. If you don't plan to touch the prover (Phase A.4 / `crates/rollup/provers/risc0`), the lighter alternative is `export RUSTUP_TOOLCHAIN=1.93.0` per shell to bypass the override.
+3. **Metal kernel build** — Risc0 tries to compile macOS Metal kernels at build time. If you don't have full Xcode (only Command Line Tools), set:
+   ```bash
+   export RISC0_SKIP_BUILD_KERNELS=1
+   ```
+   **Do NOT set this in CI** — Linux runners build CPU kernels cleanly, and skipping there produces unresolved-symbol errors at link time. Per-machine workaround only.
+
+Tracking: [#417](https://github.com/ligate-io/ligate-chain/issues/417) covers proposed ergonomic improvements (`.cargo/config.toml`, etc.) — cargo doesn't support target-conditional env vars natively, so this stays a documented per-machine setup for now.
 
 ### CI gates
 


### PR DESCRIPTION
## Summary

Two doc-only improvements addressing #417 (macOS local-dev ergonomics) and part of #418 (GHCR image docs gap).

## What changed in README.md

### 1. Quick start callout (top of Quick start section)

A short upfront pointer telling readers who just want to RUN a node — not build from source — where to go:
- Pre-built binaries on GitHub Releases (Linux x86_64 / Linux arm64 / macOS arm64)
- Container image on GHCR (\`ghcr.io/ligate-io/ligate-chain:<version>\`)
- Operator-facing recipes on docs.ligate.io/nodes

Closes part of #418. The docs side (\`nodes.mdx\` Container image subsection) ships in [ligate-io/docs](https://github.com/ligate-io/docs/pulls) as a sibling PR.

### 2. macOS first-build trifecta (under System dependencies)

Previously the README only documented bug 1 (\`librocksdb-sys\` link). A clean macOS machine hits THREE failure modes in sequence on first \`cargo check\`. CONTRIBUTING.md had the full story buried deep; promoting all three to a single recipe under the existing System dependencies section means the next macOS contributor doesn't have to bounce between files.

The three bugs covered:
1. \`librocksdb-sys\` link — \`DYLD_FALLBACK_LIBRARY_PATH\` + \`LIBCLANG_PATH\`
2. Risc0 rustup toolchain override — \`rzup install\` (or \`RUSTUP_TOOLCHAIN=1.93.0\` if not touching prover code)
3. Metal kernel build — \`RISC0_SKIP_BUILD_KERNELS=1\` (per-machine only; NEVER in CI)

Cross-link to #417 noting that cargo doesn't support target-conditional env vars natively (verified via the cargo book), so this stays a documented per-machine setup.

## Why this isn't a \`.cargo/config.toml\` fix

The original #417 plan proposed a \`.cargo/config.toml\` with \`[target.<triple>.env]\` to auto-set the macOS env vars. Verified via the cargo reference: \`[env]\` is global only; target sections only support \`linker\`/\`runner\`/\`rustflags\`/\`rustdocflags\`. No supported target-conditional env path.

A \`.cargo/config.toml [env]\` block with \`RISC0_SKIP_BUILD_KERNELS=1\` would apply on Linux too and break the CI build (per the existing CONTRIBUTING warning). Best path remains documented per-machine setup; the README improvement makes it discoverable.

## Test plan

- [ ] Render the new callouts in GitHub markdown view — link targets resolve, code blocks render cleanly
- [ ] A new macOS contributor reads only the README "System dependencies" section and gets to a successful \`cargo check\` without needing CONTRIBUTING.md
- [ ] No behavior change; no CI gating change