### PR TITLE
cloud-init: bump LIGATE_TAG to v0.2.7

### DIFF
--- a/ops/cloud-init/sequencer.yaml
+++ b/ops/cloud-init/sequencer.yaml
@@ -233,7 +233,7 @@ runcmd:
   # swaps, the same flow used during the v0.2.3 → v0.2.4 swap on
   # 2026-05-20).
   - |
-    LIGATE_TAG=v0.2.5
+    LIGATE_TAG=v0.2.7
     LIGATE_VERSION=0.2.5
     ARTIFACT="ligate-node-${LIGATE_VERSION}-linux-amd64.tar.gz"
     # Keep the artifact's original filename so `sha256sum -c` can find
@@ -256,7 +256,7 @@ runcmd:
   # Idempotent: --depth 1 + a fresh tmp clone every cloud-init run;
   # cp -rn so we don't clobber an operator-edited /opt/ligate/devnet-1/.
   - |
-    LIGATE_TAG=v0.2.5
+    LIGATE_TAG=v0.2.7
     rm -rf /tmp/ligate-chain
     git clone --depth 1 --branch ${LIGATE_TAG} \
       https://github.com/ligate-io/ligate-chain.git /tmp/ligate-chain


### PR DESCRIPTION
Future VM re-images pull v0.2.7 (chain#435 full fix: in-process DbElected role transition + bug 1 + bug 2). v0.2.6 was broken and yanked; v0.2.7 is the live tag on VM-1 + VM-2 + VM-3 and the one that just passed the forced-failover drill.