### PR TITLE
chain v0.2.12: SubmitBlobReceipt cost fields + ligate_da_blob_bytes_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,27 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-05-22
+
+Lands real on-wire bytes-per-blob telemetry from the DA layer (`ligate_da_blob_bytes_total`) by extending the SDK's `SubmitBlobReceipt` with cost fields. Plumbing release; no behaviour shift, `chain_hash` unchanged.
+
 ### Added
 
-- `ligate_da_blob_bytes_total` (counter) — total bytes posted to the DA layer, summed from the SDK `SubmitBlobReceipt::size_in_bytes` on every observed `Published` event. Authoritative (not an estimate); lets Grafana show GB-per-month posted and real cost-per-byte trends as attestation payload size evolves. (chain#452)
-- `ligate_da_blob_gas_total` (counter) — total DA-layer gas burned, summed from `SubmitBlobReceipt::gas_used`. Only bumps when the adapter surfaces a value (Celestia: yes; mock DA: skipped). Authoritative. (chain#452)
+- `ligate_da_blob_bytes_total` (counter) — total bytes posted to the DA layer, summed from `SubmitBlobReceipt::size_in_bytes` on every observed `Published` event. Authoritative (not an estimate); lets Grafana show GB-per-month posted and real cost-per-byte trends as attestation payload size evolves. (chain#452)
+- `ligate_da_blob_gas_total` (counter) — total DA-layer gas burned, summed from `SubmitBlobReceipt::gas_used`. Registered but does not bump yet: both Celestia (the celestia-grpc client's `TxInfo` carries only `hash` + `height`) and mock-DA leave `gas_used` as `None`. Once the Celestia `get_tx` follow-up surfaces gas this counter starts tracking real values with no code change here. (chain#452)
 
 ### Changed
 
-- SDK pin bumped to `ligate-io/sovereign-sdk@33e1f419f`. The branch extends `SubmitBlobReceipt<T>` with `fee_paid: Option<u64>` (Celestia nanoTIA), `gas_used: Option<u64>` (Celestia PFB gas), and `size_in_bytes: u64`. Celestia adapter currently leaves both `fee_paid` and `gas_used` as `None` (the celestia-grpc client's `TxInfo` only exposes `hash` + `height`; surfacing gas/fee needs a follow-up `get_tx` lookup against the DA node). Mock-DA adapter also sets fee/gas to `None`. `size_in_bytes` is always populated, making `ligate_da_blob_bytes_total` the one new authoritative counter shipping today.
-- `ligate_da_tia_burned_nano_estimate_total` now prefers the receipt's `fee_paid` when present (authoritative), falling back to the compiled-in `DA_BLOB_TIA_ESTIMATE_NANO` constant when the adapter leaves it `None`. The `_estimate_` suffix stays for now since the Celestia path still uses the constant. Once the Celestia tx-body decode lands the suffix will drop in a follow-up. (chain#452)
+- SDK pin bumped to `ligate-io/sovereign-sdk@33e1f419f` (PR #3). Extends `SubmitBlobReceipt<T>` with `fee_paid: Option<u64>`, `gas_used: Option<u64>`, and `size_in_bytes: u64`. `size_in_bytes` is always populated by every adapter; `fee_paid` + `gas_used` are `None` everywhere today pending the per-adapter follow-ups.
+- `ligate_da_tia_burned_nano_estimate_total` now prefers the receipt's `fee_paid` when present (authoritative), falling back to the compiled-in `DA_BLOB_TIA_ESTIMATE_NANO` constant when the adapter leaves it `None`. The `_estimate_` suffix stays for now since the Celestia path still uses the constant; once the Celestia tx-body decode lands the suffix drops in a follow-up. (chain#452)
 
 ### Compatibility
 
-`chain_hash` unchanged. Safe binary swap. New counters appear automatically on next `/metrics` scrape.
+`chain_hash` unchanged from v0.2.11. Safe binary swap. New counters appear automatically on next `/metrics` scrape.
 
 ### Followup
 
-- Decode `tx_response.tx: Option<Any>` in the Celestia adapter to extract the real `fee_paid` (nanoTIA) from the PFB tx body's `auth_info.fee.amount`. Once landed, the chain-side `unwrap_or(DA_BLOB_TIA_ESTIMATE_NANO)` becomes pure pass-through and the `_estimate_` suffix can drop. Filing as the next chain#452 follow-up.
+- Add a `get_tx` lookup in the Celestia adapter (after `submit_pay_for_blob` returns the `TxInfo`) to fetch the full `TxResponse`, extract `gas_used` and decode `tx.auth_info.fee.amount` for the utia coin. Once landed, both `ligate_da_blob_gas_total` and the `_estimate_` counter start emitting real Celestia values without further chain-side changes.
 
 ## [0.2.11] - 2026-05-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 
 [[package]]
 name = "nmt-rs"
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -7738,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "backon",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7845,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7857,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7949,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "borsh",
  "derivative",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -8025,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "axum",
@@ -8050,7 +8050,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8072,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8167,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "bech32",
@@ -8189,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8229,7 +8229,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "axum",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "axum",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8376,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "derive_more",
  "rockbound",
@@ -8416,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8441,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8508,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8534,7 +8534,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8643,7 +8643,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "bech32",
  "borsh",
@@ -8681,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8707,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=847993648791504bf4d20db3048145b8983697ec#847993648791504bf4d20db3048145b8983697ec"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]


### PR DESCRIPTION
Cuts v0.2.12 to ship the chain#452 work to devnet-1's `/metrics`.

## Summary
- Bumps workspace version `0.2.11` → `0.2.12`.
- Folds the `[Unreleased]` CHANGELOG content into a new `[0.2.12] - 2026-05-22` section.

## What ships in v0.2.12
- New counter `ligate_da_blob_bytes_total` — real on-wire bytes posted to Celestia DA per blob, summed.
- New counter `ligate_da_blob_gas_total` — registered, doesn't bump yet (Celestia + mock leave `gas_used: None` until the `get_tx` follow-up).
- SDK pin at `ligate-io/sovereign-sdk@33e1f41` (the merged chain#452 SDK change).
- `ligate_da_tia_burned_nano_estimate_total` flips to `fee_paid.unwrap_or(estimate)`; behaviour unchanged today (always falls back), but flips to authoritative the moment a future SDK PR populates `fee_paid`.

## Compatibility
`chain_hash` unchanged from v0.2.11 (no STF / module / genesis touches). Safe binary swap on VM-1; no state quarantine, no replay.

## Post-merge
1. Tag `v0.2.12` on the merged commit → `release.yml` builds the linux-amd64 binary.
2. SSH to `ligate-devnet-1-sequencer`, swap binary, `systemctl restart ligate-node`.
3. Verify: `curl https://rpc.ligate.io/v1/rollup/info` reports `version: 0.2.12`, and `curl 127.0.0.1:9100/metrics | grep ligate_da_blob_bytes_total` exists + climbs.

## Test plan
- [ ] CI green (full Rust suite)
- [ ] After deploy: `/v1/rollup/info` shows `0.2.12`
- [ ] After deploy: `ligate_da_blob_bytes_total` appears and climbs on every Celestia publish