### PR TITLE
chain#479: add static musl binaries via cross-rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,32 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             archive_suffix: linux-amd64
+            use_cross: false
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             archive_suffix: linux-arm64
+            use_cross: false
           - target: aarch64-apple-darwin
             runner: macos-14
             archive_suffix: darwin-arm64
+            use_cross: false
+          # Static musl binaries (chain#479). Audience: Alpine /
+          # distroless / `scratch` Docker image operators who don't
+          # have glibc at all. Built via `cross-rs` because
+          # `librocksdb-sys` (transitive C++ dep) needs musl-g++ as
+          # well as musl-gcc, and Ubuntu's `musl-tools` apt package
+          # only ships musl-gcc. cross-rs runs the build inside a
+          # Docker image with the full musl C++ toolchain, dodging
+          # the missing-tool error that killed the first attempt at
+          # this in chain#358 / PR #478.
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-22.04
+            archive_suffix: linux-amd64-musl
+            use_cross: true
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-22.04-arm
+            archive_suffix: linux-arm64-musl
+            use_cross: true
           # Intel Mac (`x86_64-apple-darwin` on `macos-13`) was
           # removed 2026-05-15. GitHub's hosted Intel pool has 1-4h
           # queue waits during EU/US business hours, which blocked the
@@ -165,10 +185,35 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-cargo-release-
 
-      - name: Build ligate-node (release)
+      # cross-rs runs the build inside a per-target Docker image with
+      # the full toolchain (incl. musl-g++ for librocksdb-sys). Only
+      # installed for musl jobs; native gnu/darwin jobs build with
+      # plain `cargo`. `--locked` pins cross to the version recorded
+      # in its own Cargo.lock so a surprise upstream release can't
+      # break a release build.
+      - name: Install cross-rs (musl targets only)
+        if: matrix.use_cross
+        shell: bash
+        run: cargo install cross --locked
+
+      - name: Build ligate-node with cargo (native targets)
+        if: ${{ !matrix.use_cross }}
         shell: bash
         run: |
           cargo build --release --bin ligate-node --target "${{ matrix.target }}"
+
+      - name: Build ligate-node with cross (musl targets)
+        if: matrix.use_cross
+        shell: bash
+        env:
+          # cross-rs reads SKIP_GUEST_BUILD via Cross.toml's
+          # `passthrough` list (see Cross.toml at repo root). Without
+          # the passthrough the env var is dropped at the container
+          # boundary and the guest build would re-attempt inside the
+          # musl image (no risc0 toolchain there → fail).
+          SKIP_GUEST_BUILD: "1"
+        run: |
+          cross build --release --bin ligate-node --target "${{ matrix.target }}"
 
       - name: Strip + package
         id: package

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,18 @@
+# cross-rs configuration. Used by the release workflow's musl matrix
+# entries (chain#479). The default cross images for the musl targets
+# already ship a working musl-gcc / musl-g++ toolchain that
+# `librocksdb-sys` can drive directly; the only thing we need from
+# this file is the env-var passthrough.
+#
+# `SKIP_GUEST_BUILD=1` matches the env block in `ci.yml` / `release.yml`
+# and tells the risc0 build script to skip compiling the zk guest.
+# Without `passthrough` cross-rs strips it at the container boundary
+# (env doesn't auto-propagate; see cross-rs docs §"Environment
+# variables passthrough") and the build then tries to invoke the
+# risc0 toolchain inside the musl image, which doesn't have it.
+
+[build.env]
+passthrough = [
+    "SKIP_GUEST_BUILD",
+    "CARGO_TERM_COLOR",
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,18 +1,32 @@
 # cross-rs configuration. Used by the release workflow's musl matrix
-# entries (chain#479). The default cross images for the musl targets
-# already ship a working musl-gcc / musl-g++ toolchain that
-# `librocksdb-sys` can drive directly; the only thing we need from
-# this file is the env-var passthrough.
+# entries (chain#479).
 #
-# `SKIP_GUEST_BUILD=1` matches the env block in `ci.yml` / `release.yml`
-# and tells the risc0 build script to skip compiling the zk guest.
-# Without `passthrough` cross-rs strips it at the container boundary
-# (env doesn't auto-propagate; see cross-rs docs §"Environment
-# variables passthrough") and the build then tries to invoke the
-# risc0 toolchain inside the musl image, which doesn't have it.
+# Image pin (`:main`): cross 0.2.5's default musl images are based on
+# Ubuntu 18.04 and ship libclang-10. `librocksdb-sys`'s build script
+# uses `bindgen` ≥0.69 which calls `clang_Type_getValueType`, a
+# symbol only added in libclang ≥12. Without this pin the build
+# fails with `rust-lld: error: undefined symbol:
+# clang_Type_getValueType`. The `:main` tag follows the cross-rs
+# `main` branch (Ubuntu 22.04 base, libclang-14) and is the
+# documented fix in cross-rs's own troubleshooting docs
+# (https://github.com/cross-rs/cross/wiki/Recipes).
+#
+# `SKIP_GUEST_BUILD=1` matches the env block in `ci.yml` /
+# `release.yml` and tells the risc0 build script to skip compiling
+# the zk guest. Without `passthrough` cross-rs strips it at the
+# container boundary (env doesn't auto-propagate; see cross-rs docs
+# §"Environment variables passthrough") and the build then tries to
+# invoke the risc0 toolchain inside the musl image, which doesn't
+# have it.
 
 [build.env]
 passthrough = [
     "SKIP_GUEST_BUILD",
     "CARGO_TERM_COLOR",
 ]
+
+[target.x86_64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:main"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"


### PR DESCRIPTION
Closes #479.

Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the release matrix. Statically-linked tarballs for operators on Alpine, distroless, or `scratch` Docker images who have no glibc at all.

## Why cross-rs

First attempt (PR #478) used Ubuntu's `musl-tools` apt package. That ships `musl-gcc` but not `musl-g++`, and `librocksdb-sys` (transitive C++ dep) needs the C++ compiler. Build fails with:

```
error occurred in cc-rs: failed to find tool "x86_64-linux-musl-g++"
```

`cross-rs` runs the build inside a per-target Docker image with the full musl C++ toolchain pre-installed. Same machinery the Rust release team uses for the official musl artifacts.

## Diff

- `release.yml`: added `use_cross` matrix flag; 3 existing entries get `use_cross: false` (cargo); 2 new musl entries get `use_cross: true` (cross). Split the single build step into 3: install cross-rs (conditional), build with cargo (native), build with cross (musl).
- `Cross.toml` (new): passes `SKIP_GUEST_BUILD` + `CARGO_TERM_COLOR` through the container boundary so the risc0 guest stays skipped inside the musl image (no risc0 toolchain there).

## Test plan

- [ ] PR push exercises all 5 matrix entries (3 cargo + 2 cross) via the `build:` job, which has no tag gate.
- [ ] Both new musl entries produce a stripped tarball + `.sha256` artifact.
- [ ] No regression on the 3 existing entries (linux-gnu x64/arm64, darwin-arm64).
- [ ] Tarballs only ship to a Release on the next tag push (next planned: `v0.3.0`).