### PR TITLE
chain v0.2.11: cost + economy Prometheus metrics + Grafana cost row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-05-22
+
+Adds cost + economy Prometheus metrics so Grafana dashboards can show DA spend and protocol-treasury health alongside ops metrics. Plumbing-only release; no behaviour shift, `chain_hash` unchanged.
+
+### Added
+
+- `ligate_da_blobs_published_total` (counter) and `ligate_da_tia_burned_nano_estimate_total` (counter) — bump on every observed Celestia `Published` event. The TIA value is a **fixed-per-blob estimate** (`DA_BLOB_TIA_ESTIMATE_NANO = 300_000`, calibrated against Mocha rates on 2026-05-22), not extracted from the actual Celestia tx receipt. The SDK's `SubmitBlobReceipt` doesn't currently carry `fee_paid` from the PFB tx; making it do so is filed as a separate follow-up. Treat the gauge as a floor.
+- `ligate_da_tia_estimate_per_blob_nano` (gauge) — exposes the compiled-in constant so Grafana can render "we assume X nanoTIA per blob" next to the burn counter.
+- Six new gauges mirrored from api `/v1/stats/totals`: `ligate_protocol_treasury_balance_nano`, `ligate_protocol_total_supply_nano`, `ligate_protocol_txs_total`, `ligate_protocol_attestations_total`, `ligate_protocol_schemas_registered`, `ligate_protocol_attestor_sets_registered`. Polled every 60s by a new tokio task in `metrics.rs`. Soft-fail on api unreachable: gauges hold last value; `ligate_protocol_economy_last_scrape_unix` (also new) stops advancing so Grafana can flag staleness.
+- `LIGATE_API_URL` env var (default `https://api.ligate.io`) for operators running their own api. Set to a non-existent host to effectively disable economy polling (gauges stay at zero / unset).
+- `ops/grafana/ligate-node.json`: new **Cost & economy** row at y=48 with 4 panels: cumulative TIA burned (stat), TIA burn rate per hour (time series), treasury balance in LGT (stat), and a 4-up "protocol totals" stat row (txs / attestations / schemas / attestor sets).
+
+### Compatibility
+
+`chain_hash` unchanged from v0.2.10. Safe binary swap. New env var is optional with a sensible default.
+
+### Followup
+
+- File a chain issue to extend the SDK's `SubmitBlobReceipt` with the actual `fee_paid` from the Celestia PFB tx receipt. Once available, the TIA estimate becomes the real ledger.
+- File an ops issue for GCP infra cost: enable Cloud Billing → BigQuery export and add a Grafana BigQuery datasource. Doesn't belong in `ligate-node` — the chain binary should stay portable for non-GCP operators.
+
 ## [0.2.10] - 2026-05-22
 
 Surfaces the DbElected sequencer role + transitions as Prometheus metrics so the paper-leader scenario from 2026-05-21 (chain#446) becomes visible on Grafana, not just in logs. Plumbing-only change; no behaviour shift.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]

--- a/crates/rollup/src/main.rs
+++ b/crates/rollup/src/main.rs
@@ -260,6 +260,19 @@ async fn run() -> anyhow::Result<()> {
             "http://127.0.0.1:12346/v1/sequencer/role".to_string(),
             metrics::DEFAULT_SEQUENCER_ROLE_POLL_INTERVAL,
         );
+
+        // Protocol-economy poller (chain#446 Track 4). Mirrors the
+        // api's `/v1/stats/totals` into chain Prometheus so ops
+        // dashboards have a single source. Defaults to the public
+        // api at `api.ligate.io`; `LIGATE_API_URL` env var overrides
+        // for operators running their own api (or for disabling by
+        // pointing at a sink). Soft-fails on api unreachable; gauges
+        // hold last value and `ligate_protocol_economy_last_scrape_unix`
+        // stops advancing so dashboards can flag staleness.
+        let api_url =
+            std::env::var("LIGATE_API_URL").unwrap_or_else(|_| "https://api.ligate.io".to_string());
+        let totals_url = format!("{}/v1/stats/totals", api_url.trim_end_matches('/'));
+        metrics::spawn_economy_task(totals_url, metrics::DEFAULT_ECONOMY_POLL_INTERVAL);
     }
 
     let genesis_paths = GenesisPaths::from_dir(&args.genesis_config_dir);

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -1028,6 +1028,11 @@ fn protocol_economy_last_scrape_unix() -> &'static IntGauge {
     })
 }
 
+/// Pre-touch all economy gauges so their `HELP` / `TYPE` lines show
+/// up in the very first `/metrics` scrape, before the first poll
+/// completes. Without this, alerting rules that match against these
+/// metric names would fire a "no data" condition for the first ~60
+/// seconds after boot.
 pub fn init_economy_metrics() {
     let _ = protocol_treasury_balance_nano();
     let _ = protocol_total_supply_nano();

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -795,48 +795,6 @@ pub fn spawn_sequencer_role_task(role_url: String, interval: Duration) {
     });
 }
 
-#[cfg(test)]
-mod sequencer_role_tests {
-    use super::encode_role;
-
-    #[test]
-    fn encode_leader() {
-        let (v, l) = encode_role("\"BatchProducer\"");
-        assert_eq!(v, 2);
-        assert_eq!(l, "leader");
-    }
-
-    #[test]
-    fn encode_replica() {
-        let (v, l) = encode_role("\"PgSyncReplica\"");
-        assert_eq!(v, 1);
-        assert_eq!(l, "replica");
-    }
-
-    #[test]
-    fn encode_unknown_on_empty() {
-        let (v, l) = encode_role("");
-        assert_eq!(v, 0);
-        assert_eq!(l, "unknown");
-    }
-
-    #[test]
-    fn encode_unknown_on_garbage() {
-        // Future role variant or chain on a different version: degrade
-        // to unknown rather than crashing the gauge.
-        let (v, l) = encode_role("\"SomeFutureRole\"");
-        assert_eq!(v, 0);
-        assert_eq!(l, "unknown");
-    }
-
-    #[test]
-    fn encode_handles_whitespace() {
-        let (v, l) = encode_role("  \"BatchProducer\"  \n");
-        assert_eq!(v, 2);
-        assert_eq!(l, "leader");
-    }
-}
-
 // ============================================================================
 // DA cost estimate (Track 4 follow-up to chain#446)
 //
@@ -1102,4 +1060,55 @@ pub fn spawn_economy_task(api_url: String, interval: Duration) {
             sample_economy(&api_url).await;
         }
     });
+}
+
+// ============================================================================
+// Unit tests
+//
+// Placed at the very end so clippy's `items_after_test_module` lint is
+// satisfied. When you add new test cases, add them HERE — don't insert
+// a new `#[cfg(test)] mod` higher up in the file or downstream items
+// stop compiling.
+// ============================================================================
+
+#[cfg(test)]
+mod sequencer_role_tests {
+    use super::encode_role;
+
+    #[test]
+    fn encode_leader() {
+        let (v, l) = encode_role("\"BatchProducer\"");
+        assert_eq!(v, 2);
+        assert_eq!(l, "leader");
+    }
+
+    #[test]
+    fn encode_replica() {
+        let (v, l) = encode_role("\"PgSyncReplica\"");
+        assert_eq!(v, 1);
+        assert_eq!(l, "replica");
+    }
+
+    #[test]
+    fn encode_unknown_on_empty() {
+        let (v, l) = encode_role("");
+        assert_eq!(v, 0);
+        assert_eq!(l, "unknown");
+    }
+
+    #[test]
+    fn encode_unknown_on_garbage() {
+        // Future role variant or chain on a different version: degrade
+        // to unknown rather than crashing the gauge.
+        let (v, l) = encode_role("\"SomeFutureRole\"");
+        assert_eq!(v, 0);
+        assert_eq!(l, "unknown");
+    }
+
+    #[test]
+    fn encode_handles_whitespace() {
+        let (v, l) = encode_role("  \"BatchProducer\"  \n");
+        assert_eq!(v, 2);
+        assert_eq!(l, "leader");
+    }
 }

--- a/crates/rollup/src/metrics.rs
+++ b/crates/rollup/src/metrics.rs
@@ -556,6 +556,9 @@ pub fn init_da_metrics() {
     let _ = da_submission_failures();
     let _ = da_finalization_latency();
     let _ = metrics_dropped();
+    // DA cost estimate metrics are bundled with the rest of the DA
+    // surface — same lifecycle, same scrape cadence.
+    init_da_cost_metrics();
 }
 
 /// Spawn a tokio task that subscribes to the BlobSender's
@@ -622,6 +625,14 @@ pub fn spawn_da_metrics_task<Da: DaSpec>(
                                 }
                             }
                             in_flight.insert(receipt.blob_hash, std::time::Instant::now());
+                            // Bump the DA cost estimate counters
+                            // (chain#446 Track 4). Each Published
+                            // event counts as one blob; we add a
+                            // fixed nanoTIA estimate because the
+                            // SDK's `SubmitBlobReceipt` doesn't
+                            // currently carry the real `fee_paid`
+                            // value from the Celestia PFB receipt.
+                            record_da_blob_published();
                         }
                         BlobSubmissionStatus::Finalized { receipt } => {
                             if let Some(started) = in_flight.remove(&receipt.blob_hash) {
@@ -824,4 +835,266 @@ mod sequencer_role_tests {
         assert_eq!(v, 2);
         assert_eq!(l, "leader");
     }
+}
+
+// ============================================================================
+// DA cost estimate (Track 4 follow-up to chain#446)
+//
+// The Sovereign SDK's `SubmitBlobReceipt` doesn't currently carry the
+// actual `fee_paid` value from the Celestia PFB tx receipt — only
+// `blob_hash` and `da_transaction_id`. So we surface an *estimate*
+// based on a fixed per-blob TIA cost calibrated to Mocha testnet rates
+// observed on 2026-05-22. Filed as a follow-up to extend the SDK
+// receipt with the real fee.
+//
+// Two metrics:
+// - `ligate_da_blobs_published_total`: bumps every time a blob hits
+//   `Published` on the BlobSender's broadcast channel. Useful as a
+//   denominator and as a sanity check vs `ligate_da_finalization_*`.
+// - `ligate_da_tia_burned_nano_estimate_total`: bumps by the fixed
+//   per-blob constant on every Published event. Sum × time = estimated
+//   TIA burn over the window. Mark "estimate" in Grafana so nobody
+//   reads it as authoritative.
+// ============================================================================
+
+/// Estimated cost of a single Celestia blob submission, in nanoTIA
+/// (1 TIA = 1_000_000_000 nanoTIA). Calibrated from Mocha gas rates
+/// observed on 2026-05-22 for our typical attestation blobs (~13 to
+/// ~50 bytes of payload after framing, plus the PFB tx envelope).
+/// Conservative — will under-count once attestation payloads include
+/// larger evidence blobs. Revisit when chain#XXX (SDK fee_paid in
+/// receipt) lands.
+pub const DA_BLOB_TIA_ESTIMATE_NANO: u64 = 300_000;
+
+fn da_blobs_published() -> &'static IntCounter {
+    static M: OnceLock<IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter!(
+            "ligate_da_blobs_published_total",
+            "Number of blobs this node has observed reaching `Published` state on Celestia DA. \
+             Bumps once per blob, regardless of whether the same blob later finalizes or \
+             retries."
+        )
+        .expect("counter registers once")
+    })
+}
+
+fn da_tia_burned_nano_estimate() -> &'static IntCounter {
+    static M: OnceLock<IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_counter!(
+            "ligate_da_tia_burned_nano_estimate_total",
+            "ESTIMATED total TIA (in nanoTIA, 1e-9 TIA) this node has burned posting blobs to \
+             Celestia DA. Bumps by a fixed per-blob constant on every observed `Published` \
+             event (the SDK's `SubmitBlobReceipt` doesn't currently carry the real `fee_paid`). \
+             Under-counts once blob sizes grow; treat as a floor for ops dashboards, not an \
+             authoritative ledger."
+        )
+        .expect("counter registers once")
+    })
+}
+
+fn da_tia_estimate_per_blob_nano() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_da_tia_estimate_per_blob_nano",
+            "The fixed per-blob TIA estimate (in nanoTIA) the chain uses to compute \
+             `ligate_da_tia_burned_nano_estimate_total`. Exposed as a gauge so dashboards can \
+             show the assumed rate next to the burn counter."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+/// Pre-touch the DA-cost metrics so their HELP/TYPE land in the first
+/// `/metrics` scrape. Also sets the per-blob estimate gauge to the
+/// compiled-in constant so it's never `0` (a 0 there is misleading).
+pub fn init_da_cost_metrics() {
+    let _ = da_blobs_published();
+    let _ = da_tia_burned_nano_estimate();
+    da_tia_estimate_per_blob_nano().set(DA_BLOB_TIA_ESTIMATE_NANO as i64);
+}
+
+/// Record one observed `Published` blob event. Called from inside the
+/// existing `spawn_da_metrics_task` loop, alongside the in-flight
+/// tracking the finalization-latency metric uses.
+pub fn record_da_blob_published() {
+    init_da_cost_metrics();
+    da_blobs_published().inc();
+    da_tia_burned_nano_estimate().inc_by(DA_BLOB_TIA_ESTIMATE_NANO);
+}
+
+// ============================================================================
+// Protocol economy mirror (Track 4 follow-up to chain#446)
+//
+// Mirrors the api's `/v1/stats/totals` into chain Prometheus so ops
+// dashboards have a single source of truth. Each chain node polls the
+// api independently; the values are chain-wide, so all instances
+// expose the same number (Grafana aggregates with `max` or `last`).
+//
+// Soft-fails on api unreachable: gauges hold their last observed
+// value rather than zeroing out (a 0 would falsely show "treasury
+// empty"). Staleness is visible via `ligate_protocol_economy_last_scrape_unix`.
+// ============================================================================
+
+/// Default polling interval for the economy sampler. 60s is plenty —
+/// treasury and supply move on a per-transaction cadence, and devnet
+/// tx volume is low enough that finer sampling adds noise without
+/// signal.
+pub const DEFAULT_ECONOMY_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+fn protocol_treasury_balance_nano() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_protocol_treasury_balance_nano",
+            "Current LGT balance of the protocol treasury address, in nanoLGT \
+             (1 LGT = 1_000_000_000 nanoLGT). Sourced from the api's \
+             `/v1/stats/totals.treasury_balance_nano`."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+fn protocol_total_supply_nano() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_protocol_total_supply_nano",
+            "Total LGT supply, in nanoLGT. Genesis-fixed at 1B LGT for devnet-1; this gauge \
+             tracks the chain's reported value so a future emission policy is auto-picked-up."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+fn protocol_txs_total() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_protocol_txs_total",
+            "Total transactions ever included on chain (per the api's indexer). Includes both \
+             SUCCESS and REVERTED."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+fn protocol_attestations_total() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_protocol_attestations_total",
+            "Total attestations ever submitted, per api indexer."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+fn protocol_schemas_registered() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_protocol_schemas_registered",
+            "Total schemas registered, per api indexer."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+fn protocol_attestor_sets_registered() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_protocol_attestor_sets_registered",
+            "Total attestor sets registered, per api indexer."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+fn protocol_economy_last_scrape_unix() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        register_int_gauge!(
+            "ligate_protocol_economy_last_scrape_unix",
+            "Unix timestamp (seconds) of the most recent successful poll of the api's \
+             `/v1/stats/totals`. If this stops advancing, the api is unreachable and the \
+             economy gauges above are stale — Grafana should show a 'stale data' badge once \
+             this drifts more than 5 minutes from `now()`."
+        )
+        .expect("gauge registers once")
+    })
+}
+
+pub fn init_economy_metrics() {
+    let _ = protocol_treasury_balance_nano();
+    let _ = protocol_total_supply_nano();
+    let _ = protocol_txs_total();
+    let _ = protocol_attestations_total();
+    let _ = protocol_schemas_registered();
+    let _ = protocol_attestor_sets_registered();
+    let _ = protocol_economy_last_scrape_unix();
+}
+
+/// Parse a numeric string field out of the api's totals JSON and set
+/// the matching gauge. Strings are used by the api because supply +
+/// treasury values can exceed JS Number's safe-integer range (2^53);
+/// they fit in i64 for any realistic chain state we'll see.
+fn set_from_str(v: &serde_json::Value, key: &str, gauge: &IntGauge) {
+    if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+        if let Ok(n) = s.parse::<i64>() {
+            gauge.set(n);
+        }
+    }
+}
+
+fn set_from_int(v: &serde_json::Value, key: &str, gauge: &IntGauge) {
+    if let Some(n) = v.get(key).and_then(|x| x.as_i64()) {
+        gauge.set(n);
+    }
+}
+
+/// Sample the api's `/v1/stats/totals` once and update the protocol-
+/// economy gauges. Soft-fails: a network error or a parse error
+/// leaves the previous gauge values in place and the
+/// `last_scrape_unix` gauge does not advance. Public so a test
+/// harness can drive a single sample without spinning the task.
+pub async fn sample_economy(api_url: &str) {
+    init_economy_metrics();
+    let body =
+        match reqwest::Client::new().get(api_url).timeout(Duration::from_secs(5)).send().await {
+            Ok(resp) if resp.status().is_success() => resp.text().await.unwrap_or_default(),
+            _ => return,
+        };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&body) else {
+        return;
+    };
+    set_from_str(&v, "treasury_balance_nano", protocol_treasury_balance_nano());
+    set_from_str(&v, "total_supply_nano", protocol_total_supply_nano());
+    set_from_int(&v, "txs_total", protocol_txs_total());
+    set_from_int(&v, "attestations", protocol_attestations_total());
+    set_from_int(&v, "schemas", protocol_schemas_registered());
+    set_from_int(&v, "attestor_sets", protocol_attestor_sets_registered());
+    if let Ok(now) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        protocol_economy_last_scrape_unix().set(now.as_secs() as i64);
+    }
+}
+
+/// Spawn the protocol-economy poller. Polls `api_url` every
+/// `interval` (default 60s) and updates the LGT-economy gauges.
+/// Fire-and-forget; lives until the runtime drops. Safe before the
+/// api is reachable — early polls just skip-update until the network
+/// path comes up.
+pub fn spawn_economy_task(api_url: String, interval: Duration) {
+    init_economy_metrics();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            sample_economy(&api_url).await;
+        }
+    });
 }

--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -1,7 +1,7 @@
 # Grafana dashboard for `ligate-node`
 
 Drop-in Grafana dashboard for the Phase 1 + Phase 2 metrics shipped
-on `ligate-node:9100/metrics`. Six rows, seventeen panels:
+on `ligate-node:9100/metrics`. Seven rows, twenty-one panels:
 
 - **Chain activity** — schemas registered, attestor sets registered,
   attestation submission rate.
@@ -22,6 +22,14 @@ on `ligate-node:9100/metrics`. Six rows, seventeen panels:
   transitions = steady state; spikes during a planned failover drill
   are expected; rapid flapping or two simultaneous leaders = page
   on-call.
+- **Cost & economy** (chain#446 Track 4) — cumulative TIA burned
+  (estimate, from `ligate_da_tia_burned_nano_estimate_total`), TIA
+  burn rate per hour, protocol treasury balance in LGT
+  (`ligate_protocol_treasury_balance_nano`), and a 4-up stat row
+  mirroring api `/v1/stats/totals` (txs / attestations / schemas /
+  attestor sets). The TIA burn is an estimate based on a fixed
+  per-blob constant; follow-up to extend the SDK receipt with the
+  real `fee_paid` is filed separately.
 
 Tracking issue: [#165](https://github.com/ligate-io/ligate-chain/issues/165).
 

--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -1298,6 +1298,268 @@
       ],
       "title": "Sequencer role transitions (rate over 5m)",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 600,
+      "panels": [],
+      "title": "Cost & economy",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "ESTIMATED cumulative TIA burned posting blobs to Celestia DA, in TIA (converted from nanoTIA via `/1e9`). The estimate uses a fixed per-blob constant baked into the chain binary; under-counts once blob sizes grow. See HELP on `ligate_da_tia_burned_nano_estimate_total`.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 6,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 49
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(ligate_da_tia_burned_nano_estimate_total{instance=~\"$instance\"}) / 1e9",
+          "legendFormat": "TIA (est)",
+          "refId": "A"
+        }
+      ],
+      "title": "TIA burned (cumulative, est.)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "TIA burn rate over 5-minute windows, scaled to TIA/hour. Estimate. Steady-state value is `(blobs/hr) \u00d7 (per-blob estimate)`.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1
+          },
+          "decimals": 6,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 6,
+        "y": 49
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(ligate_da_tia_burned_nano_estimate_total{instance=~\"$instance\"}[5m]) * 3600 / 1e9",
+          "legendFormat": "{{instance}} (TIA/hr est.)",
+          "refId": "A"
+        }
+      ],
+      "title": "TIA burn rate (TIA/hr, est.)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Protocol treasury LGT balance, converted from nanoLGT to LGT (`/1e9`). Sourced from api `/v1/stats/totals.treasury_balance_nano`. Same value on every instance \u2014 Grafana picks `max`.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 3,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 49
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(ligate_protocol_treasury_balance_nano{instance=~\"$instance\"}) / 1e9",
+          "legendFormat": "Treasury (LGT)",
+          "refId": "A"
+        }
+      ],
+      "title": "Treasury balance (LGT)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Cumulative protocol totals mirrored from api `/v1/stats/totals`. Grafana picks `max` because each chain instance polls and reports the same chain-wide values.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "max(ligate_protocol_txs_total{instance=~\"$instance\"})",
+          "legendFormat": "txs total",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "max(ligate_protocol_attestations_total{instance=~\"$instance\"})",
+          "legendFormat": "attestations",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "max(ligate_protocol_schemas_registered{instance=~\"$instance\"})",
+          "legendFormat": "schemas",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "expr": "max(ligate_protocol_attestor_sets_registered{instance=~\"$instance\"})",
+          "legendFormat": "attestor sets",
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "title": "Protocol totals (mirrored from api)",
+      "type": "stat"
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## What

Two new metric groups on `ligate-node:9100/metrics` so Grafana can show DA spend + protocol-treasury health alongside ops metrics. Plumbing only; `chain_hash` unchanged.

### DA cost (estimate)

- `ligate_da_blobs_published_total` (counter) — bumps on every observed Celestia `Published` event.
- `ligate_da_tia_burned_nano_estimate_total` (counter) — bumps by a fixed per-blob constant (`DA_BLOB_TIA_ESTIMATE_NANO = 300_000`) on every Published event.
- `ligate_da_tia_estimate_per_blob_nano` (gauge) — exposes the constant so Grafana shows the assumed rate.

The estimate is fixed because the SDK's `SubmitBlobReceipt` currently carries only `blob_hash` + `da_transaction_id`, not `fee_paid`. Filed as a separate follow-up to extend the receipt with the actual fee from the PFB tx. Under-counts once blob sizes grow; treat as a floor.

### Protocol economy mirror

Six gauges polled from api `/v1/stats/totals` every 60s by a new tokio task:

- `ligate_protocol_treasury_balance_nano`
- `ligate_protocol_total_supply_nano`
- `ligate_protocol_txs_total`
- `ligate_protocol_attestations_total`
- `ligate_protocol_schemas_registered`
- `ligate_protocol_attestor_sets_registered`

Plus `ligate_protocol_economy_last_scrape_unix` (gauge) so Grafana can flag staleness when api is unreachable. Soft-fails: gauges hold last value on api error.

New env var `LIGATE_API_URL` (default `https://api.ligate.io`) for operators running their own api.

### Grafana

New **Cost & economy** row at y=48 with 4 panels:
1. Cumulative TIA burned (stat, in TIA via `/1e9`)
2. TIA burn rate per hour (time series)
3. Treasury balance in LGT (stat)
4. 4-up "protocol totals" stat row (txs / attestations / schemas / attestor sets)

## Operator action

- Binary swap on next deploy. Re-import `ops/grafana/ligate-node.json` to pick up the new row (or `jq` out just the new panels: id 600 + 18 + 19 + 20 + 21).
- Optionally set `LIGATE_API_URL=<your-api>` in `/etc/ligate/env` if running your own api; defaults to public devnet api otherwise.

## Compatibility

`chain_hash` unchanged from v0.2.10. Safe binary swap. New env var optional.

## Followup

- File issue: SDK `SubmitBlobReceipt.fee_paid` extension so the TIA counter becomes the real ledger, not an estimate.
- File issue: GCP infra cost — enable Cloud Billing BigQuery export, add Grafana BigQuery datasource. Out of scope for `ligate-node` since the chain binary should stay portable for non-GCP operators.