### PR TITLE
cloud-init: bump LIGATE_TAG + LIGATE_VERSION to v0.2.10 (and fix 0.2.5 mismatch)

### DIFF
--- a/ops/cloud-init/sequencer.yaml
+++ b/ops/cloud-init/sequencer.yaml
@@ -172,7 +172,7 @@ runcmd:
 
   # ---------------------------------------------------------------------
   # Multi-instance config (chain#422): read per-VM identity + role from
-  # GCP instance metadata, install the v0.2.4 ligate-node binary,
+  # GCP instance metadata, install the pinned ligate-node binary,
   # place devnet-1 config, write /etc/ligate/env, and start the
   # service. Per-instance metadata is set at create time:
   #
@@ -224,15 +224,15 @@ runcmd:
     chown root:ligate /etc/ligate/env
     echo "cloud-init: identity=$LIGATE_NODE_ID mode=$LIGATE_MODE celestia-jwt=${#CELESTIA_JWT}chars" >&2
 
-  # Install the v0.2.4 ligate-node binary from the published GitHub
-  # Release. Pinned tag for reproducibility — bumping requires
-  # editing this file and re-running cloud-init (or operator-side
-  # `systemctl stop && curl + tar && systemctl start` for in-place
-  # swaps, the same flow used during the v0.2.3 → v0.2.4 swap on
-  # 2026-05-20).
+  # Install the pinned ligate-node binary from the published GitHub
+  # Release. `LIGATE_TAG` must match `LIGATE_VERSION` (the artifact
+  # filename embeds the bare version, the URL path uses the v-prefixed
+  # tag). Bumping requires editing this file and re-running cloud-init
+  # (or operator-side `systemctl stop && curl + tar && systemctl start`
+  # for in-place swaps — the standard path for running VMs).
   - |
-    LIGATE_TAG=v0.2.7
-    LIGATE_VERSION=0.2.5
+    LIGATE_TAG=v0.2.10
+    LIGATE_VERSION=0.2.10
     ARTIFACT="ligate-node-${LIGATE_VERSION}-linux-amd64.tar.gz"
     # Keep the artifact's original filename so `sha256sum -c` can find
     # it via the relative path written into the .sha256 file by the


### PR DESCRIPTION
## Why

Two things in `ops/cloud-init/sequencer.yaml`:

1. Bump `LIGATE_TAG` from `v0.2.7` to `v0.2.10` so future cloud-init runs install the current released binary.
2. Fix a stale `LIGATE_VERSION=0.2.5` that didn't get bumped alongside `LIGATE_TAG=v0.2.7` in commit \`bef503c\`. The mismatch meant cloud-init was trying to download \`ligate-node-0.2.5-linux-amd64.tar.gz\` from the \`v0.2.7\` release, which 404s (the v0.2.7 release artifact is \`ligate-node-0.2.7-linux-amd64.tar.gz\`). Net effect: any fresh VM spun up since v0.2.7 would have had its binary install step fail. Running VMs are unaffected because we swap binaries by hand, not by re-running cloud-init.

## What

- `LIGATE_TAG=v0.2.7` → `v0.2.10`
- `LIGATE_VERSION=0.2.5` → `0.2.10`
- Comment updates: drop "v0.2.4" specific language (it's a moving pin, not a per-release script), add a one-line note that `LIGATE_TAG` and `LIGATE_VERSION` must match.

## Net diff

9 lines changed in one file.

## Followup

This same pin gets stale every release. Filing a separate issue to either auto-derive `LIGATE_VERSION` from `LIGATE_TAG` (strip the \`v\`) or fetch the latest release tag dynamically. For now, document the manual bump procedure in `docs/development/runbooks/release.md` (does that runbook exist? if not, file an issue to create one).