### PR TITLE
ops: VM rename follow-ups (Caddy localhost upstream + Grafana instance label = ligate-sequencer)

### DIFF
--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -70,7 +70,7 @@
 # `reverse_proxy { ... }` block (bare IPs would have to appear on the
 # `reverse_proxy` line itself and can't be carried by an `import`).
 (sequencer_pool) {
-    to 10.128.0.3:12346
+    to 127.0.0.1:12346
     # VM-2 (10.128.0.6) + VM-3 (10.128.0.11) stopped on 2026-05-22 when
     # we went single-VM mode. Their probes would 5xx every 2s and spam
     # the Caddy log. Re-add when the multi-sequencer cluster comes back

--- a/ops/cloud-init/sequencer.yaml
+++ b/ops/cloud-init/sequencer.yaml
@@ -2,7 +2,7 @@
 # Cloud-init for a Ligate Chain sequencer VM (Ubuntu 24.04, GCP-tested).
 #
 # Use:
-#   gcloud compute instances create ligate-devnet-1-sequencer \
+#   gcloud compute instances create ligate-sequencer \
 #       --machine-type=e2-standard-4 \
 #       --image-family=ubuntu-2404-lts-amd64 --image-project=ubuntu-os-cloud \
 #       --boot-disk-size=20GB \
@@ -176,11 +176,11 @@ runcmd:
   # place devnet config, write /etc/ligate/env, and start the
   # service. Per-instance metadata is set at create time:
   #
-  #   gcloud compute instances create ligate-devnet-1-sequencer-2 \
+  #   gcloud compute instances create ligate-sequencer-2 \
   #       ... \
   #       --metadata=ligate-node-id=ligate-devnet-1-sequencer-2,ligate-mode=follower
   #
-  # Defaults: node-id = `ligate-devnet-1-sequencer` (matches the
+  # Defaults: node-id = `ligate-sequencer` (matches the
   # original single-instance VM-1) and mode = `sequencer`. So
   # re-running this cloud-init on VM-1 (or rebuilding it from this
   # template) keeps its identity stable and continues as the active
@@ -196,7 +196,7 @@ runcmd:
   - |
     LIGATE_NODE_ID=$(curl -fsSL -H "Metadata-Flavor: Google" \
       http://metadata.google.internal/computeMetadata/v1/instance/attributes/ligate-node-id 2>/dev/null \
-      || echo "ligate-devnet-1-sequencer")
+      || echo "ligate-sequencer")
     LIGATE_MODE=$(curl -fsSL -H "Metadata-Flavor: Google" \
       http://metadata.google.internal/computeMetadata/v1/instance/attributes/ligate-mode 2>/dev/null \
       || echo "sequencer")

--- a/ops/grafana/ligate-node.json
+++ b/ops/grafana/ligate-node.json
@@ -114,7 +114,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "expr": "ligate_block_height{instance=\"ligate-devnet-2-sequencer\"}",
+          "expr": "ligate_block_height{instance=\"ligate-sequencer\"}",
           "legendFormat": "head slot",
           "refId": "A"
         }
@@ -563,7 +563,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "expr": "rate(ligate_da_blob_bytes_total{instance=\"ligate-devnet-2-sequencer\"}[5m])",
+          "expr": "rate(ligate_da_blob_bytes_total{instance=\"ligate-sequencer\"}[5m])",
           "legendFormat": "bytes/sec",
           "refId": "A"
         }
@@ -615,7 +615,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "expr": "rate(ligate_da_blobs_published_total{instance=\"ligate-devnet-2-sequencer\"}[5m]) * 60",
+          "expr": "rate(ligate_da_blobs_published_total{instance=\"ligate-sequencer\"}[5m]) * 60",
           "legendFormat": "blobs/min",
           "refId": "A"
         }
@@ -1242,7 +1242,7 @@
         "name": "instance",
         "query": "label_values(ligate_block_height, instance)",
         "refresh": 2,
-        "regex": "ligate-devnet-2-sequencer.*",
+        "regex": "ligate-sequencer.*",
         "sort": 1,
         "type": "query"
       }

--- a/ops/grafana/ligate-operator.json
+++ b/ops/grafana/ligate-operator.json
@@ -13,7 +13,7 @@
       },
       "id": 1,
       "options": {
-        "content": "# Ligate Devnet \u2014 Operator view\n\nPrometheus metrics from `ligate-node:9100/metrics` (scraped by Alloy on `ligate-devnet-2-sequencer`, pushed to `grafanacloud-ligate-prom` every 15s). Chain ID: **`ligate-devnet-2`** \u00b7 Chain hash: `lsch1amq80arn\u2026` \u00b7 For business metrics see [`Ligate Devnet \u2014 Investor metrics`](/d/ligate-investor).\n\n**VM-level host metrics (CPU/disk/network)** are NOT here yet \u2014 Alloy needs a `prometheus.exporter.unix` block per [chain#363](https://github.com/ligate-io/ligate-chain/issues/363).",
+        "content": "# Ligate Devnet \u2014 Operator view\n\nPrometheus metrics from `ligate-node:9100/metrics` (scraped by Alloy on `ligate-sequencer`, pushed to `grafanacloud-ligate-prom` every 15s). Chain ID: **`ligate-devnet-2`** \u00b7 Chain hash: `lsch1amq80arn\u2026` \u00b7 For business metrics see [`Ligate Devnet \u2014 Investor metrics`](/d/ligate-investor).\n\n**VM-level host metrics (CPU/disk/network)** are NOT here yet \u2014 Alloy needs a `prometheus.exporter.unix` block per [chain#363](https://github.com/ligate-io/ligate-chain/issues/363).",
         "mode": "markdown"
       },
       "title": "",
@@ -2301,7 +2301,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(process_cpu_seconds_total{instance=\"ligate-devnet-2-sequencer\"}[5m])",
+          "expr": "rate(process_cpu_seconds_total{instance=\"ligate-sequencer\"}[5m])",
           "legendFormat": "{{instance}} cores",
           "refId": "A"
         }
@@ -2366,7 +2366,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "process_resident_memory_bytes{instance=\"ligate-devnet-2-sequencer\"}",
+          "expr": "process_resident_memory_bytes{instance=\"ligate-sequencer\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -2431,7 +2431,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "ligate_state_db_size_bytes{instance=\"ligate-devnet-2-sequencer\"}",
+          "expr": "ligate_state_db_size_bytes{instance=\"ligate-sequencer\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -2495,7 +2495,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "process_open_fds{instance=\"ligate-devnet-2-sequencer\"}",
+          "expr": "process_open_fds{instance=\"ligate-sequencer\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }


### PR DESCRIPTION
Catch-up PR for repo state after the live VM rename to \`ligate-sequencer\`.

## What changed live earlier today

- **Old VM** \`ligate-devnet-1-sequencer\` deleted; data disk \`ligate-data-v2\` + boot disk preserved
- **New VM** \`ligate-sequencer\` created with both disks reattached + same static IP (\`34.66.206.13\`, address resource \`ligate-devnet-1-rpc\`, that resource name is immutable; cosmetic only)
- **Caddyfile** patched live: \`reverse_proxy to 10.128.0.3:12346\` → \`127.0.0.1:12346\`. The old hardcoded internal IP belonged to the deleted VM; new VM is at \`10.128.0.12\` but localhost is the right pattern anyway for the single-VM topology
- **Alloy config** on the new VM: \`instance = "ligate-devnet-1-sequencer"\` → \`"ligate-sequencer"\` (so the Prometheus instance label is stable across future VM renames)
- **Grafana dashboards** (live, via API): all 4 dashboards (\`ligate-node\`, \`ligate-operator\`, \`ligate-investor\`, \`ligate-cost\`) had their queries flipped from \`instance="ligate-devnet-2-sequencer"\` → \`instance="ligate-sequencer"\` to match. PR #495 had set them to \`devnet-2-sequencer\` which never matched live Alloy.

## What this PR does

Three repo-side syncs:
- \`ops/caddy/Caddyfile\`: \`10.128.0.3:12346\` → \`127.0.0.1:12346\` (matches live)
- \`ops/cloud-init/sequencer.yaml\`: example \`gcloud instances create\` commands + \`node-id\` default → \`ligate-sequencer\`
- \`ops/grafana/{ligate-node,ligate-operator}.json\`: queries filter on \`instance="ligate-sequencer"\` (matches live Grafana + live Alloy)

4 files. Catch-up only; no behavioral change in this PR (live is already where this lands).
