### PR TITLE
ci(bump-versions): set persist-credentials=false to fix actions/checkout@v6 + create-pull-request@v6 duplicate-Authorization 400

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -35,6 +35,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # actions/checkout@v6 persists its own `Authorization` header in
+          # the local git config. When `peter-evans/create-pull-request@v6`
+          # later pushes the auto-PR branch, it adds its own header too,
+          # producing `Duplicate header: "Authorization"` and a git HTTP
+          # 400. Disable persistence; the create-pull-request action
+          # supplies its own credential via the `token:` input below.
+          # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md
+          persist-credentials: false
 
       - name: Install yq
         run: |


### PR DESCRIPTION
## Summary

Fixes the `bump-versions: chain-released` workflow that failed on the v0.3.1 release ([run 26414629022](https://github.com/ligate-io/ligate-chain/actions/runs/26414629022)).

**Root cause**: `actions/checkout@v6` (bumped from v4 in #488, part of v0.3.1's dep-bump bundle) persists an `Authorization` header in the local git config. When `peter-evans/create-pull-request@v6` later pushes the auto-PR branch, it adds its own `Authorization` header. Two `Authorization` headers on the same git push request → `remote: Duplicate header: "Authorization"` → git HTTP 400 → workflow fails before the auto-PR opens.

**Fix**: set `persist-credentials: false` on the `actions/checkout@v6` step. `create-pull-request@v6` then supplies the only credential, via its `token:` input. Canonical fix per [create-pull-request docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md).

**Blast radius**: only this workflow is affected in chain. `release.yml` also uses `checkout@v6` but never pushes back, so it's fine. The downstream `bump-versions.yml` workflows in `ligate-io/docs` and `ligate-io/ligate-marketing` are still on `checkout@v4` (their v0.3.1 dispatches succeeded), but I'm filing the same pre-emptive `persist-credentials: false` PR on both so Dependabot's eventual v4→v6 bump doesn't reproduce this failure.

## Test plan

- [x] Confirmed `release.yml` doesn't push back, so it doesn't need the same fix.
- [x] Confirmed no other chain workflow pairs `checkout@v6` with `create-pull-request`.
- [ ] CI green on this PR.
- [ ] After merge: manually `workflow_dispatch` `bump-versions.yml` to re-run the failed v0.3.1 self-bump (`0.3.0` → `0.3.1` across the 7 paths in `.versions-paths.txt`). Daily 07:00 UTC cron is the safety net if I forget.