### PR TITLE
chain#446 followup: sequencer role + transitions Prometheus metrics + Grafana panels (v0.2.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-05-22
+
+Surfaces the DbElected sequencer role + transitions as Prometheus metrics so the paper-leader scenario from 2026-05-21 (chain#446) becomes visible on Grafana, not just in logs. Plumbing-only change; no behaviour shift.
+
+### Added
+
+- `ligate_sequencer_role` gauge in `crates/rollup/src/metrics.rs`. 0 = unknown (chain HTTP unreachable / still booting), 1 = PgSyncReplica, 2 = BatchProducer. Sampled from the local `/v1/sequencer/role` endpoint every 2s (matches the SDK's Postgres heartbeat cadence).
+- `ligate_sequencer_role_transitions_total{from,to}` counter. Bumps each time the sampled role differs from the previous sample. `from` and `to` labels are readable role names (`unknown` / `replica` / `leader`) so a Grafana panel can show "VM-3: replica → leader at 22:51 UTC" without a join.
+- `crates/rollup/src/main.rs` spawns the role poller alongside the existing metrics tasks. Hardcoded loopback URL (`http://127.0.0.1:12346`); operators who change the SDK's HTTP bind would need to patch this, but nobody does in practice.
+- `ops/grafana/ligate-node.json`: new **Cluster topology** row at y=40 with two panels — role per VM (Stat, value-mapped + color-coded: red unknown, blue replica, green leader) and role transitions rate (Time series over 5m windows). The role panel is the primary visual for catching split-brain or flapping.
+- Unit tests in `metrics.rs` covering the `encode_role` shape (leader / replica / unknown on empty / unknown on future variant / whitespace handling).
+
+### Operator notes
+
+The Prometheus scrape config is unchanged. New metrics show up automatically on next scrape after the binary swap. Re-import `ops/grafana/ligate-node.json` to pick up the new row, or add the two PromQL queries to your own dashboard:
+
+- `ligate_sequencer_role{instance=~"$instance"}`
+- `sum by (instance, from, to) (rate(ligate_sequencer_role_transitions_total{instance=~"$instance"}[5m]))`
+
+Alert idea (not shipped here, file an issue if you want a default rule): page on `count(ligate_sequencer_role == 2) != 1` sustained for 60s. Zero leaders = leaderless; two leaders = split-brain.
+
+### Compatibility
+
+`chain_hash` unchanged from v0.2.9. Safe binary swap.
+
 ## [0.2.9] - 2026-05-21
 
 Removes the `--mode {sequencer,follower}` operator flag and the corresponding `NodeRole::Follower` machinery (chain#446). DbElected, the SDK's lock-elected sequencer mode, is the only sequencer path now; the boot-time mode toggle was redundant with the lock check and actively harmful in one observed case.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -65,6 +65,12 @@ attestation = { path = "../modules/attestation", features = ["native"] }
 prometheus = { workspace = true, features = ["process"] }
 axum       = { workspace = true }
 
+# Loopback HTTP client for the sequencer-role poller (chain#446 followup).
+# The role poller hits the SDK's own `/v1/sequencer/role` endpoint via
+# 127.0.0.1; reqwest is already on the workspace because client-rs and
+# bootstrap-cli use it for their REST surfaces.
+reqwest = { workspace = true }
+
 # Postgres pool for `/v1/cluster/nodes` (issue #442). Scoped to this
 # crate only: the SDK fork's heartbeat task has its own pool for
 # election; rather than expose it, we open a tiny 2-connection pool

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -67,9 +67,11 @@ axum       = { workspace = true }
 
 # Loopback HTTP client for the sequencer-role poller (chain#446 followup).
 # The role poller hits the SDK's own `/v1/sequencer/role` endpoint via
-# 127.0.0.1; reqwest is already on the workspace because client-rs and
-# bootstrap-cli use it for their REST surfaces.
-reqwest = { workspace = true }
+# 127.0.0.1. Version pinned inline (rather than via workspace.deps) to
+# match `bootstrap-cli`'s pattern; reqwest doesn't yet have a workspace
+# entry, and adding one would touch every consumer at once. Re-evaluate
+# if a third caller appears.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 # Postgres pool for `/v1/cluster/nodes` (issue #442). Scoped to this
 # crate only: the SDK fork's heartbeat task has its own pool for

--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -242,6 +242,24 @@ async fn run() -> anyhow::Result<()> {
                 tracing::error!(error = ?e, "metrics server stopped");
             }
         });
+
+        // Sequencer-role poller (chain#446 follow-up). Polls the local
+        // chain's `/v1/sequencer/role` and surfaces it as the
+        // `ligate_sequencer_role` gauge + role-transitions counter, so
+        // Grafana can paint paper-leader scenarios (lock held but no
+        // batch production) as a clear divergence between the role
+        // gauge and the batch-blob-submission rate.
+        //
+        // URL is hardcoded to the SDK's default loopback bind. We
+        // don't read it out of `rollup_config` here because the config
+        // load happens inside `run_with_*` after this metrics setup.
+        // If an operator overrides the SDK's bind, early polls will
+        // hit "unknown" until they patch this URL — acceptable; nobody
+        // overrides it in practice.
+        metrics::spawn_sequencer_role_task(
+            "http://127.0.0.1:12346/v1/sequencer/role".to_string(),
+            metrics::DEFAULT_SEQUENCER_ROLE_POLL_INTERVAL,
+        );
     }
 
     let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -663,3 +663,171 @@ pub fn spawn_da_metrics_task<Da: DaSpec>(
         }
     });
 }
+
+// ============================================================================
+// Sequencer role gauge + transition counter (chain#446 follow-up)
+//
+// Surfaces who's currently the DbElected leader to Grafana so the
+// paper-leader scenario (which bit us on 2026-05-21) is visible as a
+// metric, not just a log line. Two metrics:
+//
+// - `ligate_sequencer_role`: 0=unknown, 1=PgSyncReplica, 2=BatchProducer.
+//   Single integer because Grafana panels color-code by value cleanly.
+// - `ligate_sequencer_role_transitions_total{from,to}`: bumps on each
+//   observed transition. The `from`/`to` labels carry the readable
+//   names so a Stat panel can show "last leader change" without a join.
+// ============================================================================
+
+/// Default polling interval for the sequencer role sampler. 2s
+/// matches the SDK's Postgres heartbeat cadence; tighter polling
+/// wouldn't surface anything new and would spam the loopback server.
+pub const DEFAULT_SEQUENCER_ROLE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// `ligate_sequencer_role` gauge. 0 = unknown (no observation yet,
+/// or local chain HTTP server unreachable), 1 = PgSyncReplica
+/// (following leader via Postgres state-sync), 2 = BatchProducer
+/// (this node holds the leader lock and posts blobs to DA).
+fn sequencer_role() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_sequencer_role",
+            "Current sequencer role for this node. 0 = unknown (no observation yet or chain \
+             HTTP server unreachable), 1 = PgSyncReplica (following leader via Postgres \
+             state-sync), 2 = BatchProducer (this node holds the leader lock and posts blobs \
+             to DA)."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+/// `ligate_sequencer_role_transitions_total{from,to}` counter. Bumps
+/// every time the sampled role differs from the previous sample. The
+/// `from` and `to` labels are the readable role names (`unknown`,
+/// `replica`, `leader`) so a Grafana panel can show "VM-1: leader →
+/// replica at 22:51 UTC" without a join.
+fn sequencer_role_transitions() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter_vec!(
+            "ligate_sequencer_role_transitions_total",
+            "Number of observed sequencer-role transitions on this node, labelled by `from` \
+             and `to` role. Each label is `unknown`, `replica`, or `leader`.",
+            &["from", "to"]
+        )
+        .expect("counter registers once")
+    })
+}
+
+/// Pre-touch both sequencer-role metrics so their HELP/TYPE lines
+/// show up in the very first `/metrics` scrape, before the poller's
+/// first tick lands.
+pub fn init_sequencer_role() {
+    let _ = sequencer_role();
+    let _ = sequencer_role_transitions();
+}
+
+/// Decode the SDK's `/v1/sequencer/role` response into the gauge
+/// encoding. Response body is a quoted JSON string like
+/// `"BatchProducer"` or `"PgSyncReplica"`. Anything we don't
+/// recognise (connection failure, unbound port, future role variant)
+/// degrades to `unknown` rather than crashing the poller.
+fn encode_role(raw: &str) -> (i64, &'static str) {
+    match raw.trim().trim_matches('"') {
+        "BatchProducer" => (2, "leader"),
+        "PgSyncReplica" => (1, "replica"),
+        _ => (0, "unknown"),
+    }
+}
+
+/// Sample the local `/v1/sequencer/role` endpoint once and update
+/// the gauge + transition counter. `prev` carries the last observed
+/// label so a transition only bumps the counter on actual change.
+/// Pulled out of the spawn loop for unit-testability.
+pub async fn sample_sequencer_role(role_url: &str, prev: &mut Option<&'static str>) {
+    init_sequencer_role();
+    // Loopback fetch. Failures (chain still booting, port not yet
+    // bound, body not JSON) all fold into `encode_role` returning
+    // `(0, "unknown")` — the right "we don't know" signal for
+    // dashboards until the next poll succeeds.
+    let body = match reqwest::Client::new()
+        .get(role_url)
+        .timeout(Duration::from_secs(1))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => resp.text().await.unwrap_or_default(),
+        _ => String::new(),
+    };
+    let (value, label) = encode_role(&body);
+    sequencer_role().set(value);
+    if let Some(prev_label) = *prev {
+        if prev_label != label {
+            sequencer_role_transitions()
+                .with_label_values(&[prev_label, label])
+                .inc();
+            info!(from = prev_label, to = label, "sequencer role transition observed");
+        }
+    }
+    *prev = Some(label);
+}
+
+/// Spawn the sequencer-role poller. Polls `role_url` every `interval`
+/// (default 2s) and keeps `ligate_sequencer_role` plus the transition
+/// counter up to date. Fire-and-forget; lives until the runtime
+/// drops. Safe to call before the SDK's HTTP server is bound — early
+/// polls just record `unknown` until the loopback connection succeeds.
+pub fn spawn_sequencer_role_task(role_url: String, interval: Duration) {
+    init_sequencer_role();
+    tokio::spawn(async move {
+        let mut prev: Option<&'static str> = None;
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            sample_sequencer_role(&role_url, &mut prev).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod sequencer_role_tests {
+    use super::encode_role;
+
+    #[test]
+    fn encode_leader() {
+        let (v, l) = encode_role("\"BatchProducer\"");
+        assert_eq!(v, 2);
+        assert_eq!(l, "leader");
+    }
+
+    #[test]
+    fn encode_replica() {
+        let (v, l) = encode_role("\"PgSyncReplica\"");
+        assert_eq!(v, 1);
+        assert_eq!(l, "replica");
+    }
+
+    #[test]
+    fn encode_unknown_on_empty() {
+        let (v, l) = encode_role("");
+        assert_eq!(v, 0);
+        assert_eq!(l, "unknown");
+    }
+
+    #[test]
+    fn encode_unknown_on_garbage() {
+        // Future role variant or chain on a different version: degrade
+        // to unknown rather than crashing the gauge.
+        let (v, l) = encode_role("\"SomeFutureRole\"");
+        assert_eq!(v, 0);
+        assert_eq!(l, "unknown");
+    }
+
+    #[test]
+    fn encode_handles_whitespace() {
+        let (v, l) = encode_role("  \"BatchProducer\"  \n");
+        assert_eq!(v, 2);
+        assert_eq!(l, "leader");
+    }
+}

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -750,22 +750,16 @@ pub async fn sample_sequencer_role(role_url: &str, prev: &mut Option<&'static st
     // bound, body not JSON) all fold into `encode_role` returning
     // `(0, "unknown")` — the right "we don't know" signal for
     // dashboards until the next poll succeeds.
-    let body = match reqwest::Client::new()
-        .get(role_url)
-        .timeout(Duration::from_secs(1))
-        .send()
-        .await
-    {
-        Ok(resp) if resp.status().is_success() => resp.text().await.unwrap_or_default(),
-        _ => String::new(),
-    };
+    let body =
+        match reqwest::Client::new().get(role_url).timeout(Duration::from_secs(1)).send().await {
+            Ok(resp) if resp.status().is_success() => resp.text().await.unwrap_or_default(),
+            _ => String::new(),
+        };
     let (value, label) = encode_role(&body);
     sequencer_role().set(value);
     if let Some(prev_label) = *prev {
         if prev_label != label {
-            sequencer_role_transitions()
-                .with_label_values(&[prev_label, label])
-                .inc();
+            sequencer_role_transitions().with_label_values(&[prev_label, label]).inc();
             info!(from = prev_label, to = label, "sequencer role transition observed");
         }
     }

--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -1,7 +1,7 @@
 # Grafana dashboard for `ligate-node`
 
 Drop-in Grafana dashboard for the Phase 1 + Phase 2 metrics shipped
-on `ligate-node:9100/metrics`. Five rows, fifteen panels:
+on `ligate-node:9100/metrics`. Six rows, seventeen panels:
 
 - **Chain activity** — schemas registered, attestor sets registered,
   attestation submission rate.
@@ -13,6 +13,15 @@ on `ligate-node:9100/metrics`. Five rows, fifteen panels:
   the last hour, RPC p95 latency by endpoint.
 - **Process / observability** — process CPU (cores), RSS, open FDs,
   metrics-dropped rate (broadcast lag).
+- **Cluster topology** (chain#446 follow-up) — sequencer role per VM
+  (`unknown` / `replica` / `leader` value-mapped from
+  `ligate_sequencer_role`) and rate of role transitions
+  (`ligate_sequencer_role_transitions_total`). The role panel is the
+  primary visual for the paper-leader scenario from 2026-05-21:
+  exactly one `leader` should be lit at any time. Flat-zero
+  transitions = steady state; spikes during a planned failover drill
+  are expected; rapid flapping or two simultaneous leaders = page
+  on-call.
 
 Tracking issue: [#165](https://github.com/ligate-io/ligate-chain/issues/165).
 

--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {"type": "datasource", "uid": "grafana"},
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -46,445 +49,1272 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 100,
       "panels": [],
       "title": "Chain activity",
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Cumulative count of `register_schema` transactions accepted by the chain. Counter only; resets on node restart unless Prometheus retention covers the gap.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 1},
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "id": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": {"calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_schemas_registered_total{instance=~\"$instance\"}", "legendFormat": "schemas", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ligate_schemas_registered_total{instance=~\"$instance\"}",
+          "legendFormat": "schemas",
+          "refId": "A"
+        }
       ],
       "title": "Schemas registered",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Cumulative count of `register_attestor_set` transactions accepted by the chain.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 1},
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "reduceOptions": {"calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_attestor_sets_registered_total{instance=~\"$instance\"}", "legendFormat": "attestor sets", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ligate_attestor_sets_registered_total{instance=~\"$instance\"}",
+          "legendFormat": "attestor sets",
+          "refId": "A"
+        }
       ],
       "title": "Attestor sets registered",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Per-second rate of accepted `submit_attestation` transactions (5m window). Headline metric for chain throughput.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ops"
         }
       },
-      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 1},
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
       "id": 3,
       "options": {
-        "legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "rate(ligate_attestations_submitted_total{instance=~\"$instance\"}[5m])", "legendFormat": "attestations / sec", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(ligate_attestations_submitted_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "attestations / sec",
+          "refId": "A"
+        }
       ],
       "title": "Attestations submitted (rate)",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 6},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
       "id": 200,
       "panels": [],
       "title": "Node health",
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Current head slot number from `LedgerStateProvider`. Climbing = chain producing blocks. Flat for >60s = sequencer halted, DA submission failing, or follower disconnected.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 0, "y": 7},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
       "id": 4,
       "options": {
-        "legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_block_height{instance=~\"$instance\"}", "legendFormat": "block height", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ligate_block_height{instance=~\"$instance\"}",
+          "legendFormat": "block height",
+          "refId": "A"
+        }
       ],
       "title": "Block height",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Pending tx count in the sequencer mempool. Sustained growth means the chain isn't including txs as fast as they arrive (DA throughput, validator stalls, or a publish backlog).",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 100},
-              {"color": "red", "value": 1000}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 6, "y": 7},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 7
+      },
       "id": 9,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_mempool_depth{instance=~\"$instance\"}", "legendFormat": "pending txs", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ligate_mempool_depth{instance=~\"$instance\"}",
+          "legendFormat": "pending txs",
+          "refId": "A"
+        }
       ],
       "title": "Mempool depth",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Total on-disk allocation under `storage.path` (NOMT + RocksDB ledger + state-db). Reports actual on-disk allocation via `meta.blocks() * 512`, not nominal logical size.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 50000000000},
-              {"color": "red", "value": 100000000000}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50000000000
+              },
+              {
+                "color": "red",
+                "value": 100000000000
+              }
             ]
           },
           "unit": "bytes"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 12, "y": 7},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 7
+      },
       "id": 5,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "ligate_state_db_size_bytes{instance=~\"$instance\"}", "legendFormat": "state db", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ligate_state_db_size_bytes{instance=~\"$instance\"}",
+          "legendFormat": "state db",
+          "refId": "A"
+        }
       ],
       "title": "State DB size",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "RPC request rate by endpoint (5m window). Spikes mean an indexer is back-filling or a faucet is being hammered.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never", "stacking": {"mode": "normal"}},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "reqps"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 18, "y": 7},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
       "id": 6,
       "options": {
-        "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true},
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (endpoint) (rate(ligate_rpc_requests_total{instance=~\"$instance\"}[5m]))", "legendFormat": "{{endpoint}}", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (endpoint) (rate(ligate_rpc_requests_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
       ],
       "title": "RPC requests / sec (by endpoint)",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
       "id": 250,
       "panels": [],
       "title": "DA layer",
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Rate of DA submission failures by typed-error discriminant. Non-zero is operator-actionable. Reasons: `submission` (RPC error), `publish_timeout` (no inclusion within deadline), `reorg` (DA re-org), `finality_check` (finality query failed), `max_retries_exhausted` (rollup shutdown).",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 1, "showPoints": "never", "stacking": {"mode": "normal"}},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 0.001}]},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
           "unit": "ops"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
       "id": 10,
       "options": {
-        "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true},
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "sum by (reason) (rate(ligate_da_submission_failures_total{instance=~\"$instance\"}[5m]))", "legendFormat": "{{reason}}", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (reason) (rate(ligate_da_submission_failures_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
       ],
       "title": "DA submission failures (rate, by reason)",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "DA finalization latency: time from `Published` to `Finalized` for each blob. Mocha block time ~12s. Rising p99 means Celestia is slow to finalize, often a sign the network is congested or our light node is lagging.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 60},
-              {"color": "red", "value": 300}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
             ]
           },
           "unit": "s"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
       "id": 11,
       "options": {
-        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true},
-        "tooltip": {"mode": "multi"}
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.50, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))", "legendFormat": "p50", "refId": "A"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))", "legendFormat": "p95", "refId": "B"},
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))", "legendFormat": "p99", "refId": "C"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
       ],
       "title": "DA finalization latency (Published -> Finalized)",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
       "id": 300,
       "panels": [],
       "title": "Errors / rejections",
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Top rejection reasons over the last hour. Each `reason` is one of the stable snake_case discriminants on `AttestationError`.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "showPoints": "never", "stacking": {"mode": "normal"}},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
       "id": 7,
       "options": {
-        "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true},
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "topk(10, sum by (reason) (rate(ligate_attestations_rejected_total{instance=~\"$instance\"}[1h])))", "legendFormat": "{{reason}}", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, sum by (reason) (rate(ligate_attestations_rejected_total{instance=~\"$instance\"}[1h])))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
       ],
       "title": "Attestation rejections by reason (top 10, 1h)",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "p95 RPC latency by endpoint (5m window). Spikes to multi-second territory mean RocksDB iteration is slow or the chain is producing blocks faster than the indexer can keep up.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never"},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 0.5},
-              {"color": "red", "value": 2}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
             ]
           },
           "unit": "s"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
       "id": 8,
       "options": {
-        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true},
-        "tooltip": {"mode": "multi"}
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "histogram_quantile(0.95, sum by (le, endpoint) (rate(ligate_rpc_request_duration_seconds_bucket{instance=~\"$instance\"}[5m])))", "legendFormat": "{{endpoint}}", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, endpoint) (rate(ligate_rpc_request_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
       ],
       "title": "RPC latency p95 (by endpoint)",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
       "id": 400,
       "panels": [],
       "title": "Process / observability",
       "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "CPU usage as a fraction of one core (5m rate). Linux only — non-Linux builds skip the process_collector. >0.8 sustained is a sign we're CPU-bound.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "CPU usage as a fraction of one core (5m rate). Linux only \u2014 non-Linux builds skip the process_collector. >0.8 sustained is a sign we're CPU-bound.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 0.8},
-              {"color": "red", "value": 1.5}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
             ]
           },
           "unit": "percentunit"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 0, "y": 33},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 33
+      },
       "id": 12,
       "options": {
-        "legend": {"calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[5m])", "legendFormat": "cores", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "cores",
+          "refId": "A"
+        }
       ],
       "title": "Process CPU (cores)",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Resident set size (RSS) of the ligate-node process. Linux only.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 6, "y": 33},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 33
+      },
       "id": 13,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "process_resident_memory_bytes{instance=~\"$instance\"}", "legendFormat": "RSS", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
+          "legendFormat": "RSS",
+          "refId": "A"
+        }
       ],
       "title": "Process RSS",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Open file descriptors. Climbing without bound means a leak (most likely a tokio task that never drops a TCP socket). Linux only.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 1024},
-              {"color": "red", "value": 4096}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1024
+              },
+              {
+                "color": "red",
+                "value": 4096
+              }
             ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 12, "y": 33},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 33
+      },
       "id": 14,
       "options": {
-        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "process_open_fds{instance=~\"$instance\"}", "legendFormat": "open FDs", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "process_open_fds{instance=~\"$instance\"}",
+          "legendFormat": "open FDs",
+          "refId": "A"
+        }
       ],
       "title": "Process open FDs",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Rate of metric events dropped because a metric observer's broadcast receiver lagged. Non-zero rate means we need to widen the BlobSender broadcast channel (currently 1024) or speed up the consumer.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "custom": {"drawStyle": "line", "fillOpacity": 30, "lineWidth": 2, "showPoints": "never"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 0.001}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
           "unit": "ops"
         }
       },
-      "gridPos": {"h": 7, "w": 6, "x": 18, "y": 33},
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 33
+      },
       "id": 15,
       "options": {
-        "legend": {"calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true},
-        "tooltip": {"mode": "single"}
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
-        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "expr": "rate(ligate_metrics_dropped_total{instance=~\"$instance\"}[5m])", "legendFormat": "dropped/sec", "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(ligate_metrics_dropped_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "dropped/sec",
+          "refId": "A"
+        }
       ],
       "title": "Metrics dropped (broadcast lagged)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 500,
+      "panels": [],
+      "title": "Cluster topology",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Current sequencer role on each VM (`ligate_sequencer_role`). 0 = unknown (chain HTTP unreachable / still booting), 1 = PgSyncReplica (following leader via Postgres state-sync), 2 = BatchProducer (this node holds the leader lock and posts blobs to DA). Exactly one VM should show `BatchProducer` at any time; two simultaneously = split-brain (page on-call), zero = leaderless (page on-call after 30s).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "unknown",
+                  "color": "red"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "text": "replica",
+                  "color": "blue"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "2": {
+                  "text": "leader",
+                  "color": "green"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ligate_sequencer_role{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sequencer role per VM",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of sequencer-role transitions over 5-minute windows. Steady state should be flat at zero; a spike means a failover happened. Healthy failover drill: one `leader -> replica` and one `replica -> leader` within the same minute. Anything more chatty (rapid back-and-forth) is split-brain / flapping \u2014 page on-call.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (instance, from, to) (rate(ligate_sequencer_role_transitions_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{instance}}: {{from}} -> {{to}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sequencer role transitions (rate over 5m)",
       "type": "timeseries"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
-  "tags": ["ligate", "ligate-chain", "ligate-node"],
+  "tags": [
+    "ligate",
+    "ligate-chain",
+    "ligate-node"
+  ],
   "templating": {
     "list": [
       {
-        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -501,7 +1331,10 @@
         "name": "instance",
         "label": "Sequencer instance",
         "type": "query",
-        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
         "query": "label_values(ligate_block_height, instance)",
         "regex": "ligate-devnet-1-sequencer.*",
         "refresh": 2,
@@ -511,16 +1344,23 @@
         "allValue": ".+",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         }
       }
     ]
   },
-  "time": {"from": "now-6h", "to": "now"},
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
-  "title": "Ligate Chain — ligate-node",
+  "title": "Ligate Chain \u2014 ligate-node",
   "uid": "ligate-node",
   "version": 2,
   "weekStart": ""


### PR DESCRIPTION
## Why

The paper-leader incident from 2026-05-21 (chain#446) was diagnosed by reading systemd logs across all 3 VMs and grep'ing for "Skipping batch production". That's fine for a one-off, terrible for the next one. The cluster role state — who holds the lock, when did the last transition happen — needs to be a first-class metric so Grafana surfaces it and an alert rule can page on-call.

## What

Two new Prometheus metrics on every `ligate-node:9100/metrics`:

- `ligate_sequencer_role` (gauge): 0 = unknown (HTTP unreachable / still booting), 1 = PgSyncReplica, 2 = BatchProducer. Sampled every 2s from the local `/v1/sequencer/role` endpoint.
- `ligate_sequencer_role_transitions_total{from,to}` (counter): bumps on every observed role change. Labels are readable names (`unknown` / `replica` / `leader`) so a Grafana panel reads "VM-3: replica → leader at 22:51 UTC" without joins.

Plus the matching Grafana panels in `ops/grafana/ligate-node.json`:

- **Cluster topology** row at y=40
- **Sequencer role per VM** Stat panel with value mappings + colors (red unknown, blue replica, green leader)
- **Sequencer role transitions (rate over 5m)** Time series

## Implementation

- New section at the bottom of `crates/rollup/src/metrics.rs` (~150 lines): metric accessors, `init_sequencer_role`, `encode_role`, `sample_sequencer_role`, `spawn_sequencer_role_task` — same shape as the existing `state_db_size` / `block_height` patterns.
- New spawn call in `crates/rollup/src/main.rs` inside the `is_metrics_disabled` block, after the metrics server is bound. Hardcoded loopback URL (`http://127.0.0.1:12346/v1/sequencer/role`) — operators who change the SDK's bind would need to patch this, but nobody does.
- 5 unit tests covering `encode_role` shapes (leader, replica, empty, future variant, whitespace).
- Grafana dashboard JSON gets a new row + 2 panels appended (id 500/16/17). Re-import to pick them up, or `jq -r '.panels[] | select(.id >= 16 and .id <= 17 or .id == 500)' ops/grafana/ligate-node.json` to extract just the new ones.

## Operator action

After the binary swap, new metrics appear on next Prometheus scrape (no scrape-config change needed). Re-import the dashboard to pick up the Cluster topology row.

Suggested alert (not shipped here, file an issue if you want a default rule):

```
- alert: SequencerLeaderlessOrSplitBrain
  expr: count(ligate_sequencer_role == 2) != 1
  for: 60s
```

Zero leaders for 60s = leaderless (failover stuck). Two leaders = split-brain (Postgres lock semantic broken).

## Version

Bumps workspace to v0.2.10. `chain_hash` unchanged from v0.2.9 — safe binary swap.

## Net diff

7 files changed, +1214 / -154 (~1100 net additions, most of it the Grafana JSON which is bulky).