### PR TITLE
grafana: fix instance variable parse error (drop nested last_over_time)

### DIFF
--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -2499,7 +2499,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "query": "label_values(last_over_time(ligate_block_height[5m]), instance)",
+        "query": "label_values(ligate_block_height, instance)",
         "regex": "ligate-devnet-1-sequencer.*",
         "refresh": 2,
         "sort": 1,


### PR DESCRIPTION
Fix for the warning Stefan saw on the live ligate-node dashboard: `1:15: parse error: unexpected "("`.

## Root cause
The `instance` template variable's query was:

```
label_values(last_over_time(ligate_block_height[5m]), instance)
```

Grafana's variable parser doesn't accept nested function calls inside `label_values()` — it only accepts a metric name or a metric+selectors. The PromQL parser sees the inner `last_over_time(` at column 15 and trips.

The nested form was added in commit `b984650` to filter out stopped VM-2/VM-3 from the instance picker. Since the multi-sequencer tear-down (chain v0.2.10), there's only one VM, so the staleness filter is doing nothing useful anyway.

## Fix
Revert to the simple form:

```
label_values(ligate_block_height, instance)
```

Prometheus's natural series staleness (5-minute default) drops the dropdown to active-only instances automatically — same end behaviour without the parser-breaking syntax.

## Live dashboard already updated
Pushed via the Grafana API (`POST /api/dashboards/db`); the live dashboard is now at version 3 with the fix applied and the 3 new GCP cost panels from chain#473 included. This PR catches the source-of-truth file up to the live state.

## Test plan
- [ ] Hover the variable warning icon on https://ligate.grafana.net/d/ligate-node — should be gone
- [ ] Re-import `ops/grafana/ligate-node.json` and confirm the dashboard renders cleanly