### PR TITLE
cut v0.2.7 hotfix: revert broken http serve timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-05-21
+
+Hotfix for v0.2.6 which was broken on deploy: the HTTP server died 20 seconds after boot because of a faulty `tokio::time::timeout` wrap around `axum::serve` in the SDK fork. Reverts that wrap. The chain-side 35-second shutdown watchdog (also added in v0.2.6) still bounds any future shutdown hang. v0.2.6 was deployed to VM-1 at 10:52 UTC and rolled back to v0.2.4 at 10:55 UTC after the public RPC started returning 502; no chain state was affected.
+
+### Fixed
+
+- SDK fork (`ligate-io/sovereign-sdk@2633af2d5`): revert `tokio::time::timeout(20s, axum::serve(...).with_graceful_shutdown(...))` from `sov-stf-runner/src/http/mod.rs`. The previous code in v0.2.6 forced the HTTP server to return Ok after 20 seconds of normal operation regardless of whether shutdown was signaled, leaving the chain producing batches but with no REST endpoint. The intent (bound graceful drain to 20s after shutdown signal) would need to spawn a separate watchdog task; for now the chain-side process-level watchdog at 35s covers the original hang scenario.
+- Kept the 5-second timeout on `server_handle.stopped()` after shutdown signal (jsonrpsee server drain); that one is correctly gated by the prior shutdown call so it can't fire during normal operation.
+
+### Changed
+
+- SDK pin bumped from `d3e7acf28e1ebe98f523c235084c61a1c93d0b38` to `2633af2d599c6a899fcdc484a0f198a26307d16b`.
+- Internal workspace crates bumped 0.2.6 -> 0.2.7 in `Cargo.lock`.
+
+### Compatibility
+
+`chain_hash` unchanged from v0.2.6 (and v0.2.5). Safe binary swap.
+
 ## [0.2.6] - 2026-05-21
 
 Failover-recovery hardening (chain#435). Cuts a tagged release for the SDK pin bump and shutdown-watchdog plumbing that resolve the three bugs surfaced by the 2026-05-20 multi-sequencer failover drill: a forced kill on the leader left every node in a cascading 5-minute shutdown hang with stale Postgres state, requiring manual RocksDB surgery to recover. The combined fix in this release replaces the SDK's "Replica acquired leadership → exit-to-restart" pattern with an in-process role transition, makes graceful shutdown bounded, and lets any future kill auto-recover.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 
 [[package]]
 name = "nmt-rs"
@@ -7703,7 +7703,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "backon",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7781,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7843,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -7875,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7924,7 +7924,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7947,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "borsh",
  "derivative",
@@ -7995,7 +7995,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -8009,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "axum",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8121,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8227,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "axum",
@@ -8248,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8267,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8285,7 +8285,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8304,7 +8304,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8324,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "axum",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8374,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -8402,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "derive_more",
  "rockbound",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8532,7 +8532,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8567,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8628,7 +8628,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8641,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -8662,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "bech32",
  "borsh",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -8689,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8705,7 +8705,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=d3e7acf28e1ebe98f523c235084c61a1c93d0b38#d3e7acf28e1ebe98f523c235084c61a1c93d0b38"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2633af2d599c6a899fcdc484a0f198a26307d16b#2633af2d599c6a899fcdc484a0f198a26307d16b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]
@@ -146,35 +146,35 @@ debug = 0
 #
 # Rebase discipline + workflow lives in the fork's CONTRIBUTING.md.
 [patch."https://github.com/Sovereign-Labs/sovereign-sdk.git"]
-sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-blob-sender                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
-sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "d3e7acf28e1ebe98f523c235084c61a1c93d0b38" }
+sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-blob-sender                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }
+sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2633af2d599c6a899fcdc484a0f198a26307d16b" }


### PR DESCRIPTION
Reverts the bug 2a HTTP timeout wrap from v0.2.6 that killed the HTTP server 20 seconds after boot. See CHANGELOG.md for the full incident summary. Caught on VM-1 deploy at 10:52 UTC; rolled back to v0.2.4 at 10:55 UTC; chain state unaffected.