### PR TITLE
cloud-init: bump LIGATE_TAG v0.2.4 → v0.2.5 (canonical bundle now in the release)

### DIFF
--- a/ops/cloud-init/sequencer.yaml
+++ b/ops/cloud-init/sequencer.yaml
@@ -233,8 +233,8 @@ runcmd:
   # swaps, the same flow used during the v0.2.3 → v0.2.4 swap on
   # 2026-05-20).
   - |
-    LIGATE_TAG=v0.2.4
-    LIGATE_VERSION=0.2.4
+    LIGATE_TAG=v0.2.5
+    LIGATE_VERSION=0.2.5
     ARTIFACT="ligate-node-${LIGATE_VERSION}-linux-amd64.tar.gz"
     # Keep the artifact's original filename so `sha256sum -c` can find
     # it via the relative path written into the .sha256 file by the
@@ -256,7 +256,7 @@ runcmd:
   # Idempotent: --depth 1 + a fresh tmp clone every cloud-init run;
   # cp -rn so we don't clobber an operator-edited /opt/ligate/devnet-1/.
   - |
-    LIGATE_TAG=v0.2.4
+    LIGATE_TAG=v0.2.5
     rm -rf /tmp/ligate-chain
     git clone --depth 1 --branch ${LIGATE_TAG} \
       https://github.com/ligate-io/ligate-chain.git /tmp/ligate-chain


### PR DESCRIPTION
## Summary

Bump \`ops/cloud-init/sequencer.yaml\`'s pinned chain tag from v0.2.4 to v0.2.5. v0.2.5 includes the canonical \`devnet-1/\` substituted bundle (#429), so the cloud-init's \`git clone --branch \${LIGATE_TAG} ... && cp -rn devnet-1/ ...\` step now places the SUBSTITUTED chain_state.json (\`genesis_da_height: 11357228\`) instead of the v0.2.4 TEMPLATE (\`genesis_da_height: 0\`).

This is the last piece for VM-4 (or any re-image) to boot 100% clean — no manual SCP of substituted bundle from VM-1 needed.

## Three line changes

\`\`\`diff
-    LIGATE_TAG=v0.2.4
+    LIGATE_TAG=v0.2.5
-    LIGATE_VERSION=0.2.4
+    LIGATE_VERSION=0.2.5
-    LIGATE_TAG=v0.2.4
+    LIGATE_TAG=v0.2.5
\`\`\`

Two of those drive the binary download URL (\`ligate-node-0.2.5-linux-amd64.tar.gz\` from the v0.2.5 release tag); the third drives the \`git clone --branch\` for the devnet-1 config.

## Order of operations

This PR can be merged anytime — the cloud-init isn't run on existing VMs. It only matters when someone actually \`gcloud compute instances create ... --metadata-from-file=user-data=ops/cloud-init/sequencer.yaml\`. By the time anyone creates VM-4, the v0.2.5 release artifacts will be live (the release.yml + docker.yml workflows are running right now from the v0.2.5 tag push; ~30-45 min total).

## Backward compat

Re-running this cloud-init on VM-1, -2, -3 would re-install the v0.2.5 binary (no-op since they're already on v0.2.4-compatible code; \`chain_hash\` unchanged) and re-place the devnet-1 config (cp -rn doesn't clobber existing files). Safe.

## Test plan

- [ ] CI green
- [ ] After merge + v0.2.5 release workflows complete: any new VM creation with this cloud-init boots fully clean (verified empirically when we create VM-4 in a future session)
- [ ] Existing VM-1/-2/-3 still on v0.2.4 binary; no auto-rollforward (binary swaps stay operator-driven)

## Parent

- #82 multi-sequencer umbrella
- #422 sub-issue 5 (the deliverable A loop now fully clean)