### PR TITLE
chain#345: build linux binaries on ubuntu-22.04 (GLIBC 2.35) for wider compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux gnu builds run on ubuntu-22.04 (GLIBC 2.35) instead
+          # of the latest ubuntu-24.04 (GLIBC 2.39) so the produced
+          # binaries work on the common Linux server distros operators
+          # actually run. glibc is forward-compatible (binary works
+          # on newer glibc) but NOT backward-compatible — a binary
+          # built on 24.04 won't load on Debian 12 (GLIBC 2.36),
+          # Ubuntu 22.04 (2.35), RHEL 9 (2.34), or Amazon Linux 2023
+          # (2.34). Bug originally surfaced on v0.1.0-devnet's first
+          # Debian 12 deploy (chain#345). Building on 22.04 covers
+          # all of those; the few operators on bleeding-edge distros
+          # have glibc ≥2.35 anyway. Once an operator-relevant distro
+          # drops 2.35 support we revisit.
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
             archive_suffix: linux-amd64
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             archive_suffix: linux-arm64
           - target: aarch64-apple-darwin
             runner: macos-14

--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -47,7 +47,7 @@ Faucet and indexer **do not run on this VM**; they live in [`ligate-io/ligate-ap
 
 Persistent data disk can be **live-resized without downtime** via `gcloud compute disks resize` + `resize2fs /dev/sdb`; ext4 supports online growth. Done on `ligate-devnet-1-sequencer` on 2026-05-16 (50GB → 150GB) when local snapshot accumulation projected to fill the original 50GB within ~24h.
 
-**OS choice: Ubuntu 24.04 LTS, not Debian 12.** The released `ligate-node` binary is built on Ubuntu 24.04 and links against GLIBC 2.39. Debian 12 ships GLIBC 2.36, so the binary fails to load with `version GLIBC_2.39 not found`. If you want Debian for some reason, build from source (`cargo build --release --bin ligate-node`) on the same Debian VM, but that pulls in a Rust toolchain + ~30 min of compile time. Ubuntu is the pragmatic default.
+**OS choice.** As of chain#345 the released `ligate-node` Linux binary is built on Ubuntu 22.04 (GLIBC 2.35), so it runs cleanly on every common server distro: Ubuntu 22.04+, Debian 12+, RHEL 9, Amazon Linux 2023. Older distros (GLIBC <2.35) still need a from-source build. Ubuntu 24.04 stays the canonical operator choice for the rest of the runbook because cloud-init + GCP image families are stable on it, but Debian 12 works fine too if you prefer.
 
 ## Step 1: Provision the VM
 


### PR DESCRIPTION
Closes #345.

## The change
Switch the two linux-gnu matrix entries in `.github/workflows/release.yml`:

| | Before | After |
|---|---|---|
| x86_64-unknown-linux-gnu | `ubuntu-24.04` (GLIBC 2.39) | `ubuntu-22.04` (GLIBC 2.35) |
| aarch64-unknown-linux-gnu | `ubuntu-24.04-arm` (GLIBC 2.39) | `ubuntu-22.04-arm` (GLIBC 2.35) |

That's it for the build side. macOS targets are unaffected.

## Why it matters
glibc is forward-compatible (binary works on newer glibc) but not backward. Today's binary built on GLIBC 2.39 fails to load on:

| Distro | glibc | Was the binary loading? |
|---|---|---|
| Debian 12 (bookworm) | 2.36 | ❌ `version GLIBC_2.39 not found` |
| Ubuntu 22.04 LTS | 2.35 | ❌ |
| RHEL 9 / CentOS Stream 9 | 2.34 | ❌ |
| Amazon Linux 2023 | 2.34 | ❌ |
| Ubuntu 24.04 LTS | 2.39 | ✅ |

After this PR, all of those work. The only systems left out are anything pre-2022 (Ubuntu 20.04, CentOS 7, etc.) — at this point those need a from-source build, which is the same recommendation we already make for unusual distros.

## Docs
Updated `docs/development/public-devnet-deploy.md`'s OS-choice note to reflect the new compat surface. Companion docs.ligate.io update in https://github.com/ligate-io/docs/pull/TBD (Linux binary install Note + errors.mdx GLIBC entry).

## Test plan
- [ ] CI green
- [ ] After merge: cut a tag and verify a fresh Debian 12 VM can run `ligate-node --version` from the new release tarball without `GLIBC_2.NN not found` errors

## Followup not touched here
chain#479 (musl static binaries via cross-rs) covers Alpine + scratch Docker image users who don't use glibc at all. Different audience, different fix.