### PR TITLE
devnet-1: commit the live substituted bundle so cloud-init clones work end-to-end (#428)

### DIFF
--- a/devnet-1/celestia.toml
+++ b/devnet-1/celestia.toml
@@ -140,7 +140,7 @@ tokio_runtime_metrics_interval_millis = 500
 
 [proof_manager]
 aggregated_proof_block_jump = 10
-prover_address = "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+prover_address = "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"
 max_number_of_transitions_in_db = 100
 max_number_of_transitions_in_memory = 30
 # Added by SDK rev `f6cd64749` (Sovereign-Labs/sovereign-sdk#2832): bound
@@ -161,7 +161,7 @@ max_concurrent_batch_blobs = 128
 # proof blobs in flight on the DA layer; rollup shuts down on saturation.
 max_concurrent_proof_blobs = 1024
 max_allowed_node_distance_behind = 10
-rollup_address = "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+rollup_address = "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"
 
 [sequencer.preferred]
 # Conscious choice (per #293, option A). We run preferred sequencer

--- a/devnet-1/genesis/chain_state.json
+++ b/devnet-1/genesis/chain_state.json
@@ -1,6 +1,6 @@
 {
   "current_time": 0,
-  "genesis_da_height": 0,
+  "genesis_da_height": 11357228,
   "inner_code_commitment": [
     0,
     0,


### PR DESCRIPTION
## Summary

Closes #428. Replaces the **template** \`devnet-1/celestia.toml\` + \`devnet-1/genesis/chain_state.json\` with the **substituted live values** from VM-1 (the working sequencer).

This unblocks VM-3 boot under chain#422: \`ops/cloud-init/sequencer.yaml\` git-clones the chain repo at the current tag and \`cp -rn devnet-1/\` into \`/opt/ligate/devnet-1/\`. Until now that placed the template (\`genesis_da_height: 0\`, placeholder addresses), so the chain panicked at boot with "height is equal to 0" — Celestia has no block at height 0.

VM-2 manually unblocked today by SCPing VM-1's files; this PR makes the next VM boot clean from \`git clone\` alone.

## Changes

Three field replacements; rest of the file content is byte-identical.

### \`devnet-1/genesis/chain_state.json\`

\`\`\`diff
- "genesis_da_height": 0,
+ "genesis_da_height": 11357228,
\`\`\`

11357228 is the Mocha-4 block height at devnet-1 launch (queried live from VM-1's running rollup). The chain's DA-sync loop starts here; anything earlier is irrelevant.

### \`devnet-1/celestia.toml\`

\`\`\`diff
[proof_manager]
- prover_address = "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+ prover_address = "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"

[sequencer]
- rollup_address = "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+ rollup_address = "lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt"
\`\`\`

\`lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt\` is the v0 Anvil dev actor address that owns treasury / sequencer / attester / prover roles per the existing comment in \`devnet/rollup.toml\` (the localnet config) — single-actor genesis simplifies the boot story.

## Why commit live values instead of keeping templates

Per the #428 analysis: the substituted values are PUBLIC chain genesis info (the chain_state.json values are on-chain queryable; addresses appear in every block's proposer field). Committing them to the repo:

- Removes operator hand-holding for any new follower spin-up (anyone with the public repo + a Celestia signer key can run a ligate-devnet-1 follower)
- Aligns with how other public chains ship their canonical genesis (Cosmos, Celestia, etc. all ship the live values, not templates)
- Doesn't break the \`ligate-genesis-tool\` substitution path — that tool stays useful for fresh-chain deploys (testnet, mainnet in the future)

For a NEW chain (testnet-1 etc.) the operator would copy this directory, edit chain_id + run the substitution tool against the new operating-mode actor. Same as before; the substitution tool still has value.

## What this unblocks

\`gcloud compute instances create ligate-devnet-1-sequencer-3 ... --metadata=ligate-node-id=ligate-devnet-1-sequencer-3,ligate-mode=follower --metadata-from-file=user-data=ops/cloud-init/sequencer.yaml\` should now boot clean — no SCP from VM-1, no manual chain_state.json patching.

(The cloud-init at v0.2.4 still git-clones \`--branch v0.2.4\`. After this PR merges we either (a) bump the cloud-init's tag pin to the latest \`main\` head, or (b) wait for v0.2.5 to fold all of today's cloud-init work into a tagged release. Option (b) is cleaner.)

## Test plan

- [ ] CI green (no Rust changes; pure config-data update)
- [ ] Reviewer: confirm the addresses I pulled match the dev-actor address documented in \`devnet/rollup.toml\` line 98 (\`lig1h72nh5c7jfjkcygku4thsh2t53dyh33kkpktpy84w06qwr4agvt\`)
- [ ] Post-merge: VM-3 boot test in a later session

## Parent

- #82 multi-sequencer umbrella
- #428 (closed by this PR)
- #422 sub-issue 5 deliverable A continued