### PR TITLE
ci(cla): add proofmancer to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,4 +29,4 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/ligate-io/ligate-chain/blob/main/CLA.md'
           branch: 'cla/signatures'
-          allowlist: 'sstefdev,dependabot[bot],*[bot]'
+          allowlist: 'proofmancer,sstefdev,dependabot[bot],*[bot]'


### PR DESCRIPTION
Codeowner GitHub handle is proofmancer; allowlist only had sstefdev (local git author name) which never matches.