### PR TITLE
ops: bump stale internal version pins to v0.2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Quick start
 
 > **Just want to run a node, not build from source?**
-> Pre-built Linux x86_64 / Linux arm64 / macOS arm64 binaries ship on every release: <https://github.com/ligate-io/ligate-chain/releases>. A multi-arch container image is also published on every release tag at `ghcr.io/ligate-io/ligate-chain:<version>` (e.g. `:0.2.4`, plus `:latest`). See [docs.ligate.io/nodes](https://docs.ligate.io/nodes) for the operator-facing install + boot recipes.
+> Pre-built Linux x86_64 / Linux arm64 / macOS arm64 binaries ship on every release: <https://github.com/ligate-io/ligate-chain/releases>. A multi-arch container image is also published on every release tag at `ghcr.io/ligate-io/ligate-chain:<version>` (e.g. `:0.2.13`, plus `:latest`). See [docs.ligate.io/nodes](https://docs.ligate.io/nodes) for the operator-facing install + boot recipes.
 
 ### Build and test
 

--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -436,7 +436,7 @@ docker run -d \
     -e SOV_CELESTIA_GRPC_URL=http://host.docker.internal:9090 \
     -e SOV_CELESTIA_SIGNER_KEY="$(gcloud secrets versions access latest --secret=ligate-devnet-1-sequencer-signer)" \
     -e RUST_LOG=info,sov=info \
-    ghcr.io/ligate-io/ligate-chain:v0.1.0-devnet \
+    ghcr.io/ligate-io/ligate-chain:v0.2.13 \
     --da-layer celestia \
     --rollup-config-path /opt/ligate/devnet-1/celestia.toml \
     --genesis-config-dir /opt/ligate/devnet-1/genesis \

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -4,13 +4,14 @@
 # container at startup. The compose file references them with the
 # `${VAR:-default}` form so unset vars fall back to safe defaults.
 
-# Chain image version. Use a specific pre-release for testing
-# (`0.0.1-rc.4`), `latest` once a full release is tagged
-# (`v0.1.0-devnet` and onward). `latest` will not pull pre-releases.
-LIGATE_VERSION=0.0.1-rc.4
+# Chain image version. Pin to a specific tag for reproducible deploys
+# (`0.2.13` is the latest devnet-1 release as of 2026-05-23). Set to
+# `latest` to track the most recent release automatically; never use
+# `latest` on production VMs.
+LIGATE_VERSION=0.2.13
 
 # Sequencer-mode hot key (hex). Holds Mocha TIA for blob inclusion.
-# Follower-mode operators leave empty.
+# Read-only-mode operators leave empty.
 #
 # DO NOT commit your real signer key. Use a secret store (1Password,
 # GCP Secret Manager, AWS Secrets Manager) and inject at runtime.

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ Wait ~10 minutes for Celestia to header-sync, then:
 
 ```bash
 curl http://localhost:12346/v1/rollup/info
-# {"chain_id":"ligate-devnet-1","chain_hash":"...","version":"0.0.1-rc.4"}
+# {"chain_id":"ligate-devnet-1","chain_hash":"...","version":"0.2.13"}
 
 curl http://localhost:12346/health
 # {"status":"ok"}

--- a/ops/cloud-init/sequencer.yaml
+++ b/ops/cloud-init/sequencer.yaml
@@ -231,8 +231,8 @@ runcmd:
   # (or operator-side `systemctl stop && curl + tar && systemctl start`
   # for in-place swaps — the standard path for running VMs).
   - |
-    LIGATE_TAG=v0.2.10
-    LIGATE_VERSION=0.2.10
+    LIGATE_TAG=v0.2.13
+    LIGATE_VERSION=0.2.13
     ARTIFACT="ligate-node-${LIGATE_VERSION}-linux-amd64.tar.gz"
     # Keep the artifact's original filename so `sha256sum -c` can find
     # it via the relative path written into the .sha256 file by the
@@ -254,7 +254,7 @@ runcmd:
   # Idempotent: --depth 1 + a fresh tmp clone every cloud-init run;
   # cp -rn so we don't clobber an operator-edited /opt/ligate/devnet-1/.
   - |
-    LIGATE_TAG=v0.2.7
+    LIGATE_TAG=v0.2.13
     rm -rf /tmp/ligate-chain
     git clone --depth 1 --branch ${LIGATE_TAG} \
       https://github.com/ligate-io/ligate-chain.git /tmp/ligate-chain

--- a/tests/smoke/multi-sequencer/README.md
+++ b/tests/smoke/multi-sequencer/README.md
@@ -120,12 +120,12 @@ render script produces.
 
 ## Image selection
 
-By default uses `ghcr.io/ligate-io/ligate-chain:0.2.3`. The v0.2.3
-SDK pin (`4b4a313b7`) has the full DbElected machinery; no newer
-chain version needed for this verification.
+By default uses `ghcr.io/ligate-io/ligate-chain:0.2.13` (current
+devnet-1 release as of 2026-05-23). The DbElected machinery has
+been stable since v0.2.3 (`4b4a313b7`); any v0.2.x image works
+for this verification.
 
-Override via env: `LIGATE_IMAGE=ghcr.io/ligate-io/ligate-chain:v0.2.4
-./run.sh up` once v0.2.4 is cut.
+Override via env: `LIGATE_IMAGE=ghcr.io/ligate-io/ligate-chain:vX.Y.Z ./run.sh up`.
 
 ## Cleanup notes
 

--- a/tests/smoke/multi-sequencer/docker-compose.yml
+++ b/tests/smoke/multi-sequencer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       retries: 30
 
   ligate-1:
-    image: ${LIGATE_IMAGE:-ghcr.io/ligate-io/ligate-chain:0.2.3}
+    image: ${LIGATE_IMAGE:-ghcr.io/ligate-io/ligate-chain:0.2.13}
     user: "0:0"  # smoke-only: run as root so the named volumes (root-owned by default) are writable
     security_opt:
       - seccomp=unconfined  # macOS Docker: required for io_uring (NOMT state tree backend)
@@ -52,7 +52,7 @@ services:
       - "12346:12346"
 
   ligate-2:
-    image: ${LIGATE_IMAGE:-ghcr.io/ligate-io/ligate-chain:0.2.3}
+    image: ${LIGATE_IMAGE:-ghcr.io/ligate-io/ligate-chain:0.2.13}
     user: "0:0"  # smoke-only: run as root so the named volumes (root-owned by default) are writable
     security_opt:
       - seccomp=unconfined  # macOS Docker: required for io_uring (NOMT state tree backend)
@@ -80,7 +80,7 @@ services:
       - "12347:12346"
 
   ligate-3:
-    image: ${LIGATE_IMAGE:-ghcr.io/ligate-io/ligate-chain:0.2.3}
+    image: ${LIGATE_IMAGE:-ghcr.io/ligate-io/ligate-chain:0.2.13}
     user: "0:0"  # smoke-only: run as root so the named volumes (root-owned by default) are writable
     security_opt:
       - seccomp=unconfined  # macOS Docker: required for io_uring (NOMT state tree backend)


### PR DESCRIPTION
Phase 1 catch-up. Bumps every stale chain-version pin inside the chain repo itself to match the deployed v0.2.13:

| File | Before | After |
|---|---|---|
| `README.md` | container example `:0.2.4` | `:0.2.13` |
| `ops/cloud-init/sequencer.yaml` | binary install `LIGATE_TAG=v0.2.10`, devnet-1 config clone `LIGATE_TAG=v0.2.7` | both `v0.2.13` |
| `examples/.env.example` | `LIGATE_VERSION=0.0.1-rc.4` (pre-devnet RC!) + stale "follower-mode" comment | `0.2.13` + reworded |
| `examples/README.md` | expected version in `/v1/rollup/info` output `0.0.1-rc.4` | `0.2.13` |
| `docs/development/public-devnet-deploy.md` | container example `:v0.1.0-devnet` | `:v0.2.13` |
| `tests/smoke/multi-sequencer/docker-compose.yml` | three services pinned to `:0.2.3` | `:0.2.13` |
| `tests/smoke/multi-sequencer/README.md` | mentions `:0.2.3` / `v0.2.4` placeholder | `:0.2.13` + generic placeholder |

No code changes, docs and config only. Phase 2 will replace these literal pins with a daily `bump-versions.yml` workflow + an unversioned tarball alias, so future releases never need this manual sweep again.

## Test plan
- [ ] CI green (docs/config-only, all jobs should pass trivially)