### PR TITLE
chain: prepare v0.3.0 release ($LGT → AVOW rename + localnet restructure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-25
+
+Token rename + naming cleanup. The native token symbol moves from `$LGT` to bare `AVOW` (drops the leading `$` from the prose ticker per the cleaner convention), and the misnamed `devnet/` directory (actually the localnet config) becomes `localnet/`. Both are state-breaking on the wire and require a fresh devnet boot (`ligate-devnet-2`) to consume them. Mainnet is not yet live; this is the moment to do these renames cleanly. Cross-repo coordination tracked under [#457](https://github.com/ligate-io/ligate-chain/issues/457).
+
 ### Changed
 
 - **Network directory restructure**: `devnet/` → `localnet/`. The old `devnet/` directory was actually the *localnet* config (MockDa, `chain_id = "ligate-localnet"`), confusingly named because it predated the `devnet-N/` numbered ladder. Rename adopts the role-based stable-path convention every mature chain uses (Solana, Sui, Aptos, Cosmos): the path describes what it is, the `chain_id` inside the TOML carries the network identity. Future network rollovers (devnet-2, testnet-1, mainnet-1) drop into siblings with stable paths; dead networks move to `archive/`. Test source files `crates/stf/tests/devnet_addresses.rs` and `crates/rollup/tests/devnet_config.rs` renamed to `localnet_*` to match. `devnet-1/` is unchanged (real public devnet, distinct concept). Touches 47 files; operators who scripted `cargo run ... --rollup-config-path devnet/rollup.toml` now use `localnet/rollup.toml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-bootstrap-cli"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-client"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-genesis-tool"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-prover-risc0"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "risc0-build",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-rollup"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "ligate-stf-declaration"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "attestation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = ["Ligate Labs <hello@ligate.io>"]


### PR DESCRIPTION
Release-prep PR. Bumps workspace `Cargo.toml` from `0.2.14` → `0.3.0` and folds the `[Unreleased]` CHANGELOG entries into a versioned `[0.3.0] - 2026-05-25` section.

Content was already merged in #482 ($LGT → AVOW token rename) and #483 (devnet/ → localnet/ directory restructure + drop $ prefix from AVOW ticker). This PR is the version-bump + changelog-fold housekeeping that makes the next tag publish cleanly.

## Why v0.3.0 (not v0.2.15)

- Genesis JSON shape break (`lgt_token_id` → `avow_token_id`)
- REST endpoint path break (`/lgt-token-id` → `/avow-token-id`)
- Wire-level + `chain_hash` break overall
- Forces fresh devnet boot (`ligate-devnet-2`) to consume

This is the first state-breaking release since the chain went public; minor bump matches the chain-release-cadence convention ("accumulate, tag only when there's a story").

## After this merges

1. Tag `v0.3.0` from main
2. `release.yml` builds + publishes Linux x64/arm64 + darwin-arm64 tarballs to GitHub Releases
3. `bump-versions.yml` auto-PRs across `ligate-io/docs`, `ligate-marketing`, and self-bump in `ligate-chain` for the new version string
4. Downstream code repos (cli, js, api, explorer) start their renames against the published `v0.3.0` chain crate / REST surface
5. `ligate-devnet-1` keeps running `v0.2.14` (no deploy from this tag). Devnet-2 cutover lands in a separate ops window when downstream is ready.

## Test plan

- [ ] CI green
- [ ] Tag push triggers `release.yml` and publishes 3 tarballs + sha256 sidecars
- [ ] Release notes pull the new `[0.3.0]` section from CHANGELOG.md
- [ ] `bump-versions.yml` opens auto-PRs in docs + marketing