### PR TITLE
chain v0.2.13 hotfix: serde(default) on SubmitBlobReceipt cost fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-05-22
+
+Hotfix for the v0.2.12 deploy panic on existing `blob_sender` RocksDB. Upgrading from v0.2.11 with a populated DB hit:
+
+```
+panicked at sov-blob-sender/src/db.rs:119:14:
+Invalid blob info in the database: Error("missing field `size_in_bytes`", line: 1, column: 215)
+```
+
+### Fixed
+
+- SDK pin bumped to `ligate-io/sovereign-sdk@2cd677a` (PR #4). The hotfix adds `#[serde(default)]` to the three new `SubmitBlobReceipt` cost fields (`fee_paid`, `gas_used`, `size_in_bytes`). Receipts persisted by older binaries now deserialize cleanly with sane defaults (`None`/`None`/`0`) instead of panicking. (chain#452)
+
+### Operator notes
+
+If you tried v0.2.12 and rolled back to v0.2.11, jump straight to v0.2.13. No data quarantine is needed; the `blob_sender` RocksDB rows that prompted the panic are read with `size_in_bytes = 0` on first load, then write the real value on the next `Published` event.
+
+### Compatibility
+
+`chain_hash` unchanged from v0.2.11/v0.2.12. Safe binary swap.
+
 ## [0.2.12] - 2026-05-22
 
 Lands real on-wire bytes-per-blob telemetry from the DA layer (`ligate_da_blob_bytes_total`) by extending the SDK's `SubmitBlobReceipt` with cost fields. Plumbing release; no behaviour shift, `chain_hash` unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 
 [[package]]
 name = "nmt-rs"
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -7738,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "backon",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7845,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7857,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7949,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "borsh",
  "derivative",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -8025,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "axum",
@@ -8050,7 +8050,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8072,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8167,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "bech32",
@@ -8189,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8229,7 +8229,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "axum",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "axum",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8376,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "derive_more",
  "rockbound",
@@ -8416,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8441,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8508,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8534,7 +8534,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8643,7 +8643,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "bech32",
  "borsh",
@@ -8681,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8707,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=33e1f419f7f5bf2f84211ad419ebe59889fef214#33e1f419f7f5bf2f84211ad419ebe59889fef214"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]
@@ -147,36 +147,36 @@ debug = 0
 #
 # Rebase discipline + workflow lives in the fork's CONTRIBUTING.md.
 [patch."https://github.com/Sovereign-Labs/sovereign-sdk.git"]
-sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-blob-sender                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-full-node-configs          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
-sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "33e1f419f7f5bf2f84211ad419ebe59889fef214" }
+sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-blob-sender                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-full-node-configs          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }


### PR DESCRIPTION
Hotfix for the v0.2.12 deploy that panicked on devnet-1 reading the existing `blob_sender` RocksDB. VM-1 is currently on v0.2.11 (rolled back).

## What broke
```
panicked at sov-blob-sender/src/db.rs:119:14:
Invalid blob info in the database: Error("missing field `size_in_bytes`", line: 1, column: 215)
```
v0.2.12 added `size_in_bytes` as a required serde field. Receipts persisted by v0.2.11 don't carry it, so deserialization fails on startup.

## Fix
SDK pin bumped to `2cd677a` (ligate-io/sovereign-sdk#4 — merged). That commit adds `#[serde(default)]` to the three new cost fields. Old rows decode with `(fee_paid=None, gas_used=None, size_in_bytes=0)`; new writes carry the real values.

## Compat
`chain_hash` unchanged from v0.2.11/v0.2.12. Safe binary swap. No quarantine.

## Test plan
- [ ] CI green
- [ ] After deploy: `/v1/rollup/info` reports `0.2.13`
- [ ] After deploy: `ligate_da_blob_bytes_total` exists in `/metrics` (zero on first scrape, climbs as new blobs publish)
- [ ] ligate-node service stays `active` past the first DA roundtrip (~6s) — proves the persisted DB rows deserialized OK