### PR TITLE
chain v0.2.14: estimate-based fee_paid from live Mocha gas price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,23 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.2.14] - 2026-05-23
+
+Cost telemetry gets meaningfully accurate. `ligate_da_tia_burned_nano_estimate_total` now bumps by a per-blob estimate derived from the live Mocha gas price (already polled by the Celestia adapter) times a calibrated per-blob gas usage, instead of a fixed 300_000 nanoTIA constant. Plumbing release; no behaviour shift, `chain_hash` unchanged.
+
 ### Changed
 
-- **Backup cadence: drop the daily tier; keep hourly (HOT, every 15 min) + weekly (COLD, Sundays 04:00 UTC).** The daily cold-snapshot at 03:30 UTC stopped `ligate-node` for ~60 s each day, costing one GCP-uptime-alert-fire per day under single-VM mode. It was redundant against the Sunday weekly + Celestia DA replay (the chain's actual source of truth). Net effect: 7 backup-induced downtimes/week → 1. Aligns with how Cosmos / Ethereum / Solana operators actually run snapshots in practice. Hourly tier (best-effort hot rsync, last-7-days rollback insurance) is unchanged. Filed as chain#468; the proper "no downtime even on weekly" fix (RocksDB hot-checkpoint API) needs upstream NOMT work and stays in the backlog. Removed: `ops/backup/systemd/ligate-backup-daily.timer`. Updated: `docs/development/runbooks/backup-restore.md`, `docs/development/public-devnet-deploy.md`.
+- SDK pin bumped to `ligate-io/sovereign-sdk@ffff9df` (PR #5). The Celestia adapter now caches the live `gas_price` from its existing periodic stat poll and computes `fee_paid = ceil(gas_price * (PFB_BASE_GAS + bytes * PFB_GAS_PER_BYTE)) * 1000` nanoTIA on every `SubmitBlobReceipt`. Constants calibrated against Mocha for our payload shapes; gas price is live, so spikes get captured automatically.
+- `ligate_da_tia_burned_nano_estimate_total` now reflects the estimated `fee_paid` from the receipt (via the `unwrap_or(constant)` fallback that's now hit only on mock-DA). For small attestation blobs the number is similar to v0.2.13; for larger proof blobs it's 10-15x more accurate.
+- **Backup cadence: drop the daily tier; keep hourly (HOT, every 15 min) + weekly (COLD, Sundays 04:00 UTC).** The daily cold-snapshot at 03:30 UTC stopped `ligate-node` for ~60 s each day, costing one GCP-uptime-alert-fire per day under single-VM mode. It was redundant against the Sunday weekly + Celestia DA replay (the chain's actual source of truth). Net effect: 7 backup-induced downtimes/week → 1. Filed as chain#468; the proper "no downtime even on weekly" fix (RocksDB hot-checkpoint API) needs upstream NOMT work and stays in the backlog. Removed: `ops/backup/systemd/ligate-backup-daily.timer`. Updated: `docs/development/runbooks/backup-restore.md`, `docs/development/public-devnet-deploy.md`.
+
+### What's still estimate-level
+
+`fee_paid` is calibrated but not authoritative. The proper fix needs upstream `celestia-client` to expose a `get_tx` query (filed as [celestiaorg/lumina#974](https://github.com/celestiaorg/lumina/pull/974)) so we can read the real fee + `gas_used` straight off the PFB tx receipt. Once that lands, the adapter calls `state().get_tx(hash)` and `fee_paid` becomes the real value with no further chain-side changes.
+
+### Compatibility
+
+`chain_hash` unchanged from v0.2.13. Safe binary swap. The `ligate_da_blob_bytes_total` and `ligate_da_blobs_published_total` counters keep counting the same things. Only the `ligate_da_tia_burned_nano_estimate_total` rate changes (it gets more accurate).
 
 ## [0.2.13] - 2026-05-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 
 [[package]]
 name = "nmt-rs"
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -7738,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "backon",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7845,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7857,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7949,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "borsh",
  "derivative",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -8025,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "axum",
@@ -8050,7 +8050,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8072,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8167,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -8189,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8229,7 +8229,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "axum",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "axum",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8376,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "derive_more",
  "rockbound",
@@ -8416,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8441,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8508,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8534,7 +8534,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8643,7 +8643,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "bech32",
  "borsh",
@@ -8681,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8707,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=2cd677ac75ca0093b7ffdc909191626787e89312#2cd677ac75ca0093b7ffdc909191626787e89312"
+source = "git+https://github.com/ligate-io/sovereign-sdk.git?rev=ffff9dfe6b615d8fbb1f71515adc760e295eb7a5#ffff9dfe6b615d8fbb1f71515adc760e295eb7a5"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]
@@ -147,36 +147,36 @@ debug = 0
 #
 # Rebase discipline + workflow lives in the fork's CONTRIBUTING.md.
 [patch."https://github.com/Sovereign-Labs/sovereign-sdk.git"]
-sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-blob-sender                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-full-node-configs          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
-sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "2cd677ac75ca0093b7ffdc909191626787e89312" }
+sov-accounts                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-address                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-api-spec                   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-attester-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-bank                       = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-blob-sender                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-blob-storage               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-build                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-capabilities               = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-celestia-adapter           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-chain-state                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-db                         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-kernels                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-mock-da                    = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-mock-zkvm                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-modules-api                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-modules-rollup-blueprint   = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-modules-stf-blueprint      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-node-client                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-operator-incentives        = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-prover-incentives          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-risc0-adapter              = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-rollup-apis                = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-rollup-full-node-interface = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-rollup-interface           = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-sequencer                  = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-sequencer-registry         = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-state                      = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-stf-runner                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-full-node-configs          = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-test-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-uniqueness                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }
+sov-zkvm-utils                 = { git = "https://github.com/ligate-io/sovereign-sdk.git", rev = "ffff9dfe6b615d8fbb1f71515adc760e295eb7a5" }


### PR DESCRIPTION
Cuts v0.2.14 to ship the SDK#5 cost-telemetry improvement to devnet-1.

## Summary

The chain's `ligate_da_tia_burned_nano_estimate_total` counter currently bumps by a fixed 300_000 nanoTIA per blob. That was calibrated for tiny 13-byte payloads on Mocha and undercounts everything else. v0.2.14 swaps that for an estimate derived from the live gas price.

## How it works

The Celestia adapter (sovereign-sdk fork) already polls `state.estimate_gas_price` every few seconds for ops metrics. SDK#5 caches that value and uses it to compute `fee_paid` on every `SubmitBlobReceipt`:

```
fee_paid_nanoTIA = ceil(live_gas_price * (PFB_BASE_GAS + bytes * PFB_GAS_PER_BYTE)) * 1000
```

The chain's metrics layer already prefers `receipt.fee_paid` over the compiled-in constant via `unwrap_or` (shipped in v0.2.12), so this PR is purely a pin bump + workspace version + changelog. No chain code changes.

## Why this isn't authoritative yet

`celestia-client`'s public API doesn't expose any way to read the real `gas_used`/fee from a PFB receipt. Filed [celestiaorg/lumina#974](https://github.com/celestiaorg/lumina/pull/974) upstream to add `get_tx` on `StateApi`. Once that merges, the adapter switches to authoritative numbers without further chain-side changes.

## What ships
- SDK pin: `2cd677a` → `ffff9df` (ligate-io/sovereign-sdk#5, merged)
- Workspace version: `0.2.13` → `0.2.14`
- Folds the Phase-2 backup-cadence change (chain#469) into the same release section

## Compatibility
`chain_hash` unchanged. Safe binary swap. The two new authoritative counters from v0.2.12/v0.2.13 (`ligate_da_blob_bytes_total` and `ligate_da_blobs_published_total`) keep counting the same things; only `_estimate_total` gets more accurate.

## Test plan
- [ ] CI green
- [ ] After deploy: `/v1/rollup/info` reports v0.2.14
- [ ] After deploy: `/metrics` shows `ligate_da_tia_burned_nano_estimate_total` advancing at a rate proportional to `ligate_da_blob_bytes_total` (not at a fixed per-blob constant)
- [ ] Service stays `active` past the first DA roundtrip (no panic)