### PR TITLE
grafana: GCP daily burn + VM capacity row + Activity leaders row (10 new panels)

### DIFF
--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -1,7 +1,7 @@
 # Grafana dashboard for `ligate-node`
 
 Drop-in Grafana dashboard for the Phase 1 + Phase 2 metrics shipped
-on `ligate-node:9100/metrics`. Seven rows, twenty-one panels:
+on `ligate-node:9100/metrics`. Nine rows, thirty-eight panels:
 
 - **Chain activity** — schemas registered, attestor sets registered,
   attestation submission rate.
@@ -25,13 +25,38 @@ on `ligate-node:9100/metrics`. Seven rows, twenty-one panels:
 - **Cost & economy** (chain#446 Track 4) — cumulative TIA burned
   (estimate, from `ligate_da_tia_burned_nano_estimate_total`), TIA
   burn rate per hour, protocol treasury balance in LGT
-  (`ligate_protocol_treasury_balance_nano`), and a 4-up stat row
+  (`ligate_protocol_treasury_balance_nano`), a 4-up stat row
   mirroring api `/v1/stats/totals` (txs / attestations / schemas /
-  attestor sets). The TIA burn is an estimate based on a fixed
-  per-blob constant; follow-up to extend the SDK receipt with the
-  real `fee_paid` is filed separately.
+  attestor sets), and **GCP daily burn (USD)** sourced from the
+  VM-1 BigQuery sidecar at `https://rpc.ligate.io/cost/daily.json`
+  (see `docs/development/runbooks/gcp-billing-export.md`). The TIA
+  burn is an estimate based on a fixed per-blob constant;
+  follow-up chain#452 covers the SDK receipt extension to make it
+  authoritative.
+- **VM capacity headroom** (chain#449 follow-up) — four threshold
+  stat panels colored green / amber / red so you know when to
+  upsize *before* a saturation incident:
+  - **CPU usage (cores)** sized for e2-standard-2 (2 vCPU). Red
+    >1.5 cores sustained = bump to e2-standard-4.
+  - **Memory (RSS)** sized for 8 GB. Red >4 GB = bump VM tier.
+  - **State DB size** sized for the default 100 GB SSD. Red >70 GB
+    = resize SSD online (non-disruptive grow).
+  - **Open FDs** as a canary for descriptor leaks (ulimit 65536).
+- **Activity leaders** (api#67) — three table panels backed by the
+  api's leaderboard endpoints via the Infinity HTTP-JSON
+  datasource: top attesters (`/v1/stats/top-attesters`), top schema
+  owners (`/v1/stats/top-schema-owners`), top attestor sets
+  (`/v1/stats/top-attestor-sets`). Same shape across all three
+  (`rank` / `address` / `count`), 10 rows each, 30s cache on the
+  api side. The "who's using the chain most" view.
 
 Tracking issue: [#165](https://github.com/ligate-io/ligate-chain/issues/165).
+
+The Infinity datasource (used by GCP daily burn + the three
+leaderboards) is preinstalled in Grafana Cloud. Self-hosted Grafana
+needs `grafana-infinity-datasource` from the plugins catalog. No
+auth — both target hosts (`api.ligate.io` + `rpc.ligate.io`) are
+public.
 
 ## Import
 

--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -1560,6 +1560,683 @@
       ],
       "title": "Protocol totals (mirrored from api)",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_INFINITY}"
+      },
+      "description": "Total daily GCP infrastructure spend, USD. Sourced from Cloud Billing \u2192 BigQuery export \u2192 /opt/ligate/bin/gcp-cost-fetch.sh on VM-1 (refreshed every 6h via systemd timer) \u2192 https://rpc.ligate.io/cost/daily.json. Returns [] until ~24h after Console enable, then populates rolling 30-day window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_INFINITY}"
+          },
+          "type": "json",
+          "source": "url",
+          "url": "https://rpc.ligate.io/cost/daily.json",
+          "url_options": {
+            "method": "GET"
+          },
+          "format": "timeseries",
+          "root_selector": "",
+          "columns": [
+            {
+              "selector": "day",
+              "text": "day",
+              "type": "timestamp"
+            },
+            {
+              "selector": "cost_usd",
+              "text": "USD",
+              "type": "number"
+            }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "GCP daily burn (USD, last 30d)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 700,
+      "panels": [],
+      "title": "VM capacity headroom (when do we need a bigger plan?)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Sustained CPU usage in cores. Thresholds sized for the current e2-standard-2 (2 vCPU). Green = comfortable. Amber = warming up (>40% of 2 cores). Red = saturating (>75%), bump to e2-standard-4 or e2-standard-8. Calculated over a 5-minute window so spikes don't trigger false alarms.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          },
+          "decimals": 2,
+          "unit": "short",
+          "max": 2
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 67
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[5m])",
+          "legendFormat": "{{instance}} cores",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU usage (cores / 2)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "ligate-node process resident memory (RSS). Thresholds sized for the current e2-standard-2 (8 GB total). Green <2 GB = comfortable. Amber 2-4 GB = OS + Caddy + chain crowding the box, plan a bump. Red >4 GB = swap risk on this machine type, bump to e2-standard-4 (16 GB) within a day.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2147483648
+              },
+              {
+                "color": "red",
+                "value": 4294967296
+              }
+            ]
+          },
+          "unit": "bytes",
+          "decimals": 1
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 67
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory used (RSS / 8 GB)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rollup state DB on-disk size (RocksDB + ledger). Thresholds sized for the default 100 GB SSD. Green <30 GB = years of runway at devnet growth. Amber 30-70 GB = plan a 200 GB resize for next quarter. Red >70 GB = resize within the week or risk filling the disk during a compaction spike. SSD resizes are non-disruptive (growable online).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 32212254720
+              },
+              {
+                "color": "red",
+                "value": 75161927680
+              }
+            ]
+          },
+          "unit": "bytes",
+          "decimals": 1
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 67
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ligate_state_db_size_bytes{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "State DB size (/ 100 GB SSD)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Open file descriptors on the chain process. Default ulimit is 65536. Green <2k = normal RocksDB SST + jsonrpsee connection mix. Amber 2-10k = unusual but not breaking. Red >10k = file-descriptor leak; investigate (the chain process or Caddy is holding refs it shouldn't). Not a VM-sizing signal, but a canary for the cluster needing a restart cycle before it hits the ulimit cliff.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2000
+              },
+              {
+                "color": "red",
+                "value": 10000
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 67
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "process_open_fds{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Open FDs (canary, ulimit 65536)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 800,
+      "panels": [],
+      "title": "Activity leaders (who's using the chain most)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_INFINITY}"
+      },
+      "description": "Addresses ranked by total attestations submitted (api: GET /v1/stats/top-attesters). All-time count.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "address"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rank"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 64
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 75
+      },
+      "id": 27,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        },
+        "cellHeight": "sm"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_INFINITY}"
+          },
+          "type": "json",
+          "source": "url",
+          "url": "https://api.ligate.io/v1/stats/top-attesters?n=10",
+          "url_options": {
+            "method": "GET"
+          },
+          "format": "table",
+          "root_selector": "rows",
+          "columns": [
+            {
+              "selector": "rank",
+              "text": "rank",
+              "type": "number"
+            },
+            {
+              "selector": "address",
+              "text": "address",
+              "type": "string"
+            },
+            {
+              "selector": "count",
+              "text": "attestations",
+              "type": "number"
+            }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "Top attesters",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_INFINITY}"
+      },
+      "description": "Addresses ranked by schemas registered (api: GET /v1/stats/top-schema-owners). All-time count.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "address"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rank"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 64
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 75
+      },
+      "id": 28,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        },
+        "cellHeight": "sm"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_INFINITY}"
+          },
+          "type": "json",
+          "source": "url",
+          "url": "https://api.ligate.io/v1/stats/top-schema-owners?n=10",
+          "url_options": {
+            "method": "GET"
+          },
+          "format": "table",
+          "root_selector": "rows",
+          "columns": [
+            {
+              "selector": "rank",
+              "text": "rank",
+              "type": "number"
+            },
+            {
+              "selector": "address",
+              "text": "address",
+              "type": "string"
+            },
+            {
+              "selector": "count",
+              "text": "schemas",
+              "type": "number"
+            }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "Top schema owners",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_INFINITY}"
+      },
+      "description": "Attestor sets (las1...) ranked by `schema_count` (denormalised on chain, single index scan in the api). The most popular sets are the most-bound-to.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "address"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 380
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rank"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 64
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 75
+      },
+      "id": 29,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        },
+        "cellHeight": "sm"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_INFINITY}"
+          },
+          "type": "json",
+          "source": "url",
+          "url": "https://api.ligate.io/v1/stats/top-attestor-sets?n=10",
+          "url_options": {
+            "method": "GET"
+          },
+          "format": "table",
+          "root_selector": "rows",
+          "columns": [
+            {
+              "selector": "rank",
+              "text": "rank",
+              "type": "number"
+            },
+            {
+              "selector": "address",
+              "text": "address",
+              "type": "string"
+            },
+            {
+              "selector": "count",
+              "text": "schemas",
+              "type": "number"
+            }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "Top attestor sets (by bound schemas)",
+      "type": "table"
     }
   ],
   "refresh": "30s",
@@ -1625,5 +2302,15 @@
   "title": "Ligate Chain \u2014 ligate-node",
   "uid": "ligate-node",
   "version": 2,
-  "weekStart": ""
+  "weekStart": "",
+  "__inputs": [
+    {
+      "name": "DS_INFINITY",
+      "label": "Infinity",
+      "description": "HTTP-JSON datasource for api leaderboards + GCP daily burn (chain#453 + #454).",
+      "type": "datasource",
+      "pluginId": "yesoreyeram-infinity-datasource",
+      "pluginName": "Infinity"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Adds three new things to `ops/grafana/ligate-node.json`, no chain code change:

### 1. GCP daily burn (USD) — appended to existing "Cost & economy" row

Time series panel reading from the new VM-1 BigQuery sidecar at `https://rpc.ligate.io/cost/daily.json` via the Infinity HTTP-JSON datasource. Empty until BigQuery's first export row lands (~24h after enable), then rolls a 30-day window. Companion to chain#453 / PR #458.

### 2. "VM capacity headroom" row — new, four threshold panels

Tells you when to upsize VM-1 **before** saturating, not after:

- **CPU (cores)** — `rate(process_cpu_seconds_total[5m])`. Green <0.8, amber 0.8-1.5, red >1.5 cores sustained = e2-standard-2 saturating, bump to e2-standard-4.
- **Memory RSS** — `process_resident_memory_bytes`. Green <2 GB, amber 2-4 GB, red >4 GB = bump VM tier (8 GB box is at risk of swap).
- **State DB size** — `ligate_state_db_size_bytes`. Green <30 GB, amber 30-70 GB, red >70 GB = resize SSD online (non-disruptive grow on GCE).
- **Open FDs** — `process_open_fds`. Canary for descriptor leaks. Default ulimit 65536, amber >2k, red >10k = investigate leak before hitting the cliff.

All thresholds tied to the **current VM tier (e2-standard-2 / 8 GB / 100 GB SSD)** so the colors are meaningful for the actual setup, not generic. If we upsize, the panel descriptions get updated.

### 3. "Activity leaders" row — new, three table panels

Backed by the api leaderboard endpoints shipped in api#67 via Infinity HTTP-JSON:

- **Top attesters** — `api.ligate.io/v1/stats/top-attesters` (addresses by attestations submitted)
- **Top schema owners** — `api.ligate.io/v1/stats/top-schema-owners` (addresses by schemas registered)
- **Top attestor sets** — `api.ligate.io/v1/stats/top-attestor-sets` (sets by `schema_count`)

Same `{rank, address, count}` shape across all three, 10 rows each. Closes chain#454 (no Infinity datasource concern — Grafana Cloud has it preinstalled, no auth needed since both api + cost endpoints are public).

## Dashboard layout

| Row y | Title |
|---|---|
| 0 | Chain activity |
| 6 | Node health |
| 14 | DA layer |
| 23 | Errors / rejections |
| 32 | Process / observability |
| 40 | Cluster topology |
| 48 | Cost & economy (+ GCP burn panel) |
| **66** | **VM capacity headroom** (new) |
| **74** | **Activity leaders** (new) |

Total: 9 rows, 38 panels.

## Operator step after merge

Re-import `ops/grafana/ligate-node.json` in Grafana. On import you'll be asked to pick a datasource for `${DS_INFINITY}` (the new templated datasource for the GCP burn + leaderboard panels). Pick the **Infinity** datasource Grafana Cloud has by default. Existing Prometheus picker continues to work as before.

## Net diff

2 files: `ops/grafana/ligate-node.json` (+~500 lines panel JSON), `ops/grafana/README.md` (+18 / -10 docs).