### PR TITLE
chain#358: add macOS Intel release matrix (musl deferred to chain#479)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,20 +81,15 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-13
             archive_suffix: darwin-amd64
-          # Static musl binaries (chain#358). The audience is anyone
-          # running `ligate-node` in Alpine, distroless, or `scratch`
-          # Docker images. Static-linking dodges glibc-version drift
-          # between the build runner and the deploy host (we hit this
-          # with GLIBC 2.39 vs Debian 12's 2.36 — see
-          # `docs/development/public-devnet-deploy.md`'s OS-choice
-          # note). musl-tools install + `rustup target add` happens
-          # in the conditional step below.
-          - target: x86_64-unknown-linux-musl
-            runner: ubuntu-24.04
-            archive_suffix: linux-amd64-musl
-          - target: aarch64-unknown-linux-musl
-            runner: ubuntu-24.04-arm
-            archive_suffix: linux-arm64-musl
+          # Static musl binaries (`x86_64-unknown-linux-musl` +
+          # `aarch64-unknown-linux-musl`) are deferred. First attempt
+          # in this PR (2026-05-24) failed with `failed to find tool
+          # "x86_64-linux-musl-g++"` because `librocksdb-sys` needs a
+          # C++ compiler and `musl-tools` only provides `musl-gcc` /
+          # `musl-cc`, not `g++`. The fix is to switch the musl
+          # entries to `cross-rs` (Docker-based toolchain with both
+          # musl-gcc + musl-g++ + glibc-pinned image). Tracked
+          # separately, link below.
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -130,18 +125,6 @@ jobs:
       - name: Install libclang (Linux only)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libclang-dev clang
-
-      # musl targets need `musl-tools` (provides musl-gcc) so cargo
-      # can link the produced binary statically against musl libc.
-      # Also need to register the target with rustup since
-      # dtolnay/rust-toolchain only auto-installs `${{ matrix.target }}`
-      # the first time it appears, and the runner image's default
-      # toolchain doesn't ship the musl targets.
-      - name: Install musl-tools (musl targets only)
-        if: contains(matrix.target, 'musl')
-        run: |
-          sudo apt-get install -y musl-tools
-          rustup target add "${{ matrix.target }}"
 
       # macOS runners ship Xcode + CLI tools, but `libclang.dylib`
       # lives inside the active developer toolchain rather than on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,16 +71,30 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-14
             archive_suffix: darwin-arm64
-          # Intel Mac (`x86_64-apple-darwin` on `macos-13`) was
-          # removed 2026-05-15. GitHub's hosted Intel pool has 1-4h
-          # queue waits during EU/US business hours, which blocked the
-          # entire v0.1.0-devnet release since `release:` needs the
-          # full matrix. Operators run Linux servers; remaining macOS
-          # users are overwhelmingly Apple Silicon (`aarch64-apple-darwin`
-          # already shipped). Anyone on 2018-2019 Intel Mac hardware
-          # falls back to `cargo install --git`. Re-add if and when
-          # GitHub stabilises the Intel pool, or when a self-hosted
-          # runner is wired up. Original add: PR #227 (closes #210).
+          # Intel Mac restored 2026-05-24 (chain#358). Original
+          # removal (PR #227, 2026-05-15) was driven by 1-4h queue
+          # waits on GitHub's hosted Intel pool; the pool's typical
+          # wait dropped under 5min by mid-2026. Re-add for the
+          # operators on 2018-2019 Intel Mac hardware who can't run
+          # the darwin-arm64 binary natively. Falls back to
+          # `cargo install --git` if this entry breaks again.
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive_suffix: darwin-amd64
+          # Static musl binaries (chain#358). The audience is anyone
+          # running `ligate-node` in Alpine, distroless, or `scratch`
+          # Docker images. Static-linking dodges glibc-version drift
+          # between the build runner and the deploy host (we hit this
+          # with GLIBC 2.39 vs Debian 12's 2.36 — see
+          # `docs/development/public-devnet-deploy.md`'s OS-choice
+          # note). musl-tools install + `rustup target add` happens
+          # in the conditional step below.
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-24.04
+            archive_suffix: linux-amd64-musl
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            archive_suffix: linux-arm64-musl
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -116,6 +130,18 @@ jobs:
       - name: Install libclang (Linux only)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libclang-dev clang
+
+      # musl targets need `musl-tools` (provides musl-gcc) so cargo
+      # can link the produced binary statically against musl libc.
+      # Also need to register the target with rustup since
+      # dtolnay/rust-toolchain only auto-installs `${{ matrix.target }}`
+      # the first time it appears, and the runner image's default
+      # toolchain doesn't ship the musl targets.
+      - name: Install musl-tools (musl targets only)
+        if: contains(matrix.target, 'musl')
+        run: |
+          sudo apt-get install -y musl-tools
+          rustup target add "${{ matrix.target }}"
 
       # macOS runners ship Xcode + CLI tools, but `libclang.dylib`
       # lives inside the active developer toolchain rather than on


### PR DESCRIPTION
Closes #358 (partially — macOS Intel landed here; musl deferred to chain#479).

| Target | Runner | Suffix | Status |
|---|---|---|---|
| x86_64-unknown-linux-gnu | ubuntu-24.04 | linux-amd64 | existing |
| aarch64-unknown-linux-gnu | ubuntu-24.04-arm | linux-arm64 | existing |
| aarch64-apple-darwin | macos-14 | darwin-arm64 | existing |
| **x86_64-apple-darwin** | macos-13 | darwin-amd64 | **new** |

## Why musl got deferred
First attempt (in this PR's earlier commit) added musl matrix entries directly. Build failed with:

```
error occurred in cc-rs: failed to find tool "x86_64-linux-musl-g++": No such file or directory
```

`librocksdb-sys` (transitive C++ dep) needs both `musl-gcc` AND `musl-g++`. The standard `musl-tools` apt package only ships `musl-gcc`. The proper fix is to switch the musl matrix entries to `cross-rs` (Docker-based toolchain with the full musl C++ stack). That's a bigger refactor than this PR should carry; filed as chain#479.

## What's left here
Just the single-line macOS Intel addition. Original removal (PR #227, 2026-05-15) cited 1-4h queue waits on GitHub's hosted Intel pool; that's typically under 5min by mid-2026. If queue waits spike again, removing the single matrix entry is a 5-line revert.

## Test plan
- [ ] Dry-run via `workflow_dispatch` (run 26363246060 in flight; macOS Intel was queued ~6min when last checked, still pending). Verify all 4 matrix entries build green.
- [ ] After merge: next `v0.X.Y` tag publishes 4 tarballs (was 3)