### PR TITLE
grafana: filter $instance var by last_over_time(5m) to drop stale VMs

### DIFF
--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -2274,7 +2274,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "query": "label_values(ligate_block_height, instance)",
+        "query": "label_values(last_over_time(ligate_block_height[5m]), instance)",
         "regex": "ligate-devnet-1-sequencer.*",
         "refresh": 2,
         "sort": 1,


### PR DESCRIPTION
## Why

After the 2026-05-22 single-VM teardown, VM-2 + VM-3 instances are TERMINATED but their Prometheus time-series (with `instance="ligate-devnet-1-sequencer-2"` / `-3`) are still in Mimir storage with their last-reported values. The dashboard's `$instance` template variable was defined as:

```promql
label_values(ligate_block_height, instance)
```

which returns every instance that has *ever* reported `ligate_block_height`, including the stopped ones. The "Sequencer role per VM" panel then renders three VMs (one of which shows "unknown" since VM-3's last reported value was role=0 between ligate-node stopping and the systemd-stop ordering).

## What

One-line change: filter the variable's label_values to only consider series reporting in the last 5 minutes.

```promql
label_values(last_over_time(ligate_block_height[5m]), instance)
```

`last_over_time(...[5m])` returns no datapoint when the series hasn't reported in 5 min, so `label_values()` only sees currently-active instances. Stale series in Mimir storage stay there (they'll naturally age out at the retention horizon, not our concern) but drop off the dashboard immediately.

Verified live on https://ligate.grafana.net/d/ligate-node — dashboard v2 already pushed via API on 2026-05-22 16:23 UTC. This PR is the repo-side persistence so the next operator's re-import picks up the same fix.

## Net diff

One field in `ops/grafana/ligate-node.json` `templating.list[1].query` (+ `.definition`).