### PR TITLE
grafana: fix No-data panels on moved dashboards + fill engineering

### DIFF
--- a/ops/grafana/ligate-devnet-1-cost.json
+++ b/ops/grafana/ligate-devnet-1-cost.json
@@ -418,22 +418,22 @@
       "type": "timeseries"
     },
     {
-      "type": "row",
       "collapsed": false,
-      "id": 9000,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 21
       },
+      "id": 9000,
       "panels": [],
-      "title": "DA + infra spend (moved from engineering dashboard)"
+      "title": "DA + infra spend (moved from engineering dashboard)",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "ESTIMATED cumulative TIA burned posting blobs to Celestia DA, in TIA (converted from nanoTIA via `/1e9`). The estimate uses a fixed per-blob constant baked into the chain binary; under-counts once blob sizes grow. See HELP on `ligate_da_tia_burned_nano_estimate_total`.",
       "fieldConfig": {
@@ -476,7 +476,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "max(ligate_da_tia_burned_nano_estimate_total{instance=~\"$instance\"}) / 1e9",
           "legendFormat": "TIA (est)",
@@ -489,7 +489,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "TIA burn rate over 5-minute windows, scaled to TIA/hour. Estimate. Steady-state value is `(blobs/hr) \u00d7 (per-blob estimate)`.",
       "fieldConfig": {
@@ -530,7 +530,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "rate(ligate_da_tia_burned_nano_estimate_total{instance=~\"$instance\"}[5m]) * 3600 / 1e9",
           "legendFormat": "{{instance}} (TIA/hr est.)",
@@ -543,7 +543,7 @@
     {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "${DS_INFINITY}"
+        "uid": "afm64tqkoba4ga"
       },
       "description": "Total daily GCP infrastructure spend, USD. Sourced from Cloud Billing \u2192 BigQuery export \u2192 /opt/ligate/bin/gcp-cost-fetch.sh on VM-1 (refreshed every 6h via systemd timer) \u2192 https://rpc.ligate.io/cost/daily.json. Returns [] until ~24h after Console enable, then populates rolling 30-day window.",
       "fieldConfig": {
@@ -600,7 +600,7 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_INFINITY}"
+            "uid": "afm64tqkoba4ga"
           },
           "format": "timeseries",
           "refId": "A",
@@ -619,7 +619,7 @@
     {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "${DS_INFINITY}"
+        "uid": "afm64tqkoba4ga"
       },
       "description": "GCP spend by service over the last 30 days. Sourced from the VM-1 BigQuery sidecar at /var/www/cost/by-service.json, refreshed every 6h. Compute Engine + Cloud Storage are usually the top two; if anything else creeps to the top, investigate.",
       "fieldConfig": {
@@ -670,7 +670,7 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_INFINITY}"
+            "uid": "afm64tqkoba4ga"
           },
           "format": "table",
           "refId": "A",
@@ -689,7 +689,7 @@
     {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "${DS_INFINITY}"
+        "uid": "afm64tqkoba4ga"
       },
       "description": "Compute Engine spend by VM (resource.name) over the last 7 days. Sourced from /var/www/cost/by-vm.json. Today on a single-VM setup this shows one row; useful when the cluster scales back out to multi-sequencer mode.",
       "fieldConfig": {
@@ -740,7 +740,7 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_INFINITY}"
+            "uid": "afm64tqkoba4ga"
           },
           "format": "table",
           "refId": "A",
@@ -759,7 +759,7 @@
     {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "${DS_INFINITY}"
+        "uid": "afm64tqkoba4ga"
       },
       "description": "GCP total spend month-to-date (since the 1st of the current calendar month). Sourced from /var/www/cost/mtd.json. Snaps back to zero on the 1st of each month, then climbs.",
       "fieldConfig": {
@@ -825,7 +825,7 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_INFINITY}"
+            "uid": "afm64tqkoba4ga"
           },
           "format": "table",
           "refId": "A",
@@ -891,5 +891,5 @@
   "timezone": "utc",
   "title": "Ligate Devnet \u2014 Cost monitoring",
   "uid": "ligate-devnet-1-cost",
-  "version": 11
+  "version": 13
 }

--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -73,7 +73,59 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Chain head slot number. Should climb monotonically. Flat for >30s means block production stalled.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 803,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "ligate_block_height{instance=\"ligate-devnet-1-sequencer\"}",
+          "legendFormat": "head slot",
+          "refId": "A"
+        }
+      ],
+      "title": "Block height",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
       },
       "description": "Per-second rate of accepted `submit_attestation` transactions (5m window). Headline metric for chain throughput.",
       "fieldConfig": {
@@ -126,7 +178,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "rate(ligate_attestations_submitted_total{instance=~\"$instance\"}[5m])",
           "legendFormat": "attestations / sec",
@@ -152,7 +204,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "Pending tx count in the sequencer mempool. Sustained growth means the chain isn't including txs as fast as they arrive (DA throughput, validator stalls, or a publish backlog).",
       "fieldConfig": {
@@ -211,7 +263,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "ligate_mempool_depth{instance=~\"$instance\"}",
           "legendFormat": "pending txs",
@@ -224,7 +276,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "Total on-disk allocation under `storage.path` (NOMT + RocksDB ledger + state-db). Reports actual on-disk allocation via `meta.blocks() * 512`, not nominal logical size.",
       "fieldConfig": {
@@ -283,7 +335,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "ligate_state_db_size_bytes{instance=~\"$instance\"}",
           "legendFormat": "state db",
@@ -309,7 +361,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "Rate of DA submission failures by typed-error discriminant. Non-zero is operator-actionable. Reasons: `submission` (RPC error), `publish_timeout` (no inclusion within deadline), `reorg` (DA re-org), `finality_check` (finality query failed), `max_retries_exhausted` (rollup shutdown).",
       "fieldConfig": {
@@ -367,7 +419,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "sum by (reason) (rate(ligate_da_submission_failures_total{instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{reason}}",
@@ -380,7 +432,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "DA finalization latency: time from `Published` to `Finalized` for each blob. Mocha block time ~12s. Rising p99 means Celestia is slow to finalize, often a sign the network is congested or our light node is lagging.",
       "fieldConfig": {
@@ -439,7 +491,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "histogram_quantile(0.50, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))",
           "legendFormat": "p50",
@@ -448,7 +500,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "histogram_quantile(0.95, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))",
           "legendFormat": "p95",
@@ -457,7 +509,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "histogram_quantile(0.99, sum by (le) (rate(ligate_da_finalization_latency_seconds_bucket{instance=~\"$instance\"}[5m])))",
           "legendFormat": "p99",
@@ -468,12 +520,116 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Authoritative bytes posted to Celestia per second. From SubmitBlobReceipt.size_in_bytes via chain v0.2.12+. Drops to 0 when no blobs publish; climbs when attestation payloads grow.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "unit": "Bps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 801,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "rate(ligate_da_blob_bytes_total{instance=\"ligate-devnet-1-sequencer\"}[5m])",
+          "legendFormat": "bytes/sec",
+          "refId": "A"
+        }
+      ],
+      "title": "DA blob bytes posted (rate, B/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Rate of blobs reaching Celestia `Published` state. Useful denominator for cost-per-blob and the rate-of-publishing health signal.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 802,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "rate(ligate_da_blobs_published_total{instance=\"ligate-devnet-1-sequencer\"}[5m]) * 60",
+          "legendFormat": "blobs/min",
+          "refId": "A"
+        }
+      ],
+      "title": "Blobs published (rate, per min)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 30
       },
       "id": 300,
       "panels": [],
@@ -483,7 +639,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "Top rejection reasons over the last hour. Each `reason` is one of the stable snake_case discriminants on `AttestationError`.",
       "fieldConfig": {
@@ -516,7 +672,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 31
       },
       "id": 7,
       "options": {
@@ -537,7 +693,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "topk(10, sum by (reason) (rate(ligate_attestations_rejected_total{instance=~\"$instance\"}[1h])))",
           "legendFormat": "{{reason}}",
@@ -553,7 +709,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 47
       },
       "id": 500,
       "panels": [],
@@ -563,7 +719,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "Current sequencer role on each VM (`ligate_sequencer_role`). 0 = unknown (chain HTTP unreachable / still booting), 1 = PgSyncReplica (following leader via Postgres state-sync), 2 = BatchProducer (this node holds the leader lock and posts blobs to DA). Exactly one VM should show `BatchProducer` at any time; two simultaneously = split-brain (page on-call), zero = leaderless (page on-call after 30s).",
       "fieldConfig": {
@@ -624,7 +780,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 41
+        "y": 48
       },
       "id": 16,
       "options": {
@@ -644,7 +800,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "ligate_sequencer_role{instance=~\"$instance\"}",
           "legendFormat": "{{instance}}",
@@ -657,7 +813,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "grafanacloud-prom"
       },
       "description": "Rate of sequencer-role transitions over 5-minute windows. Steady state should be flat at zero; a spike means a failover happened. Healthy failover drill: one `leader -> replica` and one `replica -> leader` within the same minute. Anything more chatty (rapid back-and-forth) is split-brain / flapping \u2014 page on-call.",
       "fieldConfig": {
@@ -679,7 +835,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 41
+        "y": 48
       },
       "id": 17,
       "options": {
@@ -699,7 +855,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "grafanacloud-prom"
           },
           "expr": "sum by (instance, from, to) (rate(ligate_sequencer_role_transitions_total{instance=~\"$instance\"}[5m]))",
           "legendFormat": "{{instance}}: {{from}} -> {{to}}",
@@ -715,7 +871,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 89
       },
       "id": 800,
       "panels": [],
@@ -725,7 +881,7 @@
     {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "${DS_INFINITY}"
+        "uid": "afm64tqkoba4ga"
       },
       "description": "Addresses ranked by total attestations submitted (api: GET /v1/stats/top-attesters). All-time count.",
       "fieldConfig": {
@@ -779,7 +935,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 83
+        "y": 90
       },
       "id": 27,
       "options": {
@@ -811,7 +967,7 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_INFINITY}"
+            "uid": "afm64tqkoba4ga"
           },
           "format": "table",
           "refId": "A",
@@ -830,7 +986,7 @@
     {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "${DS_INFINITY}"
+        "uid": "afm64tqkoba4ga"
       },
       "description": "Addresses ranked by schemas registered (api: GET /v1/stats/top-schema-owners). All-time count.",
       "fieldConfig": {
@@ -884,7 +1040,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 83
+        "y": 90
       },
       "id": 28,
       "options": {
@@ -916,7 +1072,7 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_INFINITY}"
+            "uid": "afm64tqkoba4ga"
           },
           "format": "table",
           "refId": "A",
@@ -935,7 +1091,7 @@
     {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "${DS_INFINITY}"
+        "uid": "afm64tqkoba4ga"
       },
       "description": "Attestor sets (las1...) ranked by `schema_count` (denormalised on chain, single index scan in the api). The most popular sets are the most-bound-to.",
       "fieldConfig": {
@@ -989,7 +1145,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 83
+        "y": 90
       },
       "id": 29,
       "options": {
@@ -1021,7 +1177,7 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_INFINITY}"
+            "uid": "afm64tqkoba4ga"
           },
           "format": "table",
           "refId": "A",
@@ -1078,7 +1234,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "grafanacloud-prom"
         },
         "includeAll": true,
         "label": "Sequencer instance",
@@ -1100,6 +1256,6 @@
   "timezone": "",
   "title": "Ligate Chain \u2014 Engineering",
   "uid": "ligate-node",
-  "version": 3,
+  "version": 6,
   "weekStart": ""
 }

--- a/ops/grafana/ligate-operator.json
+++ b/ops/grafana/ligate-operator.json
@@ -2231,17 +2231,17 @@
       "type": "stat"
     },
     {
-      "type": "row",
       "collapsed": false,
-      "id": 9001,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 79
       },
+      "id": 9001,
       "panels": [],
-      "title": "VM capacity headroom (when do we need a bigger plan?)"
+      "title": "VM capacity headroom (when do we need a bigger plan?)",
+      "type": "row"
     },
     {
       "datasource": {
@@ -2301,7 +2301,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[5m])",
+          "expr": "rate(process_cpu_seconds_total{instance=\"ligate-devnet-1-sequencer\"}[5m])",
           "legendFormat": "{{instance}} cores",
           "refId": "A"
         }
@@ -2366,7 +2366,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
+          "expr": "process_resident_memory_bytes{instance=\"ligate-devnet-1-sequencer\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -2431,7 +2431,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "ligate_state_db_size_bytes{instance=~\"$instance\"}",
+          "expr": "ligate_state_db_size_bytes{instance=\"ligate-devnet-1-sequencer\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -2495,7 +2495,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "process_open_fds{instance=~\"$instance\"}",
+          "expr": "process_open_fds{instance=\"ligate-devnet-1-sequencer\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -2522,5 +2522,5 @@
   "timezone": "browser",
   "title": "Ligate Devnet \u2014 Operator view",
   "uid": "ligate-operator",
-  "version": 4
+  "version": 6
 }


### PR DESCRIPTION
Fixes the three No-data issues Stefan saw on the live dashboards after the chain#476 reorg, plus fills the engineering dashboard's sparse rows with useful DA throughput panels.

## What was broken
1. **Cost dashboard — TIA burn + GCP cost panels showed No data**. The panels I moved over from ligate-node referenced `${DS_PROMETHEUS}` and `${DS_INFINITY}` template variables, but the cost dashboard doesn't define those (it uses literal datasource UIDs). Templates didn't resolve, datasource ended up unset, queries silently returned nothing.
2. **Operator dashboard — VM capacity headroom row showed No data on all 4 panels**. The moved panels filtered on `instance=~"$instance"` but operator has zero template variables defined, so `$instance` never resolved.
3. **Engineering dashboard — activity leaders (Top attesters / schema owners / attestor sets) showed No data**. Same `${DS_INFINITY}` template variable issue, pre-existing but only surfaced after the reorg drew attention.

## Fix
- Replace template-variable datasource refs with literal UIDs:
  - `${DS_PROMETHEUS}` → `grafanacloud-prom`
  - `${DS_INFINITY}` → `afm64tqkoba4ga` (the Infinity datasource pointed at api.ligate.io, same one the investor dashboard already uses)
- Replace `instance=~"$instance"` → `instance="ligate-devnet-1-sequencer"` for the moved-to-operator panels (single-VM mode, no need for a query variable)

## Filler panels (engineering dashboard had visible empty space)
- **Block height** time series — chronological view of head slot, complements the operator's stat
- **DA blob bytes posted (rate, B/s)** — authoritative bytes/sec going to Celestia from `ligate_da_blob_bytes_total`
- **Blobs published (rate, per min)** — companion rate counter

Engineering goes from 13 → 14 panels (block height ts gets added to Chain activity row; DA throughput pair gets inserted after the existing DA layer panels).

## Live dashboards already pushed
- ligate-node: v5 → v6 (datasource fix + 3 filler panels)
- ligate-operator: v5 → v6 (instance filter fix)
- ligate-devnet-1-cost: v12 → v13 (datasource fix)
- ligate-investor: v1 (unchanged)

## What's still No-data (expected)
GCP cost panels (daily / by-service / by-vm / mtd) still show empty data because the BigQuery export hasn't populated yet. Verified earlier:

```
/cost/daily.json:      []
/cost/by-service.json: []
/cost/by-vm.json:      []
/cost/mtd.json:        [{"cost_usd":null}]
```

This is a Cloud Billing → BigQuery export propagation issue (enabled 2026-05-22, still not flowing 2026-05-24 — longer than the documented 24-48h lag). Tracked separately; the dashboards are correctly wired and will populate as soon as the export does.

## Test plan
- [ ] CI green
- [ ] Reload all 4 dashboards — every panel that has source data renders. Only the GCP cost panels stay No-data, and that's a Cloud Billing issue, not Grafana.