### PR TITLE
chain#392: extra GCP cost panels (by-service, by-vm, MTD)

### DIFF
--- a/docs/development/runbooks/gcp-billing-export.md
+++ b/docs/development/runbooks/gcp-billing-export.md
@@ -199,30 +199,40 @@ In Grafana Cloud (Infinity is pre-installed):
 
 The panel renders empty until BigQuery populates (~24 to 48h after Step 2's Console enable). Don't worry about the empty state until then.
 
-## Step 5: Optional break-down panels
+## Step 5: Extra break-down panels (chain#392)
 
-The fetch script's query is just the daily aggregate. To add per-service or per-VM breakdowns, write a sibling script that targets a different output file (e.g. `/var/www/cost/by-service.json`), wire a second handle_path in Caddy, and add the matching Grafana panel.
+The original v1 fetch script only wrote `daily.json`. As of chain#392 the source-of-truth script at [`ops/billing/gcp-cost-fetch.sh`](../../../ops/billing/gcp-cost-fetch.sh) runs four queries on every timer fire and writes:
 
-Useful complementary queries:
+| File | Window | Used by Grafana panel |
+|---|---|---|
+| `daily.json` | last 30 days | "GCP daily burn (USD, last 30d)" (time series) |
+| `by-service.json` | last 30 days | "GCP spend by service (last 30d)" (bar gauge) |
+| `by-vm.json` | last 7 days, Compute Engine only | "Compute Engine spend by VM (last 7d)" (bar gauge) |
+| `mtd.json` | calendar month-to-date | "GCP month-to-date burn (USD)" (stat) |
 
-```sql
--- Cost by service over the last 30d → /var/www/cost/by-service.json
-SELECT service.description AS service, SUM(cost) AS cost
-FROM `utopian-spring-494915-q1.ligate_billing.gcp_billing_export_resource_v1_*`
-WHERE usage_start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
-GROUP BY service ORDER BY cost DESC
+All four panels live in the dashboard's **Cost & economy** row and consume the same Infinity HTTP-JSON datasource. Caddy serves the whole `/cost/` directory with one `handle_path` block (no per-file routing needed); the four URLs just resolve to the four JSON files.
+
+To deploy the updated script on VM-1:
+
+```bash
+gcloud compute scp ops/billing/gcp-cost-fetch.sh \
+    ligate-devnet-1-sequencer:/tmp/gcp-cost-fetch.sh \
+    --zone=us-central1-a
+
+gcloud compute ssh ligate-devnet-1-sequencer --zone=us-central1-a --command='
+    sudo install -m 0755 -o ligate -g ligate \
+        /tmp/gcp-cost-fetch.sh /opt/ligate/bin/gcp-cost-fetch.sh
+
+    # Fire once now instead of waiting for the next 6h tick
+    sudo systemctl start gcp-cost.service
+'
 ```
 
-```sql
--- Cost by VM (resource name) over the last 7d → /var/www/cost/by-vm.json
-SELECT resource.name AS vm, SUM(cost) AS cost
-FROM `utopian-spring-494915-q1.ligate_billing.gcp_billing_export_resource_v1_*`
-WHERE usage_start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
-  AND service.description = 'Compute Engine'
-GROUP BY vm ORDER BY cost DESC
-```
+Then re-import `ops/grafana/ligate-node.json` in Grafana to pick up the new panels.
 
-For both, the Grafana panel pattern is identical to the daily-burn time series, just pointed at the new URL with the matching columns.
+### Adding even more breakdowns later
+
+The script is structured so each query is its own `run_query` call. Add new ones the same shape, point them at a new `/var/www/cost/<name>.json`, then add a matching Infinity-datasource panel in `ligate-node.json`.
 
 ## Cost of the export itself
 

--- a/ops/billing/gcp-cost-fetch.sh
+++ b/ops/billing/gcp-cost-fetch.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Refresh the GCP cost JSON sidecar files consumed by Grafana.
+#
+# Runs as a systemd oneshot fired every 6h by `gcp-cost.timer` on
+# VM-1. Each query in this script writes one JSON file under
+# `/var/www/cost/`, which Caddy serves at `https://rpc.ligate.io/cost/`
+# for the Grafana Infinity HTTP-JSON datasource to consume.
+#
+# Why this lives in ops/billing/ and not /opt/ligate/bin/:
+#   The VM-1 copy at /opt/ligate/bin/gcp-cost-fetch.sh is the live
+#   one; this is the source-of-truth tracked in git. Cloud-init can
+#   copy this file into place on a fresh VM; manual VM-1 updates use
+#   `gcloud compute scp` + `sudo install`.
+#
+# Files written (consumed by panels in ops/grafana/ligate-node.json):
+#   /var/www/cost/daily.json      -- rolling 30-day daily total
+#   /var/www/cost/by-service.json -- last 30 days, grouped by service
+#   /var/www/cost/by-vm.json      -- last 7 days, grouped by Compute Engine resource name
+#   /var/www/cost/mtd.json        -- month-to-date single-cell stat
+#
+# Tracking: chain#392.
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-utopian-spring-494915-q1}"
+DATASET="${DATASET:-ligate_billing}"
+TABLE_PREFIX="${TABLE_PREFIX:-gcp_billing_export_resource_v1_*}"
+OUTPUT_DIR="${OUTPUT_DIR:-/var/www/cost}"
+
+TABLE="\`${PROJECT_ID}.${DATASET}.${TABLE_PREFIX}\`"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Atomic write: render to a temp file, then `mv` into place. Caddy
+# never sees a half-written response.
+run_query() {
+    local label="$1" sql="$2" output_path="$3"
+    echo "==> ${label}: ${output_path}"
+    local tmp
+    tmp=$(mktemp)
+    bq query --use_legacy_sql=false --format=json --max_rows=200 "$sql" > "$tmp"
+    mv "$tmp" "$output_path"
+    chmod 644 "$output_path"
+}
+
+# 1. Daily aggregate, rolling 30-day window.
+#    Time series panel: x=day, y=cost_usd.
+run_query "daily (last 30d)" "
+    SELECT TIMESTAMP_TRUNC(usage_start_time, DAY) AS day,
+           SUM(cost) AS cost_usd
+    FROM ${TABLE}
+    WHERE usage_start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
+    GROUP BY day
+    ORDER BY day
+" "${OUTPUT_DIR}/daily.json"
+
+# 2. Cost by service, rolling 30-day window.
+#    Bar panel: x=service, y=cost_usd. Sorted high-to-low so the
+#    top spend is leftmost.
+run_query "by-service (last 30d)" "
+    SELECT service.description AS service,
+           SUM(cost) AS cost_usd
+    FROM ${TABLE}
+    WHERE usage_start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
+    GROUP BY service
+    ORDER BY cost_usd DESC
+" "${OUTPUT_DIR}/by-service.json"
+
+# 3. Cost by VM (resource.name), last 7d, Compute Engine only.
+#    Bar panel: x=vm, y=cost_usd. Filtered to Compute Engine so we
+#    aren't mixing in BigQuery/Cloud Storage/etc. resources which
+#    aren't VMs.
+run_query "by-vm (last 7d)" "
+    SELECT resource.name AS vm,
+           SUM(cost) AS cost_usd
+    FROM ${TABLE}
+    WHERE usage_start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+      AND service.description = 'Compute Engine'
+      AND resource.name IS NOT NULL
+    GROUP BY vm
+    ORDER BY cost_usd DESC
+" "${OUTPUT_DIR}/by-vm.json"
+
+# 4. Month-to-date total, single number.
+#    Stat panel showing one big USD value. Uses calendar-month
+#    boundary (DATE_TRUNC) so on the 1st of the month this snaps
+#    back to zero, then climbs over the month.
+run_query "mtd (calendar-month)" "
+    SELECT SUM(cost) AS cost_usd
+    FROM ${TABLE}
+    WHERE usage_start_time >= TIMESTAMP(DATE_TRUNC(CURRENT_DATE(), MONTH))
+" "${OUTPUT_DIR}/mtd.json"
+
+echo "==> done"

--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -22,17 +22,21 @@ on `ligate-node:9100/metrics`. Nine rows, thirty-eight panels:
   transitions = steady state; spikes during a planned failover drill
   are expected; rapid flapping or two simultaneous leaders = page
   on-call.
-- **Cost & economy** (chain#446 Track 4) — cumulative TIA burned
-  (estimate, from `ligate_da_tia_burned_nano_estimate_total`), TIA
+- **Cost & economy** (chain#446 Track 4 + chain#392) — cumulative
+  TIA burned (estimate, from
+  `ligate_da_tia_burned_nano_estimate_total`; v0.2.14 made it a
+  live-gas-price calibration instead of a fixed per-blob constant,
+  flips to authoritative when celestiaorg/lumina#974 lands), TIA
   burn rate per hour, protocol treasury balance in LGT
-  (`ligate_protocol_treasury_balance_nano`), a 4-up stat row
+  (`ligate_protocol_treasury_balance_nano`), and a 4-up stat row
   mirroring api `/v1/stats/totals` (txs / attestations / schemas /
-  attestor sets), and **GCP daily burn (USD)** sourced from the
-  VM-1 BigQuery sidecar at `https://rpc.ligate.io/cost/daily.json`
-  (see `docs/development/runbooks/gcp-billing-export.md`). The TIA
-  burn is an estimate based on a fixed per-blob constant;
-  follow-up chain#452 covers the SDK receipt extension to make it
-  authoritative.
+  attestor sets). Plus the **GCP cost sub-row** sourced from the
+  VM-1 BigQuery sidecar (see
+  `docs/development/runbooks/gcp-billing-export.md`):
+  - **GCP daily burn (USD, last 30d)** time series — `/cost/daily.json`
+  - **GCP spend by service (last 30d)** horizontal bar gauge — `/cost/by-service.json`
+  - **Compute Engine spend by VM (last 7d)** horizontal bar gauge — `/cost/by-vm.json`
+  - **GCP month-to-date burn (USD)** stat — `/cost/mtd.json`
 - **VM capacity headroom** (chain#449 follow-up) — four threshold
   stat panels colored green / amber / red so you know when to
   upsize *before* a saturation incident:

--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -1638,12 +1638,237 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_INFINITY}"
+      },
+      "description": "GCP spend by service over the last 30 days. Sourced from the VM-1 BigQuery sidecar at /var/www/cost/by-service.json, refreshed every 6h. Compute Engine + Cloud Storage are usually the top two; if anything else creeps to the top, investigate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 66
+      },
+      "id": 801,
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "displayMode": "gradient",
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_INFINITY}"
+          },
+          "type": "json",
+          "source": "url",
+          "url": "https://rpc.ligate.io/cost/by-service.json",
+          "url_options": {
+            "method": "GET"
+          },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            {
+              "selector": "service",
+              "text": "Service",
+              "type": "string"
+            },
+            {
+              "selector": "cost_usd",
+              "text": "USD",
+              "type": "number"
+            }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "GCP spend by service (last 30d)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_INFINITY}"
+      },
+      "description": "Compute Engine spend by VM (resource.name) over the last 7 days. Sourced from /var/www/cost/by-vm.json. Today on a single-VM setup this shows one row; useful when the cluster scales back out to multi-sequencer mode.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 66
+      },
+      "id": 802,
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "displayMode": "gradient",
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "showLegend": false,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_INFINITY}"
+          },
+          "type": "json",
+          "source": "url",
+          "url": "https://rpc.ligate.io/cost/by-vm.json",
+          "url_options": {
+            "method": "GET"
+          },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            {
+              "selector": "vm",
+              "text": "VM",
+              "type": "string"
+            },
+            {
+              "selector": "cost_usd",
+              "text": "USD",
+              "type": "number"
+            }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "Compute Engine spend by VM (last 7d)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_INFINITY}"
+      },
+      "description": "GCP total spend month-to-date (since the 1st of the current calendar month). Sourced from /var/www/cost/mtd.json. Snaps back to zero on the 1st of each month, then climbs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "orange",
+                "value": 400
+              },
+              {
+                "color": "red",
+                "value": 800
+              }
+            ]
+          },
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 66
+      },
+      "id": 803,
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^cost_usd$/"
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_INFINITY}"
+          },
+          "type": "json",
+          "source": "url",
+          "url": "https://rpc.ligate.io/cost/mtd.json",
+          "url_options": {
+            "method": "GET"
+          },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            {
+              "selector": "cost_usd",
+              "text": "USD",
+              "type": "number"
+            }
+          ],
+          "refId": "A"
+        }
+      ],
+      "title": "GCP month-to-date burn (USD)",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 74
       },
       "id": 700,
       "panels": [],
@@ -1687,7 +1912,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 67
+        "y": 75
       },
       "id": 23,
       "options": {
@@ -1752,7 +1977,7 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 67
+        "y": 75
       },
       "id": 24,
       "options": {
@@ -1817,7 +2042,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 67
+        "y": 75
       },
       "id": 25,
       "options": {
@@ -1881,7 +2106,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 67
+        "y": 75
       },
       "id": 26,
       "options": {
@@ -1916,7 +2141,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 82
       },
       "id": 800,
       "panels": [],
@@ -1980,7 +2205,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 75
+        "y": 83
       },
       "id": 27,
       "options": {
@@ -2085,7 +2310,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 75
+        "y": 83
       },
       "id": 28,
       "options": {
@@ -2190,7 +2415,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 75
+        "y": 83
       },
       "id": 29,
       "options": {


### PR DESCRIPTION
Closes #392.

Rounds out the Cost & economy Grafana row with three extra panels on top of the existing 'GCP daily burn' time series.

## What ships
- **`ops/billing/gcp-cost-fetch.sh`** new source-of-truth sidecar script (previously only documented inline in the runbook; now properly tracked in git). One `run_query` helper, four queries: daily, by-service, by-vm, MTD. Writes to `/var/www/cost/<name>.json` atomically via temp-file + `mv`.
- **Three new Grafana panels** in `ops/grafana/ligate-node.json` inserted into the Cost & economy row:
  - "GCP spend by service (last 30d)" — horizontal bar gauge
  - "Compute Engine spend by VM (last 7d)" — horizontal bar gauge, Compute-Engine-only
  - "GCP month-to-date burn (USD)" — single stat with green/amber/red thresholds at $200/$400/$800 (calibrated against current single-VM ~$55/mo run rate)
- Runbook + dashboard README updates pointing at the in-repo script.

## Layout impact
Inserted at y=66, h=8. Shifts the VM capacity row + everything below by +8 rows. Dashboard JSON is still valid (`python3 -c 'import json; json.load(open(...))'` passes).

## Deploy
No chain release needed. After merge, SCP the new script onto VM-1 and re-import the dashboard JSON in Grafana:

```bash
gcloud compute scp ops/billing/gcp-cost-fetch.sh \
    ligate-devnet-1-sequencer:/tmp/gcp-cost-fetch.sh --zone=us-central1-a
gcloud compute ssh ligate-devnet-1-sequencer --zone=us-central1-a --command='
    sudo install -m 0755 -o ligate -g ligate \
        /tmp/gcp-cost-fetch.sh /opt/ligate/bin/gcp-cost-fetch.sh
    sudo systemctl start gcp-cost.service
'
```

Then Grafana → Dashboards → Import → paste the updated JSON.

## Test plan
- [ ] CI green
- [ ] After deploy: `curl https://rpc.ligate.io/cost/by-service.json` returns a non-empty array
- [ ] After deploy: same for `/cost/by-vm.json` and `/cost/mtd.json`
- [ ] Grafana Cost & economy row shows 4 cost panels rendering live data