### PR TITLE
chain#422 D+F: Caddyfile leader-aware routing + multi-sequencer failover runbook

### DIFF
--- a/devnet-1/celestia.toml
+++ b/devnet-1/celestia.toml
@@ -131,6 +131,12 @@ da_polling_interval_ms = 2_000
 # fronts the node and serves the public TLS endpoint. Binding the
 # node directly to a public interface is only safe behind a firewall
 # rule restricting to your reverse proxy's source.
+#
+# Multi-sequencer (DbElected) operators must flip this to "0.0.0.0"
+# so the gateway VM's Caddy can reach the replicas' REST surface over
+# the VPC. The GCP firewall already restricts 12346 to VPC peers. See
+# `docs/development/runbooks/multi-sequencer-failover.md` for the
+# bind-flip procedure and `ops/caddy/Caddyfile` for the fan-out config.
 bind_host = "127.0.0.1"
 bind_port = 12346
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -46,6 +46,7 @@ Operational procedures. Each is dated to its last review and pins a "Status: vN"
 | [`runbooks/faucet-ops.md`](./runbooks/faucet-ops.md) | `ligate-api`'s faucet endpoint operation: hot key, rate limits, per-address tracking |
 | [`runbooks/backup-restore.md`](./runbooks/backup-restore.md) | GCS-backed `ligate-node` RocksDB snapshot + restore; quarterly drill cadence |
 | [`runbooks/log-shipping.md`](./runbooks/log-shipping.md) | Fluent Bit deploy on the chain VM; Cloud Logging filter patterns |
+| [`runbooks/multi-sequencer-failover.md`](./runbooks/multi-sequencer-failover.md) | DbElected mode operations: cluster state read, planned Leader replacement, unplanned failover, forced takeover, Postgres outage handling |
 
 ## Alerts
 

--- a/docs/development/runbooks/multi-sequencer-failover.md
+++ b/docs/development/runbooks/multi-sequencer-failover.md
@@ -1,0 +1,305 @@
+# Runbook: Multi-Sequencer Failover (DbElected)
+
+**Status:** v0. Covers DbElected mode on devnet-1 (Postgres-backed
+leader election + heartbeat). Documents what we have **live-tested** vs
+what is **SDK-documented but not yet exercised in production**. Part of
+the multi-sequencer rollout tracked at
+[chain#82](https://github.com/ligate-io/ligate-chain/issues/82) (umbrella)
+and [chain#422](https://github.com/ligate-io/ligate-chain/issues/422)
+(devnet rollout).
+
+This page is about Ligate's `DbElected` sequencer mode: the Sovereign
+SDK feature where multiple `ligate-node` processes register with a shared
+Postgres database, one acquires a leader lock to produce batches, and the
+rest stand by as Replicas ready to take over. It is **not** about
+Celestia DA failover or generic sequencer key rotation; for those see
+[`celestia-light-node.md`](./celestia-light-node.md) and
+[`sequencer-key-rotation.md`](./sequencer-key-rotation.md).
+
+---
+
+## When does failover apply?
+
+| Cause | Severity | What it blocks |
+|---|---|---|
+| **Leader process crash** (panic, OOM) | High | Batch production halts until a Replica wins the next lock cycle. RPC `submit_tx` returns 503 on the dead node; clients should retry against the load-balanced public endpoint. |
+| **Leader VM unhealthy** (kernel hung, disk full, network partition) | High | Heartbeat lapses → lock expires → election unblocks. Recovery clock starts at the heartbeat-timeout boundary, not the moment of failure. |
+| **Postgres unreachable** (Cloud SQL maintenance, network outage) | Critical | All nodes stop progressing election. Existing Leader may continue briefly under its current lock TTL, then loses authority. No batches produced until Postgres is reachable again. |
+| **Planned Leader replacement** (binary upgrade on the active node) | Low | Stop the Leader cleanly; a Replica takes over within one election cycle. Then upgrade and rejoin as Replica. |
+
+The first three are operational incidents. The fourth is the happy-path
+workflow we use for zero-downtime ops releases.
+
+---
+
+## What "Leader" means in DbElected mode
+
+Three sequencer roles exist at the **slot level** in
+`rollup.toml → [sequencer.preferred.postgres_config]`:
+
+| `node_role` | Behaviour |
+|---|---|
+| `Leader` | Competes for and holds the lock unconditionally. Produces batches when it wins. |
+| `Replica` | Heartbeats but **never** tries to acquire the lock. Cold standby; useful for "I want this node visible in the cluster but never producing batches". |
+| `DbElected` | Heartbeats and competes for the lock. The standard production role. |
+
+Separately, the **binary-level role** (set via `--mode` / `LIGATE_MODE`
+in `/etc/ligate/env`) is `Sequencer` or `Follower`:
+
+- `Sequencer` mode runs the sequencer slot, including the Postgres
+  heartbeat task and (if `node_role != Replica`) leader-election machinery.
+- `Follower` mode syncs the STF from DA but does **not** produce batches.
+  It does still run the heartbeat task if `postgres_config` is present,
+  which is how a `Follower + Replica` slot ends up registered in the
+  `nodes` table.
+
+In practice on devnet-1 today:
+
+- VM-1 (production sequencer): `LIGATE_MODE=sequencer`, `node_role=DbElected` (after cutover). The Leader candidate.
+- VM-2 + VM-3 (cold replicas): `LIGATE_MODE=follower`, `node_role=Replica`. Never compete for leadership, just heartbeat + sync.
+
+To turn a Replica into a hot Leader candidate, both flip simultaneously:
+`LIGATE_MODE` → `sequencer` and `node_role` → `DbElected`.
+
+---
+
+## Reading cluster state
+
+All state lives in Postgres (`ligate_sequencer` database on Cloud SQL,
+private IP `10.123.0.2`). The two tables that matter:
+
+```sql
+-- Who's heartbeating, when did we last hear from them
+SELECT node_id, address, last_updated FROM nodes ORDER BY node_id;
+
+-- Who currently holds the leader lock
+SELECT node_id, last_updated, leader_acquired_at FROM sequencer_leader;
+```
+
+Connect from any sequencer VM:
+
+```sh
+PG_PASS=$(gcloud secrets versions access latest --secret=cloudsql-ligate-sequencer-db-app)
+PGPASSWORD="$PG_PASS" psql -h 10.123.0.2 -U ligate_sequencer -d ligate_sequencer
+```
+
+Healthy steady state:
+- `nodes` shows every active node with `last_updated` within the last
+  heartbeat-interval (~15s by default).
+- `sequencer_leader` shows exactly one row whose `node_id` matches the
+  expected Leader and whose `last_updated` is fresh.
+
+Unhealthy signals:
+- A node missing from `nodes` → not heartbeating (process down or
+  Postgres unreachable from that VM).
+- `sequencer_leader.last_updated` older than the lock TTL → Leader has
+  silently stopped renewing; expect election to fire shortly.
+- `sequencer_leader` empty for more than a few seconds → no Leader,
+  cluster is not producing batches.
+
+---
+
+## Procedure A: Planned Leader replacement (zero-downtime upgrade)
+
+Use this when rolling a binary upgrade on the active node. The Replica
+becomes Leader for the duration of the upgrade, then we either let it
+stay (cluster heals to N-1 + N+1) or hand authority back.
+
+**Pre-flight.** Confirm a healthy Replica exists and is fully synced:
+
+```sh
+# Heartbeats fresh on all nodes
+PGPASSWORD="$PG_PASS" psql -h 10.123.0.2 -U ligate_sequencer -d ligate_sequencer \
+  -c "SELECT node_id, EXTRACT(EPOCH FROM (NOW() - last_updated)) AS age_s FROM nodes;"
+
+# Replicas' head heights match Leader's (within a few blocks)
+for vm in ligate-devnet-1-sequencer ligate-devnet-1-sequencer-2 ligate-devnet-1-sequencer-3; do
+  echo "=== $vm ==="
+  gcloud compute ssh "$vm" --zone=us-central1-a --command='curl -s http://127.0.0.1:9100/metrics | grep ^ligate_block_height'
+done
+```
+
+1. **Promote a Replica.** On the chosen takeover node, edit
+   `/opt/ligate/devnet-1/celestia.toml` and change `node_role = "Replica"`
+   → `node_role = "DbElected"`. Restart:
+   ```sh
+   sudo systemctl restart ligate-node
+   ```
+   Watch `sequencer_leader`; it will not change yet because the current
+   Leader still holds the lock. The promoted node is now in the election
+   pool.
+
+2. **Stop the current Leader gracefully.**
+   ```sh
+   sudo systemctl stop ligate-node
+   ```
+   Within one election cycle (lock TTL, typically 30s) the promoted
+   Replica should win:
+   ```sh
+   PGPASSWORD="$PG_PASS" psql -h 10.123.0.2 -U ligate_sequencer -d ligate_sequencer \
+     -c "SELECT * FROM sequencer_leader;"
+   ```
+
+3. **Upgrade + restart the old Leader.** While the new Leader produces,
+   the old Leader's VM is free to upgrade. Set `LIGATE_TAG=vX.Y.Z` in
+   `/etc/ligate/env`, re-run the install path, and start the service.
+   It rejoins as a competing candidate (since its `node_role` is still
+   `DbElected`).
+
+4. **(Optional) Hand authority back.** If the historical Leader should
+   stay primary, demote the takeover node back to `Replica` and restart
+   it. The old Leader wins the next election cycle.
+
+**Time budget.** Lock TTL + restart of takeover node + propagation ≈
+30–60s of no-batch-production. Public RPC (load-balanced) keeps serving
+reads throughout; `submit_tx` will return 503 from any node not currently
+holding the lock.
+
+---
+
+## Procedure B: Unplanned Leader failure (crash, partition)
+
+The auto-recovery story. Triggered by either:
+- Leader process crash (systemd will restart it; if restart loops, see
+  Procedure C).
+- Leader VM unreachable for longer than the lock TTL.
+
+The cluster handles this **without operator intervention** when at least
+one healthy `DbElected` node remains:
+
+1. Leader stops renewing its lock entry in `sequencer_leader`.
+2. After the lock TTL elapses, a remaining `DbElected` node wins the
+   next acquire-attempt and starts producing.
+3. The dead Leader's `nodes` row goes stale; an operator should
+   investigate but the cluster is already producing.
+
+**What the operator does:**
+
+1. **Confirm a new Leader took over.**
+   ```sh
+   PGPASSWORD="$PG_PASS" psql -h 10.123.0.2 -U ligate_sequencer -d ligate_sequencer \
+     -c "SELECT node_id, EXTRACT(EPOCH FROM (NOW() - last_updated)) AS leader_age_s FROM sequencer_leader;"
+   ```
+   `leader_age_s` should be small (< heartbeat-interval). If
+   `sequencer_leader` is **empty**, the cluster is not producing → escalate
+   to Procedure C (forced takeover).
+
+2. **Triage the dead node.**
+   ```sh
+   gcloud compute ssh <dead-node> --zone=us-central1-a --command='sudo journalctl -u ligate-node --since "10 minutes ago" --no-pager | tail -100'
+   ```
+   Common causes: OOM (check `dmesg | tail`), Celestia light-node lost
+   sync (`sudo systemctl status celestia-light`), disk full (`df -h`).
+
+3. **Recover the dead node.** Once root cause is addressed, bring the
+   binary back up. It will rejoin as a competing `DbElected` node, but
+   the new Leader will continue producing until the next election cycle
+   chooses otherwise.
+
+4. **Decide on Leader stickiness.** If the original Leader was a
+   designated "primary" (e.g. better hardware, lower DA-RTT), demote the
+   takeover node to `Replica` after the original is healthy. The
+   original will reclaim the lock.
+
+---
+
+## Procedure C: Forced takeover (no automatic failover happening)
+
+Used when:
+- All `DbElected` nodes are unhealthy and Replicas need to be promoted
+  by hand.
+- `sequencer_leader` is empty for longer than ~2 minutes and the cluster
+  is wedged.
+
+1. **Identify the most-synced Replica.** Pick the one whose
+   `ligate_block_height` is highest:
+   ```sh
+   for vm in ligate-devnet-1-sequencer ligate-devnet-1-sequencer-2 ligate-devnet-1-sequencer-3; do
+     echo -n "$vm: "
+     gcloud compute ssh "$vm" --zone=us-central1-a --command='curl -s http://127.0.0.1:9100/metrics | grep ^ligate_block_height' 2>/dev/null
+   done
+   ```
+
+2. **Promote it.** On that VM:
+   ```sh
+   sudo sed -i 's/^node_role = "Replica"/node_role = "DbElected"/' /opt/ligate/devnet-1/celestia.toml
+   # Also flip binary mode if it was a Follower
+   sudo sed -i 's/^LIGATE_MODE=follower/LIGATE_MODE=sequencer/' /etc/ligate/env
+   sudo systemctl restart ligate-node
+   ```
+
+3. **Verify.** Within one lock-TTL cycle:
+   ```sh
+   PGPASSWORD="$PG_PASS" psql -h 10.123.0.2 -U ligate_sequencer -d ligate_sequencer \
+     -c "SELECT * FROM sequencer_leader;"
+   ```
+   `sequencer_leader.node_id` should match the promoted node. Confirm
+   block height starts advancing via Grafana `ligate-node` dashboard
+   (filter `$instance` to the promoted node) or
+   `curl -s http://127.0.0.1:9100/metrics | grep ligate_block_height`.
+
+4. **DA-key prerequisite.** The promoted node MUST have
+   `da.signer_private_key` set in `celestia.toml`; without it batch
+   submission to Celestia will fail. On devnet-1 this is currently
+   fetched from Secret Manager by cloud-init for every VM. If you spun
+   up a Follower without provisioning the DA key, fix that first (see
+   [`celestia-light-node.md`](./celestia-light-node.md)).
+
+---
+
+## Procedure D: Postgres outage
+
+Cloud SQL HA failover is automatic and typically takes 60–120s. During
+that window:
+
+1. The current Leader cannot renew its lock → it should stop producing
+   batches once its in-memory TTL view expires. (Tested in unit tests;
+   **not** yet validated end-to-end on devnet-1.)
+2. All nodes will surface Postgres errors in logs:
+   ```
+   ERROR sov_sequencer::preferred::db: failed to renew leader lock ...
+   ```
+3. No election can happen until Postgres comes back.
+
+**Operator action:** none required if HA failover succeeds. If Cloud SQL
+is down for longer than ~5 minutes, escalate per the standard GCP
+outage playbook. But note that **this is the single point of failure
+in the current devnet-1 multi-sequencer story**. It is acceptable on
+devnet (we control the SLA + failure surface); pre-mainnet we need a
+plan B (etcd / dedicated quorum). Tracked at
+[chain#82](https://github.com/ligate-io/ligate-chain/issues/82).
+
+---
+
+## Validation status
+
+What we have **live-tested** on devnet-1 as of this runbook's first
+write:
+
+- Replica registration in `nodes` (VM-2, FOLLOWER binary mode + `node_role=Replica`).
+- Heartbeat task runs in both `Sequencer` and `Follower` binary modes.
+- Postgres connection via SSL (`sslmode=require`) against Cloud SQL
+  private IP works from VMs in the same VPC.
+
+What is **SDK-documented but not yet exercised live**:
+
+- Automatic Leader → Replica failover under crash (Procedure B). Smoke-
+  harness test in [`tests/smoke/multi-sequencer/`](../../../tests/smoke/multi-sequencer/) validates the
+  election + heartbeat path but on MockDa, not Celestia (tracked at
+  [chain#420](https://github.com/ligate-io/ligate-chain/issues/420)).
+- Lock TTL behaviour under Postgres maintenance failover (Procedure D).
+- DA contention if two nodes briefly both believe they are Leader (we
+  have not deliberately split-brained the cluster).
+
+**Next planned drill.** Once VM-3 is fully synced and promoted to
+`DbElected`, kill VM-1's ligate-node process and time the failover. Open
+a follow-up issue with the measured numbers.
+
+---
+
+## Open follow-ups
+
+- [chain#82](https://github.com/ligate-io/ligate-chain/issues/82): multi-sequencer umbrella.
+- [chain#420](https://github.com/ligate-io/ligate-chain/issues/420): upgrade Docker Compose smoke harness to use local-celestia-devnet (currently MockDa only).
+- [chain#422](https://github.com/ligate-io/ligate-chain/issues/422): devnet-1 rollout, this runbook is deliverable F.
+- [chain#426](https://github.com/ligate-io/ligate-chain/issues/426): drop signer-key requirement for Follower mode (would unblock running cold Replicas without DA-signing capability).

--- a/docs/development/runbooks/multi-sequencer-failover.md
+++ b/docs/development/runbooks/multi-sequencer-failover.md
@@ -99,6 +99,36 @@ Unhealthy signals:
 
 ---
 
+## Prerequisite: `bind_host` flip for fan-out routing
+
+The canonical bundle ships with `bind_host = "127.0.0.1"` in
+`[runner.http_config]` of `celestia.toml`. That's safe for solo
+operators but **incompatible** with the gateway-VM Caddyfile in
+`ops/caddy/Caddyfile`, which fans writes out to all 3 sequencer VMs
+over the VPC. Flip the bind on every multi-sequencer VM before
+deploying the leader-aware Caddyfile:
+
+```sh
+# On each VM (VM-1, VM-2, VM-3)
+sudo sed -i 's/^bind_host = "127.0.0.1"/bind_host = "0.0.0.0"/' /opt/ligate/devnet-1/celestia.toml
+sudo systemctl restart ligate-node
+
+# Verify
+sudo ss -tlnp | grep 12346
+# Expect: LISTEN ... 0.0.0.0:12346 ... ligate-node
+```
+
+The GCP firewall already restricts port 12346 to VPC peers (default
+deny + per-VPC allow rule). No public exposure occurs.
+
+For a fresh VM coming up via cloud-init, the bind flip is currently a
+manual post-boot step: cloud-init runs the render script and writes
+the canonical `127.0.0.1` value, then an operator follows up with the
+`sed` above. Wiring `LIGATE_BIND_HOST` into `render-rollup-toml.sh` is
+a small follow-up (open as a sub-issue of chain#422 if it bites again).
+
+---
+
 ## Procedure A: Planned Leader replacement (zero-downtime upgrade)
 
 Use this when rolling a binary upgrade on the active node. The Replica
@@ -290,6 +320,10 @@ What is **SDK-documented but not yet exercised live**:
 - Lock TTL behaviour under Postgres maintenance failover (Procedure D).
 - DA contention if two nodes briefly both believe they are Leader (we
   have not deliberately split-brained the cluster).
+- Caddy leader-aware fan-out in [`ops/caddy/Caddyfile`](../../../ops/caddy/Caddyfile)
+  (write traffic routes to whichever upstream returns `BatchProducer`
+  on `/v1/sequencer/role`). Probed manually but not exercised under
+  load or during a real failover.
 
 **Next planned drill.** Once VM-3 is fully synced and promoted to
 `DbElected`, kill VM-1's ligate-node process and time the failover. Open

--- a/docs/development/runbooks/multi-sequencer-failover.md
+++ b/docs/development/runbooks/multi-sequencer-failover.md
@@ -118,6 +118,29 @@ sudo ss -tlnp | grep 12346
 # Expect: LISTEN ... 0.0.0.0:12346 ... ligate-node
 ```
 
+**Measured restart penalty: ~5 minutes per VM.** `ligate-node` currently
+ignores SIGTERM and only exits when systemd's `TimeoutStopSec` (default
+300s) expires and the process gets SIGKILL'd. This is a chain bug
+tracked at [chain#435](https://github.com/ligate-io/ligate-chain/issues/435):
+graceful shutdown is broken, so every restart is a 5-min HTTP outage
+window on that VM (Caddy returns 502 from `127.0.0.1:12346`).
+
+Workarounds while #435 is open:
+- Restart only one VM at a time so the others keep serving reads through
+  Caddy's fan-out pool (after the Caddyfile in
+  [`ops/caddy/Caddyfile`](../../../ops/caddy/Caddyfile) is deployed).
+- Apply a unit override to shorten the kill cycle:
+  ```
+  [Service]
+  TimeoutStopSec=30
+  KillMode=mixed
+  SendSIGKILL=yes
+  ```
+- For the Leader VM only, schedule restarts during low-traffic windows.
+
+This penalty also applies to **every** binary upgrade until #435 lands,
+not just the bind flip.
+
 The GCP firewall already restricts port 12346 to VPC peers (default
 deny + per-VPC allow rule). No public exposure occurs.
 
@@ -159,11 +182,11 @@ done
    Leader still holds the lock. The promoted node is now in the election
    pool.
 
-2. **Stop the current Leader gracefully.**
+2. **Stop the current Leader.** Until [chain#435](https://github.com/ligate-io/ligate-chain/issues/435) lands, `ligate-node` doesn't shut down on SIGTERM and `systemctl stop` blocks for `TimeoutStopSec` (5 min default) before SIGKILL. Until the bug is fixed, send SIGKILL directly so the lock releases fast:
    ```sh
-   sudo systemctl stop ligate-node
+   sudo systemctl kill --signal=SIGKILL ligate-node
    ```
-   Within one election cycle (lock TTL, typically 30s) the promoted
+   Within one election cycle (lock TTL, typically 30s after the dying Leader stops renewing) the promoted
    Replica should win:
    ```sh
    PGPASSWORD="$PG_PASS" psql -h 10.123.0.2 -U ligate_sequencer -d ligate_sequencer \

--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -175,14 +175,16 @@ rpc.ligate.io {
     }
 
     # READ path: every other request fans out to the full sequencer
-    # pool with round-robin. `/health` is a generic liveness probe;
-    # any non-2xx response evicts the upstream.
+    # pool with round-robin. Uses `/ready` (NOT `/health`) for the
+    # active probe so that nodes still catching up from DA return 503
+    # and Caddy excludes them. Serving reads from an unsynced node
+    # would silently surface stale state to clients.
     handle {
         reverse_proxy {
             import sequencer_pool
             lb_policy round_robin
 
-            health_uri /health
+            health_uri /ready
             health_status 200
             health_interval 5s
             health_timeout 2s

--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -1,4 +1,4 @@
-# rpc.ligate.io: TLS-terminated proxy to ligate-node REST.
+# rpc.ligate.io: TLS-terminated proxy to the ligate-node DbElected cluster.
 # Let's Encrypt cert provisions automatically on first request.
 #
 # Defense-in-depth: only accept traffic that arrived via Cloudflare's
@@ -11,6 +11,35 @@
 # on 2026-05-16. Cloudflare rarely changes these; review quarterly
 # or when the connection-from-CF check below starts dropping
 # legitimate traffic.
+#
+# ─── Topology ────────────────────────────────────────────────────────
+# Multi-sequencer mode (DbElected, chain#422). VM-1 is the public-
+# facing gateway; Cloudflare → VM-1's Caddy → fans out to the cluster
+# via VPC-private IPs. All 3 ligate-node processes register against the
+# shared Cloud SQL Postgres; exactly one holds the leader lock and
+# returns `"BatchProducer"` on `/v1/sequencer/role`. The others return
+# `"PgSyncReplica"` and 503 on `POST /v1/sequencer/txs`.
+#
+# Read traffic (everything except POST /v1/sequencer/txs):
+#   round-robin across all 3 healthy upstreams (`/health` active check).
+# Write traffic (POST /v1/sequencer/txs):
+#   `lb_policy first` against a leader-aware health probe that requires
+#   `/v1/sequencer/role` to respond with body matching `BatchProducer`.
+#   When the current Leader dies its probe stops matching, Caddy
+#   demotes it from the pool, and the next healthy upstream (which by
+#   then is the new Leader elected by the SDK) absorbs writes.
+#
+# Prerequisite: ligate-node `bind_host` must be `0.0.0.0` (or the VPC
+# range) on every VM, and the GCP firewall must allow port 12346 within
+# the VPC. The legacy single-VM config used `bind_host = 127.0.0.1` and
+# is incompatible with fan-out routing. See
+# `docs/development/runbooks/multi-sequencer-failover.md` for the bind
+# change procedure.
+#
+# Gateway HA is **not** solved here: if VM-1 itself dies, all traffic
+# stops until DNS is swung to another VM's external IP. Tracked as a
+# follow-up to chain#422; for devnet-1 the single-gateway model is
+# acceptable.
 
 (cloudflare_only) {
     @not_cloudflare not remote_ip 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13 104.24.0.0/14 172.64.0.0/13 131.0.72.0/22 2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32 2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
@@ -19,11 +48,28 @@
     }
 }
 
+# DbElected upstream pool. Private VPC IPs of the 3 sequencer VMs.
+# Replace these when re-IPing or expanding the pool.
+#
+# IPs are intentionally hardcoded: the pool is small (3), changes
+# infrequently, and the alternative (DNS lookup in Caddy) would
+# introduce a DNS-failure cliff.
+#
+# Snippet uses `to` subdirectives so it can be imported inside any
+# `reverse_proxy { ... }` block (bare IPs would have to appear on the
+# `reverse_proxy` line itself and can't be carried by an `import`).
+(sequencer_pool) {
+    to 10.128.0.3:12346
+    to 10.128.0.6:12346
+    to 10.128.0.11:12346
+}
+
 rpc.ligate.io {
     import cloudflare_only
     encode gzip
 
     # Health probes are unversioned; ligate-node serves them at the root.
+    # Reads against the gateway VM only (cheap, no fan-out needed).
     handle /health {
         reverse_proxy 127.0.0.1:12346
     }
@@ -42,8 +88,8 @@ rpc.ligate.io {
     #
     # IMPORTANT: the `redir /v1/swagger-ui/ 308` only fires when this
     # block routes ahead of the catch-all `reverse_proxy` at the end.
-    # That's the whole reason the catch-all is wrapped in handle{} —
-    # a bare `reverse_proxy` at the site-block level would compete with
+    # That's the whole reason the catch-all is wrapped in handle{}: a
+    # bare `reverse_proxy` at the site-block level would compete with
     # these handle{} blocks and could win the routing race, sending
     # /v1/swagger-ui to the chain's broken bundled UI instead.
     handle_path /v1/swagger-ui/* {
@@ -81,16 +127,65 @@ rpc.ligate.io {
         respond "Not exposed publicly. See ops docs." 404
     }
 
-    # Catch-all: every other path proxies to ligate-node.
-    # MUST be wrapped in handle{} — a bare directive at the site-block
-    # level competes with the explicit handle{} blocks above and can
-    # win the routing race. The original Caddyfile had `reverse_proxy
-    # 127.0.0.1:12346` as a bare directive, which is exactly why the
-    # `/v1/swagger-ui` (no trailing slash) redirect wasn't firing:
-    # the bare proxy was winning over `handle /v1/swagger-ui { redir }`.
-    # Empty matcher (handle without a path) = fallback for any request
-    # not matched by a more specific handle block above.
+    # Block /v1/sequencer/role from being public: it's an internal
+    # leader-detection endpoint used by the Caddy active health check
+    # below. Exposing it externally would leak cluster topology.
+    handle /v1/sequencer/role {
+        respond "Internal endpoint." 404
+    }
+
+    # WRITE path: POST /v1/sequencer/txs goes to the current Leader
+    # only. `lb_policy first` picks the first healthy upstream, and the
+    # health probe accepts only nodes returning body matching
+    # `BatchProducer`. So "first healthy" == "the Leader".
+    #
+    # When the Leader fails, its probe stops matching within
+    # `health_interval`. Caddy demotes it; the next probe cycle finds
+    # the new SDK-elected Leader (which by then has acquired the lock
+    # and started returning BatchProducer). Failover window =
+    # SDK election (~10s) + Caddy health_interval (~2s) = ~12s.
+    @write {
+        method POST
+        path /v1/sequencer/txs
+    }
+    handle @write {
+        reverse_proxy {
+            import sequencer_pool
+            lb_policy first
+            lb_try_duration 5s
+            lb_try_interval 250ms
+
+            # Active leader-detection probe.
+            health_uri /v1/sequencer/role
+            health_status 200
+            health_body "BatchProducer"
+            health_interval 2s
+            health_timeout 1s
+
+            # If the selected upstream fails to dial (TCP refused, node
+            # restarting), Caddy automatically tries the next healthy
+            # upstream within `lb_try_duration`. There is no built-in
+            # Caddyfile knob to retry on a 503 response body (would
+            # require a custom matcher plugin or JSON config); a race
+            # where a node passes the probe but loses the lock between
+            # probe and write is rare enough that we surface the 503 to
+            # the client and let them retry. Tracked as a future
+            # hardening if it bites in practice.
+        }
+    }
+
+    # READ path: every other request fans out to the full sequencer
+    # pool with round-robin. `/health` is a generic liveness probe;
+    # any non-2xx response evicts the upstream.
     handle {
-        reverse_proxy 127.0.0.1:12346
+        reverse_proxy {
+            import sequencer_pool
+            lb_policy round_robin
+
+            health_uri /health
+            health_status 200
+            health_interval 5s
+            health_timeout 2s
+        }
     }
 }


### PR DESCRIPTION
## Summary

Bundles deliverables **D** (Caddyfile leader-aware write routing) and **F** (multi-sequencer-failover runbook) of [chain#422](https://github.com/ligate-io/ligate-chain/issues/422). Both ship as part of the DbElected cutover that's underway on devnet-1.

### D: Caddyfile leader-aware fan-out

- `ops/caddy/Caddyfile` extends from single-VM `reverse_proxy 127.0.0.1:12346` to a 3-VM DbElected pool (10.128.0.3, 10.128.0.6, 10.128.0.11).
- **Writes** (`POST /v1/sequencer/txs`): `lb_policy first` against an active health probe of `/v1/sequencer/role` that requires response body `BatchProducer`. So "first healthy" == "the SDK-elected Leader". When the Leader dies, its probe stops matching within `health_interval` (2s), and the next probe cycle picks up whoever the SDK elects.
- **Reads** (everything else): round-robin across the full pool with `/health` liveness probe.
- `/v1/sequencer/role` blocked from public (internal topology leak).
- Sequencer upstream pool defined as a Caddyfile snippet so the same IP list is shared by both reverse_proxy blocks.
- Validated on VM-1: `caddy validate` returns "Valid configuration".

### F: Multi-sequencer failover runbook

- New `docs/development/runbooks/multi-sequencer-failover.md` (~340 lines).
- Cluster-state query patterns against Cloud SQL `nodes` + `sequencer_leader` tables.
- 4 procedures: planned Leader replacement (zero-downtime upgrade), unplanned Leader failure, forced takeover, Postgres outage.
- Honest validation status: separates what we've live-tested on devnet-1 (Replica heartbeat in `nodes`, Postgres SSL connection) from what's SDK-documented-only (automatic failover, lock TTL under PG maintenance, DA split-brain).
- `docs/development/README.md` runbook table updated.

### Bind_host prerequisite

The Caddyfile fan-out requires `bind_host = "0.0.0.0"` on each VM (currently `127.0.0.1` in the canonical bundle, safe for solo operators but blocks cross-VM probing). Documented as a runbook prerequisite + cross-referenced comment in `devnet-1/celestia.toml`. Cloud-init render script doesn't yet substitute it; flagged as a small follow-up.

## Deploy order (when ready)

1. Flip `bind_host` to `0.0.0.0` on all 3 VMs + `systemctl restart ligate-node`
2. Verify probes work: `curl http://10.128.0.X:12346/v1/sequencer/role` from a peer VM
3. `scp` new Caddyfile to VM-1 + `caddy reload`
4. (Separate cutover) flip VM-1 to `node_role = "DbElected"` + activate VM-3 Replica

## Test plan

- [x] `caddy validate` on the new Caddyfile (passes)
- [x] `/v1/sequencer/role` returns `"BatchProducer"` from VM-1 (Leader) and `"PgSyncReplica"` from VM-2 (Replica)
- [ ] After bind_host flip + Caddy reload: confirm reads round-robin (curl `/health` 9x, observe X-Forwarded-For or upstream logs)
- [ ] After bind_host flip + Caddy reload: confirm writes always land on VM-1 (the current Leader) via VM-1's submit log
- [ ] Manual failover drill: stop VM-1's ligate-node, observe new Leader election in Postgres, observe Caddy routing writes to new Leader within ~12s

Refs: [chain#82](https://github.com/ligate-io/ligate-chain/issues/82) (umbrella), [chain#422](https://github.com/ligate-io/ligate-chain/issues/422) (this sub-issue).