### PR TITLE
chore: sweep ligate-devnet-1 → ligate-devnet-2 across docs + crates + localnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Defaults pick up `localnet/rollup.toml` (or `localnet/celestia.toml`) and the `l
 
 The bootstrap and dev accounts above are derived from string labels via SHA-256 and have no associated private key, so on a freshly-booted localnet there's no account anyone can sign with out-of-the-box. To make `cargo run --bin ligate-node` immediately useful, [`localnet/local-dev-key.json`](localnet/local-dev-key.json) ships a deterministic Ed25519 keypair (private-key seed = `0x0101…01`, address `lig132yw8ht5p8cetl2jmvknewjawt9xwzdlrk2pyxlnwjyqz3m499u`) pre-funded with 10 000 `AVOW`. Treat it like Anvil's account-0: convenient for local testing, **never** for any real network.
 
-Operators deploying `ligate-devnet-1` MUST remove this address from `localnet/genesis/bank.json` (or use a substituted genesis bundle from [`ligate-genesis-tool`](crates/genesis-tool)) before producing the deploy artefacts. The `local-dev-key.json` file itself is harmless to ship publicly — its private key being well-known is the point.
+Operators deploying `ligate-devnet-2` MUST remove this address from `localnet/genesis/bank.json` (or use a substituted genesis bundle from [`ligate-genesis-tool`](crates/genesis-tool)) before producing the deploy artefacts. The `local-dev-key.json` file itself is harmless to ship publicly — its private key being well-known is the point.
 
 To use the dev key with [`ligate-cli`](https://github.com/ligate-io/ligate-cli):
 
@@ -303,7 +303,7 @@ The on-chain record: `(schema_id, payload_hash, submitter, timestamp, signatures
 
 ## Development status
 
-**Devnet.** `ligate-devnet-1` is live on Celestia Mocha-testnet. As of Phase A:
+**Devnet.** `ligate-devnet-2` is live on Celestia Mocha-testnet. As of Phase A:
 
 - Attestation module: data types, state layout, call handlers, ed25519 signature validation, replay protection, fee routing.
 - Runtime: `ligate-stf` composes the curated module set on the upgraded Sovereign SDK.
@@ -312,7 +312,7 @@ The on-chain record: `(schema_id, payload_hash, submitter, timestamp, signatures
 - Fees: real `AVOW` transfers through `sov-bank`, with up to 50% of attestation fees routable to the schema owner.
 - Genesis: checked-in devnet config (bank, attestation, attester incentives, prover incentives, sequencer registry, operator incentives).
 - Addresses: `lig1` accounts, `lpk1` pubkeys, `lsc1` schema IDs, `las1` attestor set IDs, `lph1` payload hashes (Bech32m).
-- Chain id ladder (Cosmos-style strings): `ligate-localnet` (single-node local dev), `ligate-devnet-1` (public devnet), `ligate-testnet-1` (later), `ligate-1` (mainnet). Trailing number bumps only on state-breaking restarts. Spec section [`Chain id`](docs/protocol/attestation-v0.md#chain-id).
+- Chain id ladder (Cosmos-style strings): `ligate-localnet` (single-node local dev), `ligate-devnet-2` (public devnet), `ligate-testnet-1` (later), `ligate-1` (mainnet). Trailing number bumps only on state-breaking restarts. Spec section [`Chain id`](docs/protocol/attestation-v0.md#chain-id).
 
 Open work items toward public devnet: hosted RPC endpoint, EVM authenticator ([#72](https://github.com/ligate-io/ligate-chain/issues/72)), and the v1 staking and disputes modules. Current tracked work lives in the [GitHub issues](https://github.com/ligate-io/ligate-chain/issues).
 

--- a/constants.toml
+++ b/constants.toml
@@ -26,7 +26,7 @@ freeze       = [1, 1]
 # value finalised at TGE; devnet uses 4242 (distinct from the SDK
 # demo's 4321 so a misconfigured client failing back to demo defaults
 # is obvious in logs). Per #54, the user-facing string identifier is
-# `ligate-devnet-1` / `ligate-1` and lives in the rollup config TOML,
+# `ligate-devnet-2` / `ligate-1` and lives in the rollup config TOML,
 # not here.
 CHAIN_ID = 4242
 CHAIN_NAME = "Ligate"

--- a/crates/bootstrap-cli/src/main.rs
+++ b/crates/bootstrap-cli/src/main.rs
@@ -141,7 +141,7 @@ async fn run(args: Args) -> Result<()> {
                     eprintln!("connected to {} (ligate-node {})", info.chain_id, info.version);
                     let id = chain_id.unwrap_or_else(|| {
                         // `chain_id` in /rollup/info is the human-readable
-                        // string ("ligate-devnet-1"); the chain signs txs
+                        // string ("ligate-devnet-2"); the chain signs txs
                         // against a u64 numeric id defined as `CHAIN_ID`
                         // in `constants.toml`. Until /rollup/info also
                         // exposes the numeric form, operators must pass

--- a/crates/bootstrap-cli/src/register.rs
+++ b/crates/bootstrap-cli/src/register.rs
@@ -62,7 +62,7 @@ pub struct RegisterParams<'a> {
     /// Operator signing key (32-byte ed25519 seed).
     pub signer_key: SovPrivateKey,
     /// Chain id (`/v1/rollup/info -> chain_id`'s numeric form, NOT the
-    /// `ligate-devnet-1` string).
+    /// `ligate-devnet-2` string).
     pub chain_id: u64,
     /// 32-byte build-time `CHAIN_HASH`, from `/v1/rollup/info`.
     pub chain_hash: [u8; 32],

--- a/crates/client-rs/src/submit.rs
+++ b/crates/client-rs/src/submit.rs
@@ -38,7 +38,7 @@
 //!    a [`sov_modules_api::transaction::Transaction`]. The signature
 //!    is domain-separated to the chain's `CHAIN_HASH` constant
 //!    (build-time hash of the runtime composition + spec). A
-//!    transaction for `ligate-devnet-1` does not verify on
+//!    transaction for `ligate-devnet-2` does not verify on
 //!    `ligate-devnet-2` even if the signing key is identical.
 //!
 //! 4. **Encode.** Borsh-serialize the signed transaction into raw

--- a/crates/genesis-tool/src/main.rs
+++ b/crates/genesis-tool/src/main.rs
@@ -81,7 +81,7 @@ enum DaFlavor {
     /// integration tests, cross-OS genesis-determinism CI.
     Mock,
     /// Celestia DA (bech32 `celestia1...` `seq_da_address`). Use for
-    /// `ligate-devnet-1` and any production-shape deployment.
+    /// `ligate-devnet-2` and any production-shape deployment.
     #[default]
     Celestia,
 }

--- a/crates/rollup/src/info.rs
+++ b/crates/rollup/src/info.rs
@@ -4,7 +4,7 @@
 //! response:
 //!
 //! - `chain_id`: the Cosmos-style string from the rollup config's
-//!   `[chain]` section (e.g. `ligate-localnet`, `ligate-devnet-1`).
+//!   `[chain]` section (e.g. `ligate-localnet`, `ligate-devnet-2`).
 //!   Bumps on state-breaking restarts only; stable across STF
 //!   upgrades.
 //! - `chain_hash`: the runtime's build-script-generated 32-byte

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -18,7 +18,7 @@ Read these in roughly this order when standing up a fresh chain instance.
 |---|---|
 | [`quickstart-partner.md`](./quickstart-partner.md) | First-look for a partner or design-partner integrator — what the chain is, how to call it, where to send `register_schema` traffic |
 | [`devnet.md`](./devnet.md) | Localnet bring-up (Mock DA) and the federated-devnet design (attestor orgs, multi-sequencer topology — forward-looking) |
-| [`public-devnet-deploy.md`](./public-devnet-deploy.md) | GCP VM bring-up procedure for `ligate-devnet-1`: project, SA, firewall, systemd unit, first boot |
+| [`public-devnet-deploy.md`](./public-devnet-deploy.md) | GCP VM bring-up procedure for `ligate-devnet-2`: project, SA, firewall, systemd unit, first boot |
 | [`celestia-ops.md`](./celestia-ops.md) | Co-located Celestia light node setup, wallet wiring, TIA funding |
 | [`snapshot-bootstrap.md`](./snapshot-bootstrap.md) | Spin up a read-only sync node that imports from a public snapshot instead of replaying DA from genesis. For design partners, auditors, third-party node operators. |
 | [`canonical-schema-registration.md`](./canonical-schema-registration.md) | Post-genesis schema registration ceremony: bootstrap-cli flow for `themisra.proof-of-prompt/v1` etc. |

--- a/docs/development/canonical-schema-registration.md
+++ b/docs/development/canonical-schema-registration.md
@@ -2,7 +2,7 @@
 
 How Ligate Labs registers `themisra.proof-of-prompt/v1` (and future first-party schemas) on the chain after genesis.
 
-This is **post-genesis** work — runs once on a freshly-booted `ligate-devnet-1` (or any future devnet / mainnet boot), uses the same on-chain `RegisterAttestorSet` + `RegisterSchema` calls any third party would use, costs the registration fees the chain charges (`attestor_set_fee` 0.05 AVOW + `schema_registration_fee` 0.1 AVOW = ~0.15 AVOW total per ceremony in v0). Fees in the genesis JSON are expressed in nano-AVOW (9 decimals).
+This is **post-genesis** work — runs once on a freshly-booted `ligate-devnet-2` (or any future devnet / mainnet boot), uses the same on-chain `RegisterAttestorSet` + `RegisterSchema` calls any third party would use, costs the registration fees the chain charges (`attestor_set_fee` 0.05 AVOW + `schema_registration_fee` 0.1 AVOW = ~0.15 AVOW total per ceremony in v0). Fees in the genesis JSON are expressed in nano-AVOW (9 decimals).
 
 Tracking issue: [#231](https://github.com/ligate-io/ligate-chain/issues/231).
 
@@ -60,12 +60,12 @@ Don't commit the filled-in file. `devnet-1/.gitignore` already excludes it.
     --chain-id 4242
 ```
 
-`--chain-id` is the numeric `CHAIN_ID` defined in `constants.toml` (NOT the human-readable `ligate-devnet-1` string). `--chain-hash` is fetched from `GET /v1/rollup/info` automatically; pass `--chain-hash <64-char-hex>` to override (the flag expects hex, optionally with a `0x` prefix; not the bech32m `lsch1…` form).
+`--chain-id` is the numeric `CHAIN_ID` defined in `constants.toml` (NOT the human-readable `ligate-devnet-2` string). `--chain-hash` is fetched from `GET /v1/rollup/info` automatically; pass `--chain-hash <64-char-hex>` to override (the flag expects hex, optionally with a `0x` prefix; not the bech32m `lsch1…` form).
 
 Expected output (success path):
 
 ```
-connected to ligate-devnet-1 (ligate-node 0.1.0-devnet)
+connected to ligate-devnet-2 (ligate-node 0.1.0-devnet)
 
 Canonical schema registration: 1 schema(s)
 

--- a/docs/development/celestia-ops.md
+++ b/docs/development/celestia-ops.md
@@ -134,7 +134,7 @@ Celestia testnets restart periodically (mocha → mocha-2 → ...). When that ha
 
 1. Operator regenerates the Celestia light-node state (`rm -rf ~/.celestia-light-mocha && celestia light init ...`).
 2. Operator regenerates the rollup state dir (the chain's blob namespace from the old testnet is gone).
-3. Coordinated chain-id bump per [`docs/protocol/upgrades.md`](../protocol/upgrades.md): `ligate-devnet-1` → `ligate-devnet-2`.
+3. Coordinated chain-id bump per [`docs/protocol/upgrades.md`](../protocol/upgrades.md): `ligate-devnet-2` → `ligate-devnet-2`.
 4. Re-run the [genesis ceremony](devnet.md#4-genesis-ceremony).
 
 This is operationally a hard fork, exactly as documented in the upgrades policy. The operator network coordinates via the `#ligate-devnet` channel (or wherever the next public release moves it).

--- a/docs/development/cost-monitoring.md
+++ b/docs/development/cost-monitoring.md
@@ -1,6 +1,6 @@
 # Cost monitoring — Mocha TIA spend + GCP infra spend
 
-**Status:** v0 — Grafana dashboard + Alertmanager rules for cost visibility on `ligate-devnet-1`. Companion to [`da-signer-rotation.md`](runbooks/da-signer-rotation.md) (TIA wallet management), [`alerts/`](runbooks/alerts/) (alert runbooks), and [`public-devnet-deploy.md`](public-devnet-deploy.md) (the deploy this monitors).
+**Status:** v0 — Grafana dashboard + Alertmanager rules for cost visibility on `ligate-devnet-2`. Companion to [`da-signer-rotation.md`](runbooks/da-signer-rotation.md) (TIA wallet management), [`alerts/`](runbooks/alerts/) (alert runbooks), and [`public-devnet-deploy.md`](public-devnet-deploy.md) (the deploy this monitors).
 
 Two cost surfaces:
 
@@ -9,7 +9,7 @@ Two cost surfaces:
 | Mocha TIA | DA signer wallet pays per-blob to Celestia | Celestia light node's `/metrics` endpoint (`celestia_node_da_signer_balance_utia`) |
 | GCP infra | VM-hours, GCS storage, network egress | GCP billing export → BigQuery |
 
-The dashboard at [`ops/grafana/ligate-devnet-1-cost.json`](../../ops/grafana/ligate-devnet-1-cost.json) puts both on one page so the operator can correlate cost spikes against chain activity.
+The dashboard at [`ops/grafana/ligate-devnet-2-cost.json`](../../ops/grafana/ligate-devnet-2-cost.json) puts both on one page so the operator can correlate cost spikes against chain activity.
 
 ---
 
@@ -49,7 +49,7 @@ Top-up procedure: [`da-signer-rotation.md` "TIA balance monitoring"](runbooks/da
 
 ### Steady-state expectation
 
-`ligate-devnet-1`'s baseline:
+`ligate-devnet-2`'s baseline:
 
 | Resource | Quantity | $/mo |
 |---|---|---|
@@ -120,7 +120,7 @@ Same dashboard, different priorities. The Grafana panels make this explicit by g
 ## Cross-references
 
 - [Issue #277](https://github.com/ligate-io/ligate-chain/issues/277) — this work closes it
-- [`ops/grafana/ligate-devnet-1-cost.json`](../../ops/grafana/ligate-devnet-1-cost.json) — the dashboard
+- [`ops/grafana/ligate-devnet-2-cost.json`](../../ops/grafana/ligate-devnet-2-cost.json) — the dashboard
 - [`ops/prometheus/alerts.yaml`](../../ops/prometheus/alerts.yaml) `ligate-node.cost` group — the alert rules
 - [`runbooks/da-signer-rotation.md`](runbooks/da-signer-rotation.md) — TIA wallet management procedure
 - [`runbooks/alerts/`](runbooks/alerts/) — alert runbooks (Tia* alerts inherit those patterns)

--- a/docs/development/devnet.md
+++ b/docs/development/devnet.md
@@ -22,10 +22,10 @@ first.
 
 Ligate Chain v0 devnet is a **federated attestation testnet**:
 
-- **Chain id**: `ligate-devnet-1`. The trailing number bumps only on a
+- **Chain id**: `ligate-devnet-2`. The trailing number bumps only on a
   state-breaking restart (full reset, new genesis); soft upgrades via
   the upgrade module ([#42](https://github.com/ligate-io/ligate-chain/issues/42))
-  keep the same id. Full ladder (`ligate-localnet` / `ligate-devnet-1` /
+  keep the same id. Full ladder (`ligate-localnet` / `ligate-devnet-2` /
   `ligate-testnet-1` / `ligate-1`) is locked in
   [the protocol spec](../protocol/attestation-v0.md#chain-id) per
   [#54](https://github.com/ligate-io/ligate-chain/issues/54).

--- a/docs/development/genesis.example.json
+++ b/docs/development/genesis.example.json
@@ -8,7 +8,7 @@
     "not the attestation genesis. Use the locked ladder per #54 and the spec",
     "section `Chain id` in `docs/protocol/attestation-v0.md`:",
     "  ligate-localnet   single-node local dev",
-    "  ligate-devnet-1   public devnet",
+    "  ligate-devnet-2   public devnet",
     "  ligate-testnet-1  public testnet (later)",
     "  ligate-1          mainnet (later)",
     "Trailing number bumps only on a state-breaking restart. Never use 0x.",

--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -1,6 +1,6 @@
 # Public devnet deploy runbook
 
-How to bring up a `ligate-devnet-1` node on GCP, in either operator role:
+How to bring up a `ligate-devnet-2` node on GCP, in either operator role:
 
 - **Sequencer** (the canonical Ligate-Labs node, single-instance in v0).
 - **Follower** (any third-party operator running their own copy of the chain state).
@@ -45,14 +45,14 @@ Sequencer sizing covers `ligate-node` + co-located Celestia light node + the loc
 
 Faucet and indexer **do not run on this VM**; they live in [`ligate-io/ligate-api`](https://github.com/ligate-io/ligate-api), deployed to Railway alongside a Railway-managed Postgres. The Next.js explorer at `explorer.ligate.io` is yet another deploy on Vercel, talking to `api.ligate.io`. Follower sizing is smaller because followers don't keep the local backup stage (they restore from GCS or replay from DA if state is lost).
 
-Persistent data disk can be **live-resized without downtime** via `gcloud compute disks resize` + `resize2fs /dev/sdb`; ext4 supports online growth. Done on `ligate-devnet-1-sequencer` on 2026-05-16 (50GB → 150GB) when local snapshot accumulation projected to fill the original 50GB within ~24h.
+Persistent data disk can be **live-resized without downtime** via `gcloud compute disks resize` + `resize2fs /dev/sdb`; ext4 supports online growth. Done on `ligate-devnet-2-sequencer` on 2026-05-16 (50GB → 150GB) when local snapshot accumulation projected to fill the original 50GB within ~24h.
 
 **OS choice.** As of chain#345 the released `ligate-node` Linux binary is built on Ubuntu 22.04 (GLIBC 2.35), so it runs cleanly on every common server distro: Ubuntu 22.04+, Debian 12+, RHEL 9, Amazon Linux 2023. Older distros (GLIBC <2.35) still need a from-source build. Ubuntu 24.04 stays the canonical operator choice for the rest of the runbook because cloud-init + GCP image families are stable on it, but Debian 12 works fine too if you prefer.
 
 ## Step 1: Provision the VM
 
 ```bash
-gcloud compute instances create ligate-devnet-1-sequencer \
+gcloud compute instances create ligate-devnet-2-sequencer \
     --project=$YOUR_GCP_PROJECT \
     --zone=us-central1-a \
     --machine-type=e2-standard-4 \
@@ -69,10 +69,10 @@ For a follower, swap `--machine-type=e2-medium`, `--create-disk=...,size=100GB`,
 Reserve a static external IP and bind it:
 
 ```bash
-gcloud compute addresses create ligate-devnet-1-rpc \
+gcloud compute addresses create ligate-devnet-2-rpc \
     --project=$YOUR_GCP_PROJECT --region=us-central1
-gcloud compute instances add-access-config ligate-devnet-1-sequencer \
-    --address=$(gcloud compute addresses describe ligate-devnet-1-rpc \
+gcloud compute instances add-access-config ligate-devnet-2-sequencer \
+    --address=$(gcloud compute addresses describe ligate-devnet-2-rpc \
         --project=$YOUR_GCP_PROJECT --region=us-central1 --format='value(address)')
 ```
 
@@ -99,7 +99,7 @@ The cloud-init does the chassis. The operator still has to:
   ```bash
   sudo -u ligate ln -s /var/lib/ligate/rocksdb /opt/ligate/devnet/data-celestia
   ```
-  Without this, the chain writes state to the 20 GB boot disk and a VM image rebuild loses chain history. Backups (per `docs/development/runbooks/backup-restore.md`) reduce the blast radius to ~15 minutes' RPO, but the persistent disk is the right home regardless. (Done after the fact on `ligate-devnet-1-sequencer` on 2026-05-16, runbook documents the in-place migration.)
+  Without this, the chain writes state to the 20 GB boot disk and a VM image rebuild loses chain history. Backups (per `docs/development/runbooks/backup-restore.md`) reduce the blast radius to ~15 minutes' RPO, but the persistent disk is the right home regardless. (Done after the fact on `ligate-devnet-2-sequencer` on 2026-05-16, runbook documents the in-place migration.)
 - **Pin `genesis_da_height` before first boot.** `devnet-1/genesis/chain_state.json` ships `genesis_da_height: 0` — a placeholder. Celestia rejects a request for DA block 0, so the chain cannot initialize against Mocha while it's `0` (this is exactly what the Mocha smoke gate surfaced; see [#331](https://github.com/ligate-io/ligate-chain/issues/331)). Set it to a recent **finalized** Mocha height:
   ```bash
   # Latest Mocha consensus height, minus a finality margin.
@@ -247,7 +247,7 @@ rpc.ligate.io {
 }
 ```
 
-Production also wraps the above with a `(cloudflare_only)` macro that 403s any request whose source IP isn't in Cloudflare's published edge ranges. See `/etc/caddy/Caddyfile` on `ligate-devnet-1-sequencer` (or the CF-IP list at <https://www.cloudflare.com/ips-v4/>) for the macro. Skip for non-Cloudflare deploys.
+Production also wraps the above with a `(cloudflare_only)` macro that 403s any request whose source IP isn't in Cloudflare's published edge ranges. See `/etc/caddy/Caddyfile` on `ligate-devnet-2-sequencer` (or the CF-IP list at <https://www.cloudflare.com/ips-v4/>) for the macro. Skip for non-Cloudflare deploys.
 
 Install + enable:
 
@@ -295,7 +295,7 @@ $EDITOR devnet-1/canonical-schemas.toml  # fill in real attestor pubkeys
 
 # 2. Run the ceremony binary. Auto-fetches chain_hash from /v1/rollup/info.
 #    --chain-id is the numeric u64 CHAIN_ID from constants.toml (NOT
-#    the "ligate-devnet-1" human-readable string).
+#    the "ligate-devnet-2" human-readable string).
 cargo run --release -p ligate-bootstrap-cli -- register-canonical-schemas \
     --config devnet-1/canonical-schemas.toml \
     --signer-key ~/.ligate-keys/devnet-1/operator.key \
@@ -361,9 +361,9 @@ Cron-driven rsync of state to a Cloud Storage bucket every 6 hours:
 Secrets go to Secret Manager, not GCS:
 
 ```bash
-gcloud secrets create ligate-devnet-1-sequencer-signer \
+gcloud secrets create ligate-devnet-2-sequencer-signer \
     --replication-policy=user-managed --locations=us-central1
-gcloud secrets versions add ligate-devnet-1-sequencer-signer --data-file=-
+gcloud secrets versions add ligate-devnet-2-sequencer-signer --data-file=-
 # (paste the private key, then EOF)
 ```
 
@@ -374,7 +374,7 @@ The `ligate-node` systemd unit reads from `/etc/ligate/env`, which on first boot
 | Symptom | Likely cause | First check | Fix |
 |---|---|---|---|
 | `ligate-node` won't start, "missing [chain] section" | Wrong config file passed | `journalctl -u ligate-node` | Check `--rollup-config-path` points at `/opt/ligate/devnet/celestia.toml`, not the localnet one |
-| `ligate-node` won't start, "chain_id 'X' does not match the locked ladder" | Operator typo in `[chain]` | `cat /opt/ligate/devnet/celestia.toml \| grep chain_id` | Fix to `ligate-devnet-1`, restart |
+| `ligate-node` won't start, "chain_id 'X' does not match the locked ladder" | Operator typo in `[chain]` | `cat /opt/ligate/devnet/celestia.toml \| grep chain_id` | Fix to `ligate-devnet-2`, restart |
 | Sequencer cannot reach Celestia | Light node down or wrong endpoint | `systemctl status celestia-light`, `curl ws://127.0.0.1:26658` | Restart `celestia-light`; if persistent, check Mocha bridge availability |
 | `/ready` returns 503 with high target_da_height | Node is catching up | Look at `synced_da_height` over 5 min | Wait; sync rate ~1 block/s on healthy network |
 | `/ready` returns 503 indefinitely | Sequencer can't keep up with DA | Check `block_height` metric and DA polling rate | Increase `da_polling_interval_ms` upward, or check for state-corruption indicators |
@@ -434,7 +434,7 @@ docker run -d \
     -p 12346:12346 -p 9100:9100 \
     -e SOV_CELESTIA_RPC_URL=ws://host.docker.internal:26658 \
     -e SOV_CELESTIA_GRPC_URL=http://host.docker.internal:9090 \
-    -e SOV_CELESTIA_SIGNER_KEY="$(gcloud secrets versions access latest --secret=ligate-devnet-1-sequencer-signer)" \
+    -e SOV_CELESTIA_SIGNER_KEY="$(gcloud secrets versions access latest --secret=ligate-devnet-2-sequencer-signer)" \
     -e RUST_LOG=info,sov=info \
     ghcr.io/ligate-io/ligate-chain:v0.3.0 \
     --da-layer celestia \

--- a/docs/development/quickstart-partner.md
+++ b/docs/development/quickstart-partner.md
@@ -1,6 +1,6 @@
-# Partner Quickstart — Zero to First Attestation on `ligate-devnet-1`
+# Partner Quickstart — Zero to First Attestation on `ligate-devnet-2`
 
-**Status:** Pre-devnet. The flow below is what `ligate-devnet-1` will support on Day 1 (target Q2 2026). Sections marked with **⚠ Preview** are wired in code but the public infrastructure they depend on (faucet, hosted RPC, canonical schemas, explorer) is still spinning up.
+**Status:** Pre-devnet. The flow below is what `ligate-devnet-2` will support on Day 1 (target Q2 2026). Sections marked with **⚠ Preview** are wired in code but the public infrastructure they depend on (faucet, hosted RPC, canonical schemas, explorer) is still spinning up.
 
 This page takes a partner from "I just heard about Ligate" to "my first attestation landed on the public chain" in one continuous flow. No tribal knowledge, no jumping between three doc sites.
 
@@ -146,7 +146,7 @@ submitted attestation:
   outcome:      committed
 ```
 
-The `--chain-hash` and `--chain-id 4242` bind the signature to the chain so it can't be replayed against testnet or another devnet revision. Pull `chain-hash` from `ligate info --json`; the numeric `chain-id` is fixed (`4242` for ligate-devnet-1; the Cosmos-style string id `ligate-devnet-1` is separate).
+The `--chain-hash` and `--chain-id 4242` bind the signature to the chain so it can't be replayed against testnet or another devnet revision. Pull `chain-hash` from `ligate info --json`; the numeric `chain-id` is fixed (`4242` for ligate-devnet-2; the Cosmos-style string id `ligate-devnet-2` is separate).
 
 ---
 

--- a/docs/development/runbooks/backup-restore.md
+++ b/docs/development/runbooks/backup-restore.md
@@ -67,7 +67,7 @@ Two layers of pruning, each handles a different scope:
 ```sh
 # Regional bucket close to the chain VM, standard storage class,
 # uniform IAM, public-access-prevention on.
-gcloud storage buckets create gs://ligate-devnet-1-backups \
+gcloud storage buckets create gs://ligate-devnet-2-backups \
     --project=$YOUR_GCP_PROJECT \
     --location=us-central1 \
     --default-storage-class=STANDARD \
@@ -75,7 +75,7 @@ gcloud storage buckets create gs://ligate-devnet-1-backups \
     --public-access-prevention
 
 # Apply the rotation policy (hourly: 7d, weekly: 365d)
-gcloud storage buckets update gs://ligate-devnet-1-backups \
+gcloud storage buckets update gs://ligate-devnet-2-backups \
     --lifecycle-file=ops/backup/gcs-lifecycle.json
 
 # Grant the VM's default Compute Engine service account write access
@@ -83,9 +83,9 @@ gcloud storage buckets update gs://ligate-devnet-1-backups \
 # project; org policy `constraints/iam.disableServiceAccountKeyCreation`
 # is enforced. Using the existing VM SA + a bucket-scoped IAM grant
 # avoids needing a key.)
-VM_SA=$(gcloud compute instances describe ligate-devnet-1-sequencer \
+VM_SA=$(gcloud compute instances describe ligate-devnet-2-sequencer \
         --zone us-central1-a --format='value(serviceAccounts[0].email)')
-gcloud storage buckets add-iam-policy-binding gs://ligate-devnet-1-backups \
+gcloud storage buckets add-iam-policy-binding gs://ligate-devnet-2-backups \
     --member="serviceAccount:$VM_SA" \
     --role="roles/storage.objectAdmin"
 ```
@@ -93,9 +93,9 @@ gcloud storage buckets add-iam-policy-binding gs://ligate-devnet-1-backups \
 The VM's default service account ships with `devstorage.read_only` scope only. Add `devstorage.read_write` (cycle of stop → set-service-account → start; ~2 min of chain downtime):
 
 ```sh
-gcloud compute instances stop ligate-devnet-1-sequencer --zone us-central1-a
+gcloud compute instances stop ligate-devnet-2-sequencer --zone us-central1-a
 
-gcloud compute instances set-service-account ligate-devnet-1-sequencer \
+gcloud compute instances set-service-account ligate-devnet-2-sequencer \
     --zone us-central1-a \
     --service-account "$VM_SA" \
     --scopes "https://www.googleapis.com/auth/devstorage.read_write,\
@@ -106,12 +106,12 @@ https://www.googleapis.com/auth/service.management.readonly,\
 https://www.googleapis.com/auth/servicecontrol,\
 https://www.googleapis.com/auth/trace.append"
 
-gcloud compute instances start ligate-devnet-1-sequencer --zone us-central1-a
+gcloud compute instances start ligate-devnet-2-sequencer --zone us-central1-a
 
 # After start: re-enable + start ligate-node (it's not enabled by default
 # because the cloud-init only installs the unit; first-boot left it
 # disabled. Subsequent boots auto-start once enabled.)
-gcloud compute ssh ligate-devnet-1-sequencer --zone us-central1-a --command '
+gcloud compute ssh ligate-devnet-2-sequencer --zone us-central1-a --command '
     sudo systemctl enable --now ligate-node.service
 '
 ```
@@ -171,13 +171,13 @@ sudo systemctl start ligate-backup@weekly.service
 sudo journalctl -u 'ligate-backup@*.service' --since "5 minutes ago" --no-pager
 
 # Inspect what landed in GCS:
-gcloud storage ls gs://ligate-devnet-1-backups/ligate-devnet-1-sequencer/
+gcloud storage ls gs://ligate-devnet-2-backups/ligate-devnet-2-sequencer/
 
 # Check the per-snapshot manifest carries height + storage path:
-TS=$(gcloud storage ls gs://ligate-devnet-1-backups/ligate-devnet-1-sequencer/hourly/ \
+TS=$(gcloud storage ls gs://ligate-devnet-2-backups/ligate-devnet-2-sequencer/hourly/ \
        | tail -1 | awk -F/ '{print $(NF-1)}')
 gcloud storage cat \
-    "gs://ligate-devnet-1-backups/ligate-devnet-1-sequencer/hourly/$TS/$TS/.snapshot-manifest.json"
+    "gs://ligate-devnet-2-backups/ligate-devnet-2-sequencer/hourly/$TS/$TS/.snapshot-manifest.json"
 ```
 
 ---
@@ -209,7 +209,7 @@ Three triggers for a restore:
 
 ```sh
 # 1. Identify the snapshot to restore from
-gcloud storage ls gs://ligate-devnet-1-backups/$(hostname -s)/hourly/
+gcloud storage ls gs://ligate-devnet-2-backups/$(hostname -s)/hourly/
 
 # 2. Run the restore script. With no args, picks the most recent hourly.
 sudo /opt/ligate/scripts/restore-rocksdb.sh
@@ -264,7 +264,7 @@ Exit codes encode the failure stage (1 = backup, 2 = restore, 3 = post-restore v
 
 ## Migrating an existing host to the persistent disk
 
-If you're operating a host where chain state landed on `/dev/root` instead of the persistent disk (cloud-init didn't pre-create the symlink), here's the in-place migration. Done on `ligate-devnet-1-sequencer` on 2026-05-16 with ~3 min of chain downtime.
+If you're operating a host where chain state landed on `/dev/root` instead of the persistent disk (cloud-init didn't pre-create the symlink), here's the in-place migration. Done on `ligate-devnet-2-sequencer` on 2026-05-16 with ~3 min of chain downtime.
 
 ```sh
 # 1. Stop the chain cleanly. TimeoutStopSec=300 gives RocksDB room
@@ -314,13 +314,13 @@ GCE persistent disks grow live, and ext4 resizes online; no chain stop needed.
 gcloud compute disks resize ligate-data-v2 --zone us-central1-a --size 150GB
 
 # 2. Inside the VM, grow the ext4 filesystem to fill the new size.
-gcloud compute ssh ligate-devnet-1-sequencer --zone us-central1-a --command '
+gcloud compute ssh ligate-devnet-2-sequencer --zone us-central1-a --command '
   sudo resize2fs /dev/sdb
   df -h /var/lib/ligate
 '
 ```
 
-Done on `ligate-devnet-1-sequencer` 2026-05-16 (50GB → 150GB) when projected local snapshot accumulation (24 hourly × ~5GB) was on track to fill the original disk within ~24h. With the `--sparse` rsync fix (see followups) each snapshot drops from ~5GB to ~1.2GB and the 50GB disk would have been fine; 150GB is comfortable headroom either way.
+Done on `ligate-devnet-2-sequencer` 2026-05-16 (50GB → 150GB) when projected local snapshot accumulation (24 hourly × ~5GB) was on track to fill the original disk within ~24h. With the `--sparse` rsync fix (see followups) each snapshot drops from ~5GB to ~1.2GB and the 50GB disk would have been fine; 150GB is comfortable headroom either way.
 
 You can't shrink a GCE persistent disk, so size up cautiously. ext4 supports shrinking but only offline; not a path we'd take on this host.
 

--- a/docs/development/runbooks/da-signer-rotation.md
+++ b/docs/development/runbooks/da-signer-rotation.md
@@ -32,7 +32,7 @@ The first three are operational outages. The fourth is a planning exercise.
 2. **Fund the new address.**
    - Mocha testnet (devnet target): hit the Mocha faucet (`https://faucet.celestia-mocha.com` or community channels).
    - Internal transfer from the old address: `celestia-appd tx bank send <old> <new> <amount>utia`.
-   - **Target balance:** at least 30 days of expected blob-fee burn. For `ligate-devnet-1` with one blob per slot at ~1000ms block time, that's roughly `2.6M slots/month × avg_blob_fee_utia`. Pull the current avg from `[monitoring].telegraf_address` metrics or `celestia-appd query txs` on a sample.
+   - **Target balance:** at least 30 days of expected blob-fee burn. For `ligate-devnet-2` with one blob per slot at ~1000ms block time, that's roughly `2.6M slots/month × avg_blob_fee_utia`. Pull the current avg from `[monitoring].telegraf_address` metrics or `celestia-appd query txs` on a sample.
 
 3. **Stop the sequencer.** Required to swap keys cleanly — partial-state rotation isn't supported by the DA adapter.
    ```sh

--- a/docs/development/runbooks/gcp-billing-export.md
+++ b/docs/development/runbooks/gcp-billing-export.md
@@ -1,6 +1,6 @@
 # GCP infra cost into Grafana
 
-> One-time setup for `ligate-devnet-1` ops. Routes GCP Cloud Billing
+> One-time setup for `ligate-devnet-2` ops. Routes GCP Cloud Billing
 > data into a BigQuery dataset, then exposes that dataset to Grafana
 > as a second datasource alongside the existing Prometheus one. After
 > setup, the chain Grafana dashboard can show a "Monthly burn rate"
@@ -62,7 +62,7 @@ PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectN
 # the export itself.
 bq --location=us-central1 mk \
   --dataset \
-  --description "GCP billing export for ligate-devnet-1 cost telemetry" \
+  --description "GCP billing export for ligate-devnet-2 cost telemetry" \
   "${PROJECT_ID}:ligate_billing"
 ```
 
@@ -109,7 +109,7 @@ The actual pattern we ship: **VM-1 runs a 6-hourly bq query, writes the result J
 
 ```bash
 PROJECT_ID=utopian-spring-494915-q1
-VM1_SA=$(gcloud compute instances describe ligate-devnet-1-sequencer \
+VM1_SA=$(gcloud compute instances describe ligate-devnet-2-sequencer \
   --zone=us-central1-a --format="value(serviceAccounts[0].email)")
 gcloud projects add-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:$VM1_SA" --role="roles/bigquery.dataViewer" --condition=None
@@ -122,18 +122,18 @@ gcloud projects add-iam-policy-binding "$PROJECT_ID" \
 Default compute VMs have a restricted scope set that does **not** include BigQuery. Even with the IAM roles above, `bq query` from the VM will return `Insufficient Permission` until you broaden the scopes. This requires a stop / scopes-change / start cycle (~6 min of public RPC downtime; same as a machine-type resize).
 
 ```bash
-gcloud compute instances stop ligate-devnet-1-sequencer --zone=us-central1-a
-gcloud compute instances set-service-account ligate-devnet-1-sequencer \
+gcloud compute instances stop ligate-devnet-2-sequencer --zone=us-central1-a
+gcloud compute instances set-service-account ligate-devnet-2-sequencer \
   --zone=us-central1-a \
   --service-account="<vm1-sa-from-4a>" \
   --scopes="https://www.googleapis.com/auth/cloud-platform"
-gcloud compute instances start ligate-devnet-1-sequencer --zone=us-central1-a
+gcloud compute instances start ligate-devnet-2-sequencer --zone=us-central1-a
 ```
 
 Verify after restart:
 
 ```bash
-gcloud compute ssh ligate-devnet-1-sequencer --zone=us-central1-a \
+gcloud compute ssh ligate-devnet-2-sequencer --zone=us-central1-a \
   --command='bq query --use_legacy_sql=false --format=json "SELECT 1 AS ok"'
 # expected: [{"ok":"1"}]
 ```
@@ -216,10 +216,10 @@ To deploy the updated script on VM-1:
 
 ```bash
 gcloud compute scp ops/billing/gcp-cost-fetch.sh \
-    ligate-devnet-1-sequencer:/tmp/gcp-cost-fetch.sh \
+    ligate-devnet-2-sequencer:/tmp/gcp-cost-fetch.sh \
     --zone=us-central1-a
 
-gcloud compute ssh ligate-devnet-1-sequencer --zone=us-central1-a --command='
+gcloud compute ssh ligate-devnet-2-sequencer --zone=us-central1-a --command='
     sudo install -m 0755 -o ligate -g ligate \
         /tmp/gcp-cost-fetch.sh /opt/ligate/bin/gcp-cost-fetch.sh
 

--- a/docs/development/runbooks/log-shipping.md
+++ b/docs/development/runbooks/log-shipping.md
@@ -1,6 +1,6 @@
 # Runbook — Centralized log shipping (GCP Cloud Logging)
 
-**Status:** v0 — ships the Fluent Bit agent config + the operator-side install for `ligate-devnet-1`. Decision recorded below; alternatives considered + rejected.
+**Status:** v0 — ships the Fluent Bit agent config + the operator-side install for `ligate-devnet-2`. Decision recorded below; alternatives considered + rejected.
 
 The devnet VM (per [`public-devnet-deploy.md`](../public-devnet-deploy.md)) runs `ligate-node`, the Celestia light node, the faucet, plus oneshot backup/snapshot jobs. Without centralized logging, debugging a stall means SSHing into the VM, running `journalctl` across N units, and grepping for the panic. With centralized logging, the operator runs one Cloud Logging query and sees everything.
 

--- a/docs/development/runbooks/multi-sequencer-failover.md
+++ b/docs/development/runbooks/multi-sequencer-failover.md
@@ -159,7 +159,7 @@ PGPASSWORD="$PG_PASS" psql -h 10.123.0.2 -U ligate_sequencer -d ligate_sequencer
   -c "SELECT node_id, EXTRACT(EPOCH FROM (NOW() - last_updated)) AS age_s FROM nodes;"
 
 # Replicas' head heights match Leader's (within a few blocks)
-for vm in ligate-devnet-1-sequencer ligate-devnet-1-sequencer-2 ligate-devnet-1-sequencer-3; do
+for vm in ligate-devnet-2-sequencer ligate-devnet-2-sequencer-2 ligate-devnet-2-sequencer-3; do
   echo "=== $vm ==="
   gcloud compute ssh "$vm" --zone=us-central1-a --command='curl -s http://127.0.0.1:9100/metrics | grep ^ligate_block_height'
 done
@@ -260,7 +260,7 @@ Used when:
 1. **Identify the most-synced Replica.** Pick the one whose
    `ligate_block_height` is highest:
    ```sh
-   for vm in ligate-devnet-1-sequencer ligate-devnet-1-sequencer-2 ligate-devnet-1-sequencer-3; do
+   for vm in ligate-devnet-2-sequencer ligate-devnet-2-sequencer-2 ligate-devnet-2-sequencer-3; do
      echo -n "$vm: "
      gcloud compute ssh "$vm" --zone=us-central1-a --command='curl -s http://127.0.0.1:9100/metrics | grep ^ligate_block_height' 2>/dev/null
    done

--- a/docs/development/runbooks/sequencer-key-rotation.md
+++ b/docs/development/runbooks/sequencer-key-rotation.md
@@ -28,7 +28,7 @@ The sequencer pubkey lives in `crates/sequencer-registry` / `genesis/sequencer_r
 
 The Sovereign SDK does **not** ship a hot-rotation primitive in v0. Until [#42 lands](https://github.com/ligate-io/ligate-chain/issues/42) + a sequencer-side rotation call lands on top, rotation is either:
 
-- **Re-genesis** (chain id ladder bumps, e.g. `ligate-devnet-1` → `ligate-devnet-2`), OR
+- **Re-genesis** (chain id ladder bumps, e.g. `ligate-devnet-2` → `ligate-devnet-2`), OR
 - **Coordinated restart with operator-side state surgery**, which we don't endorse for any state we want to keep.
 
 ---

--- a/docs/development/snapshot-bootstrap.md
+++ b/docs/development/snapshot-bootstrap.md
@@ -1,6 +1,6 @@
 # Bootstrap a node from a public snapshot
 
-**Status:** v1. Covers the public-snapshot import flow for a fresh `ligate-devnet-1` node (read-only sync node or partner-run sequencer; the procedure is role-agnostic). Snapshot artefacts are published daily by the canonical sequencer; the partner node downloads + imports + boots, skipping DA replay from height 0.
+**Status:** v1. Covers the public-snapshot import flow for a fresh `ligate-devnet-2` node (read-only sync node or partner-run sequencer; the procedure is role-agnostic). Snapshot artefacts are published daily by the canonical sequencer; the partner node downloads + imports + boots, skipping DA replay from height 0.
 
 > Renamed from `follower-bootstrap.md` after v0.2.9 dropped the `--mode follower` flag and the "follower" role label (chain#446, chain#462). The procedure itself is unchanged.
 
@@ -46,7 +46,7 @@ sudo install -m 0755 scripts/import-snapshot.sh /opt/ligate/scripts/
 
 # 3. Run the import:
 sudo /opt/ligate/scripts/import-snapshot.sh \
-    --chain-id ligate-devnet-1 \
+    --chain-id ligate-devnet-2 \
     --tier daily
 
 # The script will:
@@ -87,9 +87,9 @@ The pointer's body:
 
 ```jsonc
 {
-  "snapshot_url": "https://.../ligate-snapshot-ligate-devnet-1-12345-daily.tar.gz",
-  "manifest_url": "https://.../ligate-snapshot-ligate-devnet-1-12345-daily.manifest.json",
-  "chain_id": "ligate-devnet-1",
+  "snapshot_url": "https://.../ligate-snapshot-ligate-devnet-2-12345-daily.tar.gz",
+  "manifest_url": "https://.../ligate-snapshot-ligate-devnet-2-12345-daily.manifest.json",
+  "chain_id": "ligate-devnet-2",
   "block_height": 12345,
   "tier": "daily",
   "updated_at_utc": "2026-05-13T04:35:12Z"
@@ -198,11 +198,11 @@ Before relying on snapshots in production, run the drill:
 sudo systemctl start ligate-snapshot-publish.service
 
 # 2. Verify it landed in the public bucket
-gcloud storage ls gs://ligate-snapshots-public/snapshots/ligate-devnet-1/
+gcloud storage ls gs://ligate-snapshots-public/snapshots/ligate-devnet-2/
 
 # 3. On a fresh non-prod VM (or a wiped local docker container)
 #    that has ligate-node + configs but no state:
-sudo /opt/ligate/scripts/import-snapshot.sh --chain-id ligate-devnet-1
+sudo /opt/ligate/scripts/import-snapshot.sh --chain-id ligate-devnet-2
 
 # 4. Confirm the fresh node catches up to the canonical sequencer's
 #    head within a few minutes:
@@ -219,7 +219,7 @@ Schedule the drill quarterly (the chain repo's calendar reminder system pings th
 ## Out of scope
 
 - **Trustless verification.** Would need a light-client construction. Mainnet work.
-- **Cross-chain import.** Partner can't import a `ligate-devnet-1` snapshot into a `ligate-devnet-2` node. Chain id is enforced at import time.
+- **Cross-chain import.** Partner can't import a `ligate-devnet-2` snapshot into a `ligate-devnet-2` node. Chain id is enforced at import time.
 - **Differential snapshots.** Each snapshot is a full RocksDB. Incremental snapshots would shrink download size; out of scope until devnet shows operational pain.
 - **Operator-controlled (selective) state.** Partners who only care about specific schemas / addresses don't get a custom slice. Mainnet may revisit.
 

--- a/docs/protocol/attestation-v0.md
+++ b/docs/protocol/attestation-v0.md
@@ -364,7 +364,7 @@ Cosmos-style string identifiers, locked to a single canonical ladder so every co
 | Environment                | Chain id           |
 | -------------------------- | ------------------ |
 | Local single-node dev      | `ligate-localnet`  |
-| Public devnet              | `ligate-devnet-1`  |
+| Public devnet              | `ligate-devnet-2`  |
 | Public testnet (later)     | `ligate-testnet-1` |
 | Mainnet (later)            | `ligate-1`         |
 

--- a/docs/protocol/lips/lip-template.md
+++ b/docs/protocol/lips/lip-template.md
@@ -74,7 +74,7 @@ Existing state? Existing client APIs?
 
 If the LIP requires a chain-id bump per
 [`upgrades.md`](../upgrades.md#what-counts-as-a-hard-fork), state it
-explicitly with the proposed transition (e.g. `ligate-devnet-1` →
+explicitly with the proposed transition (e.g. `ligate-devnet-2` →
 `ligate-devnet-2`).
 
 If the LIP is backwards-compatible, explain why (e.g. "appended

--- a/docs/protocol/rest-api.md
+++ b/docs/protocol/rest-api.md
@@ -541,7 +541,7 @@ Status codes:
 
 The REST surface is **not versioned in the URL** today. Two reasons:
 
-1. Pre-mainnet, breaking changes are coordinated reset events tied to chain-id bumps (`ligate-devnet-1` to `ligate-devnet-2`). The chain id implicitly versions the API.
+1. Pre-mainnet, breaking changes are coordinated reset events tied to chain-id bumps (`ligate-devnet-2` to `ligate-devnet-2`). The chain id implicitly versions the API.
 2. Post-mainnet, append-only changes (new endpoints, new optional fields) ship via soft fork without URL versioning. Breaking changes (renames, removals) require coordinated client upgrade and would be announced through the upgrade module ([#42](https://github.com/ligate-io/ligate-chain/issues/42)).
 
 See [`upgrades.md`](upgrades.md) for the full soft-fork vs hard-fork policy.

--- a/docs/protocol/sequencer-decentralisation.md
+++ b/docs/protocol/sequencer-decentralisation.md
@@ -19,7 +19,7 @@
 
 ## 1. Context
 
-`ligate-devnet-1` runs a single sequencer operated by Ligate Labs. The chain's **safety** doesn't depend on this: every full node re-derives the state root by replaying the canonical batch stream off Celestia. A misbehaving sequencer can stall blocks but cannot fabricate state.
+`ligate-devnet-2` runs a single sequencer operated by Ligate Labs. The chain's **safety** doesn't depend on this: every full node re-derives the state root by replaying the canonical batch stream off Celestia. A misbehaving sequencer can stall blocks but cannot fabricate state.
 
 What the single-sequencer model **does** depend on for:
 

--- a/docs/protocol/threat-model.md
+++ b/docs/protocol/threat-model.md
@@ -19,11 +19,11 @@ The threat surface evolves with the chain-id ladder defined in [`attestation-v0.
 | Environment | Chain id | Trust posture | What is federated |
 |---|---|---|---|
 | Local single-node dev | `ligate-localnet` | Operator trusts their own machine | Everything |
-| Public devnet | `ligate-devnet-1` | Permissioned sequencer + federated attestor sets, no economic finality | Sequencer (Ligate Labs), attestor sets per schema |
+| Public devnet | `ligate-devnet-2` | Permissioned sequencer + federated attestor sets, no economic finality | Sequencer (Ligate Labs), attestor sets per schema |
 | Public testnet | `ligate-testnet-1` | Permissioned sequencer + federated attestor sets + slashing | Sequencer + attestor staking module |
 | Mainnet | `ligate-1` | Full PoUA + disputes + multi-sequencer | None at the protocol layer |
 
-This document describes the **v0** posture (`ligate-localnet`, `ligate-devnet-1`). Each subsequent ladder rung tightens specific gaps named below. v3 (`ligate-1`) closes the consensus-weighting gap via [PoUA](https://github.com/ligate-io/ligate-chain/issues/126).
+This document describes the **v0** posture (`ligate-localnet`, `ligate-devnet-2`). Each subsequent ladder rung tightens specific gaps named below. v3 (`ligate-1`) closes the consensus-weighting gap via [PoUA](https://github.com/ligate-io/ligate-chain/issues/126).
 
 ## How to read this
 
@@ -43,7 +43,7 @@ These attack the protocol primitive itself: schemas, attestor sets, attestations
 
 **Where:** invariant 5 in [`attestation-v0.md` §Invariants](attestation-v0.md#invariants); enforced in `crates/modules/attestation/src/lib.rs` on the `SubmitAttestation` handler.
 
-**Cross-chain replay:** every signed tx is domain-separated by `CHAIN_ID = 4242` (per `constants.toml`) plus the `CHAIN_HASH` derived from the runtime composition. Signatures from `ligate-devnet-1` do not verify on `ligate-devnet-2`.
+**Cross-chain replay:** every signed tx is domain-separated by `CHAIN_ID = 4242` (per `constants.toml`) plus the `CHAIN_HASH` derived from the runtime composition. Signatures from `ligate-devnet-2` do not verify on `ligate-devnet-2`.
 
 ### 1.2 Schema squatter
 

--- a/docs/protocol/upgrades.md
+++ b/docs/protocol/upgrades.md
@@ -43,7 +43,7 @@ Anything that changes how an existing on-chain value is **encoded, addressed, or
 - **Changing the address format or the chain id integer** (`CHAIN_ID = 4242` in [`constants.toml`](../../constants.toml)). Both are inputs to transaction signature verification.
 - **Changing the runtime composition** — adding a module, removing a module, switching a module's `Config` shape, or substituting a different DA / ZkVM spec into the canonical chain hash. Detected automatically by the `CHAIN_HASH` guard (next section).
 
-Hard forks bump the chain-id trailing number per the locked ladder: `ligate-localnet` → unaffected (it's local-only), `ligate-devnet-1` → `ligate-devnet-2`, `ligate-testnet-1` → `ligate-testnet-2`, `ligate-1` → `ligate-2`. Genesis is regenerated. Every node operator restarts against the new genesis. Any in-flight transactions on the old chain are dropped — their signatures are domain-separated to the previous chain's hash and won't verify on the new one.
+Hard forks bump the chain-id trailing number per the locked ladder: `ligate-localnet` → unaffected (it's local-only), `ligate-devnet-2` → `ligate-devnet-2`, `ligate-testnet-1` → `ligate-testnet-2`, `ligate-1` → `ligate-2`. Genesis is regenerated. Every node operator restarts against the new genesis. Any in-flight transactions on the old chain are dropped — their signatures are domain-separated to the previous chain's hash and won't verify on the new one.
 
 ---
 
@@ -57,7 +57,7 @@ Practical effect: every transaction's signature includes `CHAIN_HASH` in its dom
 
 This is the reason the chain doesn't need a separate "is this binary the right binary" check: the hash is the check. It's also the reason a hard fork is a real reset rather than a continuous upgrade — you can't roll a runtime change forward through `cargo update` and pretend nothing happened.
 
-The hash is reproducible across machines because the `Schema` is derived from canonical Rust types via a deterministic hasher, with the spec parameters pinned to `MockDaSpec + MockZkvm + MultiAddressEvm` for hash purposes regardless of the binary's actual DA / ZkVM / address spec at runtime. Two operators on `ligate-devnet-1` get byte-identical `CHAIN_HASH` outputs, even if one runs against MockDa locally and the other against Celestia mocha.
+The hash is reproducible across machines because the `Schema` is derived from canonical Rust types via a deterministic hasher, with the spec parameters pinned to `MockDaSpec + MockZkvm + MultiAddressEvm` for hash purposes regardless of the binary's actual DA / ZkVM / address spec at runtime. Two operators on `ligate-devnet-2` get byte-identical `CHAIN_HASH` outputs, even if one runs against MockDa locally and the other against Celestia mocha.
 
 ---
 
@@ -76,12 +76,12 @@ There is no on-chain "upgrade ceremony" for soft forks. The release is the upgra
 ### Hard-fork release flow (rare, deliberate)
 
 1. Decide the hard fork is necessary. Document why in an issue and link from the PR.
-2. Coordinate the new genesis with attestor org reps. Bump the chain id (e.g. `ligate-devnet-1` → `ligate-devnet-2`).
+2. Coordinate the new genesis with attestor org reps. Bump the chain id (e.g. `ligate-devnet-2` → `ligate-devnet-2`).
 3. Snapshot any state that should carry over (often: nothing; a hard fork is usually paired with a decision to drop all existing state). If state is migrating, write a one-off migration script and check it in as a tagged release artifact.
 4. Set a coordinated cutover time. Every operator restarts their node against the new chain id, the new binary, and (if applicable) the new genesis at the agreed cutover.
 5. The old chain stops producing blocks (sequencer is halted at the cutover); the new chain starts at height 0 with the new genesis.
 
-The operational runbook covering the T-7d through T+24h sequence is [`docs/development/runbooks/chain-id-bump.md`](../development/runbooks/chain-id-bump.md). The first `ligate-devnet-1 → ligate-devnet-2` cutover executes that runbook.
+The operational runbook covering the T-7d through T+24h sequence is [`docs/development/runbooks/chain-id-bump.md`](../development/runbooks/chain-id-bump.md). The first `ligate-devnet-2 → ligate-devnet-2` cutover executes that runbook.
 
 This is informal because it has to be. Pre-mainnet, there are no real funds at stake, no economic finality assumptions, and the operator pool is small enough to coordinate on a chat channel. Post-mainnet, this informality stops scaling and the upgrade module takes over (next section).
 
@@ -137,7 +137,7 @@ The strategic implication: **bake every known primitive into mainnet from day 1.
 | Paper | Lands in | Mechanism | Chain-id transition |
 |---|---|---|---|
 | **PoUA** (consensus weighting) | v3 mainnet from genesis | Module + warmup-then-activation soft fork | `ligate-testnet-1` → `ligate-1` |
-| **Native delegation** (Iris foundation) | v0.5 module | Chain-id bump | `ligate-devnet-1` → `ligate-devnet-2` |
+| **Native delegation** (Iris foundation) | v0.5 module | Chain-id bump | `ligate-devnet-2` → `ligate-devnet-2` |
 | **Per-schema fee markets** | v1 module | Chain-id bump | `ligate-devnet-2` → `ligate-testnet-1` |
 | **Cross-schema composition** | Post-mainnet, demand-driven | Upgrade module ceremony | Within `ligate-1` |
 | **Time-locked / commit-reveal attestations** | Post-mainnet, demand-driven | Upgrade module ceremony | Within `ligate-1` |

--- a/localnet/celestia.toml
+++ b/localnet/celestia.toml
@@ -16,7 +16,7 @@
 
 # Chain identity. This file targets the local Celestia smoke flow,
 # which is also the localnet rung of the ladder. Public Celestia
-# devnet bumps this to `ligate-devnet-1`. See #181 and the spec
+# devnet bumps this to `ligate-devnet-2`. See #181 and the spec
 # section `Chain id` in `docs/protocol/attestation-v0.md`.
 [chain]
 chain_id = "ligate-localnet"

--- a/localnet/local-dev-key.json
+++ b/localnet/local-dev-key.json
@@ -1,5 +1,5 @@
 {
-  "_warning": "LOCAL DEVELOPMENT KEY ONLY. DO NOT USE FOR DEVNET, TESTNET, OR MAINNET. The private key is committed to the repo so anyone can sign transactions on a localnet boot. Equivalent of Anvil's account-0 dev key for Ethereum testing. Operators deploying ligate-devnet-1 must remove this key's address from `devnet/genesis/bank.json` before generating the genesis bundle (see crates/genesis-tool).",
+  "_warning": "LOCAL DEVELOPMENT KEY ONLY. DO NOT USE FOR DEVNET, TESTNET, OR MAINNET. The private key is committed to the repo so anyone can sign transactions on a localnet boot. Equivalent of Anvil's account-0 dev key for Ethereum testing. Operators deploying ligate-devnet-2 must remove this key's address from `devnet/genesis/bank.json` before generating the genesis bundle (see crates/genesis-tool).",
   "role": "dev",
   "private_key_hex": "0101010101010101010101010101010101010101010101010101010101010101",
   "public_key_hex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",

--- a/localnet/rollup.toml
+++ b/localnet/rollup.toml
@@ -14,7 +14,7 @@
 # defaults below assume you run from the repo root.
 
 # Chain identity. Locked ladder per docs/protocol/attestation-v0.md
-# `Chain id` section: `ligate-localnet` (this file), `ligate-devnet-1`
+# `Chain id` section: `ligate-localnet` (this file), `ligate-devnet-2`
 # (public devnet), `ligate-testnet-1` (later), `ligate-1` (mainnet).
 # The node refuses to boot with a value outside the ladder; see #181.
 [chain]

--- a/ops/exporters/celestia-tia/README.md
+++ b/ops/exporters/celestia-tia/README.md
@@ -38,7 +38,7 @@ curl -s http://127.0.0.1:9101/metrics | grep celestia_node_da_signer_balance_uti
 #     targets = [{
 #       __address__ = "127.0.0.1:9101",
 #       job         = "celestia-tia",
-#       instance    = "ligate-devnet-1-sequencer",
+#       instance    = "ligate-devnet-2-sequencer",
 #     }]
 #     scrape_interval = "60s"
 #     forward_to = [prometheus.remote_write.grafana_cloud.receiver]

--- a/ops/exporters/celestia-tia/celestia-tia-exporter.py
+++ b/ops/exporters/celestia-tia/celestia-tia-exporter.py
@@ -31,7 +31,7 @@ Config via env:
     LIGHT_NODE_NETWORK      mocha
     DA_SIGNER_ADDRESS       celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33
     DA_SIGNER_ACCOUNT       da-signer   (friendly label; defaults to "da-signer")
-    LIGATE_INSTANCE         ligate-devnet-1-sequencer
+    LIGATE_INSTANCE         ligate-devnet-2-sequencer
     LIGATE_READY_URL        http://127.0.0.1:12346/ready
     LIGATE_READY_TIMEOUT    3   (seconds)
     POLL_INTERVAL_SEC       60
@@ -70,7 +70,7 @@ DA_SIGNER_ADDRESS = os.environ["DA_SIGNER_ADDRESS"]  # required; no default
 # hot/cold split, etc.) so dashboards group by account name instead of by
 # a 45-char bech32. Currently always "da-signer".
 DA_SIGNER_ACCOUNT = os.environ.get("DA_SIGNER_ACCOUNT", "da-signer")
-INSTANCE = os.environ.get("LIGATE_INSTANCE", "ligate-devnet-1-sequencer")
+INSTANCE = os.environ.get("LIGATE_INSTANCE", "ligate-devnet-2-sequencer")
 LIGATE_READY_URL = os.environ.get("LIGATE_READY_URL", "http://127.0.0.1:12346/ready")
 LIGATE_READY_TIMEOUT = float(os.environ.get("LIGATE_READY_TIMEOUT", "3"))
 POLL_INTERVAL_SEC = int(os.environ.get("POLL_INTERVAL_SEC", "60"))

--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -102,7 +102,7 @@ inside the VM / VPC:
 global:
   scrape_interval: 15s
   external_labels:
-    chain: ligate-devnet-1
+    chain: ligate-devnet-2
 
 scrape_configs:
   - job_name: ligate-node

--- a/ops/grafana/ligate-investor.json
+++ b/ops/grafana/ligate-investor.json
@@ -13,7 +13,7 @@
       },
       "id": 1,
       "options": {
-        "content": "# Ligate Devnet \u2014 Investor metrics\n\n**Chain:** `ligate-devnet-1` \u00b7 **DA:** celestia-mocha \u00b7 **API:** [api.ligate.io](https://api.ligate.io) \u00b7 **RPC:** [rpc.ligate.io](https://rpc.ligate.io) \u00b7 **Explorer:** [explorer.ligate.io](https://explorer.ligate.io)\n\nPublic-facing metrics sourced from `api.ligate.io` (`/v1/stats/*` + `/v1/info`). For chain-internal Prometheus metrics see [`Ligate Devnet \u2014 Operator view`](/d/ligate-operator).",
+        "content": "# Ligate Devnet \u2014 Investor metrics\n\n**Chain:** `ligate-devnet-2` \u00b7 **DA:** celestia-mocha \u00b7 **API:** [api.ligate.io](https://api.ligate.io) \u00b7 **RPC:** [rpc.ligate.io](https://rpc.ligate.io) \u00b7 **Explorer:** [explorer.ligate.io](https://explorer.ligate.io)\n\nPublic-facing metrics sourced from `api.ligate.io` (`/v1/stats/*` + `/v1/info`). For chain-internal Prometheus metrics see [`Ligate Devnet \u2014 Operator view`](/d/ligate-operator).",
         "mode": "markdown"
       },
       "title": "",

--- a/ops/grafana/ligate-operator.json
+++ b/ops/grafana/ligate-operator.json
@@ -13,7 +13,7 @@
       },
       "id": 1,
       "options": {
-        "content": "# Ligate Devnet \u2014 Operator view\n\nPrometheus metrics from `ligate-node:9100/metrics` (scraped by Alloy on `ligate-devnet-2-sequencer`, pushed to `grafanacloud-ligate-prom` every 15s). Chain ID: **`ligate-devnet-1`** \u00b7 Chain hash: `lsch1amq80arn\u2026` \u00b7 For business metrics see [`Ligate Devnet \u2014 Investor metrics`](/d/ligate-investor).\n\n**VM-level host metrics (CPU/disk/network)** are NOT here yet \u2014 Alloy needs a `prometheus.exporter.unix` block per [chain#363](https://github.com/ligate-io/ligate-chain/issues/363).",
+        "content": "# Ligate Devnet \u2014 Operator view\n\nPrometheus metrics from `ligate-node:9100/metrics` (scraped by Alloy on `ligate-devnet-2-sequencer`, pushed to `grafanacloud-ligate-prom` every 15s). Chain ID: **`ligate-devnet-2`** \u00b7 Chain hash: `lsch1amq80arn\u2026` \u00b7 For business metrics see [`Ligate Devnet \u2014 Investor metrics`](/d/ligate-investor).\n\n**VM-level host metrics (CPU/disk/network)** are NOT here yet \u2014 Alloy needs a `prometheus.exporter.unix` block per [chain#363](https://github.com/ligate-io/ligate-chain/issues/363).",
         "mode": "markdown"
       },
       "title": "",

--- a/ops/prometheus/alertmanager.yaml
+++ b/ops/prometheus/alertmanager.yaml
@@ -1,4 +1,4 @@
-# Alertmanager config for ligate-devnet-1.
+# Alertmanager config for ligate-devnet-2.
 #
 # NOTE: this file is the SELF-HOSTED FALLBACK path. The canonical wiring
 # for the public devnet operator is Grafana Cloud Alerting + the native


### PR DESCRIPTION
Cross-repo follow-up to the [devnet-2 cutover](https://github.com/ligate-io/ligate-chain/pull/493). After the chain itself migrated and api/cli/js/explorer flipped, an audit found ~37 stale \`ligate-devnet-1\` references in chain repo prose. This sweep handles the rest.

37 files, +96/-96 (pure rename). Touches:
- \`docs/protocol/*.md\` and \`docs/development/*.md\` operator runbooks + protocol docs
- \`crates/*/src/*.rs\` doc comments + error messages
- \`localnet/{rollup.toml, celestia.toml, local-dev-key.json}\` cross-references to the public devnet
- \`README.md\` ("\`ligate-devnet-2\` is live on Celestia Mocha-testnet")
- \`constants.toml\` comment
- \`ops/grafana/*.json\` description text (NOT UIDs or filenames, those preserved)
- \`ops/prometheus/alertmanager.yaml\` config header
- \`ops/grafana/README.md\` prose + Alloy scrape-label example

## Deliberately preserved

- \`archive/ligate-devnet-1/*\`, historical genesis bundle for the dead network
- \`CHANGELOG.md\`, historical entries
- \`docs/development/runbooks/chain-id-bump.md\`, the runbook documents THIS very bump (devnet-1 → devnet-2) as the canonical example
- \`crates/rollup/src/chain_config.rs:192\`, validator positive test \`validate_chain_id(\"ligate-devnet-1\").is_ok()\` (the ladder accepts past rungs by design; same as the \`devnet-42\` test)
- Grafana dashboard UIDs (\`/d/ligate-devnet-1-cost\`) + filenames (\`ligate-devnet-1-cost.json\`), renaming = re-provisioning deployed Grafana, distinct ops action
- GCS bucket \`ligate-devnet-1-backups\`, GCP secrets \`ligate-devnet-1-{celestia-signer-key,grafana-cloud-token}\`, VM name \`ligate-devnet-1-sequencer\`, deployed infrastructure identifiers, separate ops decision
- Chain-id-ladder enumerations that list all rungs (\`ligate-localnet, ligate-devnet-1, ligate-devnet-2, ligate-testnet-N, ligate-1\`)

## Test plan

- [x] No \`ligate-devnet-1\` left outside the deliberate-keep list
- [ ] CI green
