### PR TITLE
phase2: bump-versions.yml + unversioned tarball aliases + downstream dispatch

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -1,0 +1,95 @@
+name: bump-versions
+
+# Auto-PR when the chain's own latest published release advances ahead
+# of the version literals embedded inside this repo (Docker tag
+# examples, cloud-init install URLs, smoke compose images, README
+# blurb, etc.). Reads the current pinned version from `.versions.yml`,
+# fetches the latest release tag, and on mismatch sed-replaces the
+# literal version (and v-prefix variant) across the paths listed in
+# `.versions-paths.txt`.
+#
+# Triggers:
+#   1. Daily cron — 24-hour safety net.
+#   2. `workflow_dispatch` — manual on-demand from the Actions tab.
+#   3. `repository_dispatch` — the `release.yml` workflow dispatches
+#      `chain-released` here AND to docs / landing repos.
+#
+# Note: this workflow does NOT bump the workspace `Cargo.toml`
+# version. That's a release-time human decision (the version bump is
+# the release-ceremony's first commit). This automates only the
+# downstream literal-string drift.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [chain-released]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Read current pinned version
+        id: cur
+        run: echo "chain=$(yq '.chain' .versions.yml)" >> $GITHUB_OUTPUT
+
+      - name: Fetch latest chain release
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHAIN_TAG=$(gh release view -R ligate-io/ligate-chain --json tagName --jq '.tagName')
+          echo "chain=${CHAIN_TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Bump version pins if changed
+        id: bump
+        env:
+          OLD: ${{ steps.cur.outputs.chain }}
+          NEW: ${{ steps.latest.outputs.chain }}
+        run: |
+          changed=0
+          if [[ "$OLD" != "$NEW" ]]; then
+            echo "::notice::chain $OLD → $NEW"
+            yq -i ".chain = \"$NEW\"" .versions.yml
+            paths=$(grep -vE '^\s*(#|$)' .versions-paths.txt | tr '\n' ' ')
+            if [[ -n "$paths" ]]; then
+              # shellcheck disable=SC2086
+              sed -i "s|v${OLD}|v${NEW}|g; s|${OLD}|${NEW}|g" $paths
+            fi
+            changed=1
+          fi
+          echo "changed=$changed" >> $GITHUB_OUTPUT
+
+      - name: Open auto-PR
+        if: steps.bump.outputs.changed == '1'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump internal chain pins to v${{ steps.latest.outputs.chain }}"
+          branch: chore/bump-chain-v${{ steps.latest.outputs.chain }}
+          delete-branch: true
+          title: "chore: bump internal chain pins to v${{ steps.latest.outputs.chain }}"
+          body: |
+            **Automated by `bump-versions.yml`.**
+
+            Internal chain pins bumped: `${{ steps.cur.outputs.chain }}` → `${{ steps.latest.outputs.chain }}`.
+
+            Files touched come from `.versions-paths.txt`. The literal version was replaced exactly, both bare-semver and v-prefixed.
+
+            [Chain release notes →](https://github.com/ligate-io/ligate-chain/releases/tag/v${{ steps.latest.outputs.chain }})
+
+            ---
+
+            Triggered by: `${{ github.event_name }}`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,28 @@ jobs:
           find artifacts -type f \( -name '*.tar.gz' -o -name '*.sha256' \) -exec cp {} release/ \;
           ls -lh release/
 
+      - name: Stage unversioned tarball aliases (`/releases/latest/download/` URLs)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Publish each tarball ALSO under an unversioned name so docs
+          # can link to `releases/latest/download/ligate-node-<arch>.tar.gz`
+          # and never need a manual version bump in the install commands.
+          # The versioned originals stay in place for operators who pin
+          # to a specific tag for reproducible deploys.
+          cd release
+          for f in ligate-node-*-*.tar.gz; do
+            # `ligate-node-0.2.13-linux-amd64.tar.gz` → `ligate-node-linux-amd64.tar.gz`
+            unversioned=$(echo "$f" | sed -E 's/-[0-9]+\.[0-9]+\.[0-9]+-/-/')
+            cp "$f" "$unversioned"
+            cp "$f.sha256" "$unversioned.sha256"
+            # The sha256 sidecar embeds the filename it was computed
+            # against; rewrite to point at the unversioned name so
+            # `sha256sum -c` still verifies after the rename.
+            sed -i -E "s|ligate-node-[0-9]+\.[0-9]+\.[0-9]+-|ligate-node-|" "$unversioned.sha256"
+          done
+          ls -lh
+
       - name: Extract changelog excerpt
         id: changelog
         shell: bash
@@ -294,3 +316,31 @@ jobs:
           # Full mainnet uses `vX.Y.Z` plain.
           prerelease: ${{ contains(github.ref_name, '-rc.') }}
           fail_on_unmatched_files: true
+
+      - name: Dispatch `chain-released` to downstream repos
+        # Notifies the `bump-versions.yml` workflow in each downstream
+        # repo so they auto-PR a version-pin bump within ~30 s of a
+        # new release (instead of the daily-cron fallback). Skipped on
+        # any failure earlier in this job; the daily cron path is the
+        # safety net.
+        if: success() && !contains(github.ref_name, '-rc.')
+        env:
+          PAT: ${{ secrets.DOWNSTREAM_DISPATCH_PAT }}
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${PAT:-}" ]]; then
+            echo "::warning::DOWNSTREAM_DISPATCH_PAT not set; skipping dispatch. Daily cron in receivers will catch the bump within 24h."
+            exit 0
+          fi
+          for repo in ligate-io/docs ligate-io/ligate-marketing ligate-io/ligate-chain; do
+            echo "→ dispatching chain-released to ${repo}"
+            curl -fsSL -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${PAT}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${repo}/dispatches" \
+              -d "{\"event_type\":\"chain-released\",\"client_payload\":{\"version\":\"${TAG#v}\",\"tag\":\"${TAG}\"}}" \
+              || echo "::warning::dispatch to ${repo} failed (non-fatal; daily cron will catch up)"
+          done

--- a/.versions-paths.txt
+++ b/.versions-paths.txt
@@ -1,0 +1,13 @@
+# Paths the `bump-versions` workflow rewrites when the tracked chain
+# version bumps. One path per line; blank lines + `#` comments
+# ignored.
+#
+# These are the files Phase 1 (chain#470) hand-bumped on 2026-05-23;
+# Phase 2 automates the same sweep.
+README.md
+ops/cloud-init/sequencer.yaml
+examples/.env.example
+examples/README.md
+docs/development/public-devnet-deploy.md
+tests/smoke/multi-sequencer/docker-compose.yml
+tests/smoke/multi-sequencer/README.md

--- a/.versions.yml
+++ b/.versions.yml
@@ -1,0 +1,9 @@
+# Tracked upstream-artifact versions. Source of truth for the
+# `bump-versions` workflow at `.github/workflows/bump-versions.yml`.
+#
+# This file pins versions REFERENCED INSIDE the chain repo (Docker tag
+# examples, cloud-init install URLs, smoke-test image tags, etc).
+# The chain's OWN released version is the workspace `Cargo.toml`
+# version — that's separately bumped by hand when cutting a release
+# (see `docs/development/runbooks/chain-release.md`).
+chain: "0.2.13"


### PR DESCRIPTION
Closes the version-pin drift across chain / docs / landing. After this merges, every tagged chain release automatically:

1. Publishes **unversioned tarball aliases** (`ligate-node-linux-amd64.tar.gz` next to `ligate-node-0.2.13-linux-amd64.tar.gz`) so install commands can use `/releases/latest/download/...` and never need a version bump at all.
2. Dispatches `chain-released` to `ligate-io/docs`, `ligate-io/ligate-marketing`, and itself — each receiver's `bump-versions.yml` workflow opens an auto-PR for the literal-string drift within ~30 s.

## What lands

### `.github/workflows/release.yml`
- New step **Stage unversioned tarball aliases**: copies each `ligate-node-<ver>-<arch>.tar.gz` (+ .sha256) to `ligate-node-<arch>.tar.gz` before `softprops/action-gh-release` publishes. Sidecar SHA filenames are rewritten so `sha256sum -c` still verifies.
- New step **Dispatch `chain-released` to downstream repos** at the end of the `release` job, using `DOWNSTREAM_DISPATCH_PAT` (set in repo secrets). Skipped on `-rc.` tags; non-fatal on dispatch failure (daily cron in receivers is the safety net).

### Phase 2 manifest + workflow (this repo's own)
| File | Purpose |
|---|---|
| `.versions.yml` | Pinned chain version reflected in docs/configs (today: 0.2.13) |
| `.versions-paths.txt` | The 7 files Phase 1 hand-bumped on 2026-05-23 |
| `.github/workflows/bump-versions.yml` | Daily cron + dispatch + manual trigger |

## Trade-offs
- The unversioned aliases double the number of files on each Release page (4 versioned + 4 unversioned + sidecars). Acceptable: storage is free.
- Receivers' `bump-versions.yml` runs at most once per day per repo on cron, or ~3 times per chain release on dispatch (one per receiver). Negligible action-minute cost.

## Test plan
- [ ] CI green
- [ ] After merge: cut a no-op tag (e.g. via `workflow_dispatch` on `release.yml`) to dry-run the dispatch step. Verify the three receivers each get a `bump-versions` workflow run.
- [ ] OR: just wait for the next real chain release — that's the proper end-to-end test.

## Phase 3
Extend each receiver's `.versions.yml` + `.versions-paths.txt` to track `cli`, `sdk`, `api`. ~10 min per repo.

Companion PRs:
- ligate-io/docs#28 — receiver workflow for docs
- ligate-io/ligate-marketing#TBD — receiver workflow for landing