### PR TITLE
chain#503: auto-upgrade VMs on chain_hash-stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,27 @@ jobs:
           echo "Release notes preview (${VERSION}):"
           head -40 release-notes.md
 
+      # Emit a `chain-hash-unchanged.flag` release asset when the
+      # matching CHANGELOG section asserts that `chain_hash` is
+      # unchanged from the prior release. This is the green-light
+      # signal for `ops/systemd/ligate-auto-upgrade.timer` (#503): VM
+      # auto-upgrades only fire when this flag is present, because
+      # changing `chain_hash` requires state quarantine + replay (no
+      # safe binary swap path). Anchor matches the canonical prose
+      # we already write by hand (e.g. "`chain_hash` is unchanged",
+      # or "chain_hash unchanged"); add new variants here if the
+      # CHANGELOG style drifts.
+      - name: Emit chain-hash-unchanged.flag (when CHANGELOG marks it)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -qiE '\bchain[_ ]?hash\b[^\n]*\bunchanged\b|\bunchanged\b[^\n]*\bchain[_ ]?hash\b' release-notes.md; then
+            echo "Found chain_hash-unchanged anchor in release-notes.md; emitting flag asset."
+            touch release/chain-hash-unchanged.flag
+          else
+            echo "No chain_hash-unchanged anchor in release-notes.md; flag NOT emitted (auto-upgrade poller will treat this as chain_hash-changing and skip)."
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-upgrade VMs on chain_hash-stable releases.** Closes the manual-upgrade gap surfaced when v0.3.0 → v0.3.1 shipped with unchanged `chain_hash` but the live VM stayed on v0.3.0 until a human ran `upgrade-chain.sh`. Two pieces. (1) `release.yml` emits a `chain-hash-unchanged.flag` release asset when the matching `CHANGELOG` section asserts that `chain_hash` is unchanged from the prior release (regex matches the canonical prose we already write by hand). (2) `ops/systemd/ligate-auto-upgrade.{service,timer}` polls the GitHub Releases API hourly: if a new tag is published AND the flag is present AND the bump isn't major-version AND the operator hasn't set `/etc/ligate/auto-upgrade.disabled` as a kill-switch sentinel, the timer invokes `upgrade-chain.sh <tag>` to do the binary swap. Anything that fails any gate is a no-op log line in journald — nothing destructive happens implicitly. Cloud-init installs the timer + service + script automatically on fresh VMs; existing VMs pick it up via `install -m 0755 scripts/auto-upgrade.sh /opt/ligate/scripts/auto-upgrade.sh` + `install -m 0644 ops/systemd/ligate-auto-upgrade.* /etc/systemd/system/` + `systemctl enable --now ligate-auto-upgrade.timer`. Closes [#503](https://github.com/ligate-io/ligate-chain/issues/503).
+
 ## [0.3.1] - 2026-05-25
 
 Ops execution release after v0.3.0's wire-format break: ships the devnet-2 cutover, adopts stable-path naming for deployed infrastructure so future devnet rollovers stop accumulating renames, drops tx latency p50 from ~12s to ~7s via two `celestia.toml` tweaks, and pulls `release.yml` build wall-clock from ~25-30 min down to ~8-12 min. `chain_hash` unchanged from v0.3.0 (`eec077f4736df42cddb547236468dad32f1fd6822aaad1e822ce596307552df2`); v0.3.0 and v0.3.1 binaries are byte-compatible against `ligate-devnet-2` state.

--- a/ops/cloud-init/sequencer.yaml
+++ b/ops/cloud-init/sequencer.yaml
@@ -370,6 +370,28 @@ runcmd:
     chmod 644 /etc/alloy/config.alloy
     systemctl enable --now alloy
 
+  # Install the in-place upgrade tooling. `upgrade-chain.sh` is the
+  # canonical binary-swap script (operator-invoked: `sudo
+  # upgrade-chain.sh 0.X.Y`); `auto-upgrade.sh` is the hourly poller
+  # that calls it automatically when a chain_hash-stable release
+  # ships. Both come from the same cloned repo as the genesis
+  # bundle, so they track the pinned LIGATE_TAG above. Operators on
+  # an older VM can still pick up new versions of these scripts via
+  # `curl + install` per the runbook. (chain#503)
+  - |
+    mkdir -p /opt/ligate/scripts
+    install -m 0755 /tmp/ligate-chain/scripts/upgrade-chain.sh /opt/ligate/scripts/upgrade-chain.sh
+    install -m 0755 /tmp/ligate-chain/scripts/auto-upgrade.sh   /opt/ligate/scripts/auto-upgrade.sh
+
+  # Drop the auto-upgrade systemd units in place. The timer ticks
+  # hourly (`OnUnitActiveSec=1h`, +`RandomizedDelaySec=10min` jitter),
+  # the service wraps `auto-upgrade.sh` as a oneshot. Both are
+  # idempotent on re-runs of cloud-init: `install -C` skips when
+  # contents match. (chain#503)
+  - |
+    install -m 0644 /tmp/ligate-chain/ops/systemd/ligate-auto-upgrade.service /etc/systemd/system/
+    install -m 0644 /tmp/ligate-chain/ops/systemd/ligate-auto-upgrade.timer   /etc/systemd/system/
+
   # Start ligate-node. Cloud-init has placed the binary, devnet-1
   # config, /etc/ligate/env (managed), and /etc/ligate/env.d/celestia-signer
   # (secret drop-in) above. Alloy is also up and scraping. Follower-mode
@@ -378,3 +400,10 @@ runcmd:
   # happens at the operator's discretion (chain#422).
   - systemctl daemon-reload
   - systemctl enable --now ligate-node.service
+  # Enable the auto-upgrade timer. It defers the first check 10 min
+  # post-boot (`OnBootSec=10min`), so this `enable --now` only arms
+  # the timer; the actual poll runs after ligate-node has had time
+  # to come up and serve `/v1/rollup/info`. Disable on this VM with
+  # `touch /etc/ligate/auto-upgrade.disabled` (kill-switch sentinel)
+  # without disabling the timer itself.
+  - systemctl enable --now ligate-auto-upgrade.timer

--- a/ops/systemd/ligate-auto-upgrade.service
+++ b/ops/systemd/ligate-auto-upgrade.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Ligate Chain auto-upgrade poller
+# Wait for the chain to be up before polling — `auto-upgrade.sh`
+# reads the running version off `/v1/rollup/info`, so racing the
+# main service's startup just produces a "deferring" log line and
+# wastes a timer tick.
+After=ligate-node.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+# Runs as root because the work it delegates to (`upgrade-chain.sh`)
+# needs to `systemctl stop/start ligate-node` and `install -o ligate`
+# the new binary. The script itself does no destructive thing without
+# all four gates passing (kill-switch, major-bump check,
+# chain-hash-unchanged.flag, version comparison vs running).
+ExecStart=/opt/ligate/scripts/auto-upgrade.sh
+StandardOutput=journal
+StandardError=journal
+# `upgrade-chain.sh` polls service health for up to 90s, plus its
+# own download/install steps; 5 min is comfortable headroom.
+TimeoutStartSec=5min

--- a/ops/systemd/ligate-auto-upgrade.timer
+++ b/ops/systemd/ligate-auto-upgrade.timer
@@ -1,0 +1,21 @@
+[Unit]
+Description=Hourly ligate auto-upgrade check
+Requires=ligate-auto-upgrade.service
+
+[Timer]
+# Hourly is the right cadence: chain releases ship a few times per
+# week at devnet pace, and the binary swap itself is the long-pole
+# (~30s of downtime), so any sub-hour interval would be a no-op
+# most of the time. `OnBootSec=10min` gives the node a chance to
+# settle before the first check fires on a fresh VM.
+OnBootSec=10min
+OnUnitActiveSec=1h
+# Random jitter so a fleet of VMs doesn't synchronously hit the
+# GitHub API at exactly :00. Doesn't matter at fleet=1 but cheap
+# insurance for the day we run multiple nodes.
+RandomizedDelaySec=10min
+Persistent=true
+Unit=ligate-auto-upgrade.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/auto-upgrade.sh
+++ b/scripts/auto-upgrade.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Auto-upgrade poller for `ligate-node`. Runs hourly via the
+# `ligate-auto-upgrade.timer` systemd unit. Safely swaps the chain
+# binary when ALL of the following hold:
+#
+#   1. A new release is published on GitHub.
+#   2. The release ships a `chain-hash-unchanged.flag` asset (set by
+#      `release.yml` when the matching CHANGELOG section asserts
+#      `chain_hash` is unchanged — the only case where an in-place
+#      binary swap is safe without state quarantine + replay).
+#   3. The new version isn't a major-version bump from the running
+#      one (e.g. 0.x → 1.x stays manual).
+#   4. `/etc/ligate/auto-upgrade.disabled` doesn't exist (operator
+#      kill-switch: `touch` this file to pause auto-upgrades during
+#      incident response without disabling the timer).
+#
+# Anything that fails the gates is a no-op log line; nothing destructive
+# happens implicitly. The actual binary swap delegates to
+# `upgrade-chain.sh` (snapshot → stop → swap → start → verify →
+# auto-rollback on failure), so the safety story matches the manual
+# upgrade path exactly.
+#
+# Tracking issue: ligate-io/ligate-chain#503.
+
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────────────
+# Tunables. Override via env if a non-default install is in use.
+# ──────────────────────────────────────────────────────────────────────
+KILL_SWITCH="${KILL_SWITCH:-/etc/ligate/auto-upgrade.disabled}"
+LOCK_FILE="${LOCK_FILE:-/var/lock/ligate-auto-upgrade.lock}"
+UPGRADE_SCRIPT="${UPGRADE_SCRIPT:-/opt/ligate/scripts/upgrade-chain.sh}"
+RPC_URL="${RPC_URL:-http://127.0.0.1:12346}"
+GH_OWNER_REPO="${GH_OWNER_REPO:-ligate-io/ligate-chain}"
+SAFE_FLAG_NAME="${SAFE_FLAG_NAME:-chain-hash-unchanged.flag}"
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers.
+# ──────────────────────────────────────────────────────────────────────
+log() { printf '[auto-upgrade] %s\n' "$*"; }
+warn() { printf '[auto-upgrade] WARNING: %s\n' "$*" >&2; }
+
+# Bail without an error code on "nothing to do" exits. The systemd
+# unit logs these to journald either way, but the timer doesn't go red
+# on the next tick.
+done_ok() { log "$*"; exit 0; }
+
+# ──────────────────────────────────────────────────────────────────────
+# Gate 1: kill switch.
+# ──────────────────────────────────────────────────────────────────────
+if [[ -f "$KILL_SWITCH" ]]; then
+    done_ok "$KILL_SWITCH present; auto-upgrade paused. \`rm $KILL_SWITCH\` to re-enable."
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# Concurrency. flock makes overlapping timer ticks safe (also covers
+# operator running `auto-upgrade.sh` manually while the timer fires).
+# ──────────────────────────────────────────────────────────────────────
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+    done_ok "another auto-upgrade in flight (lock held); exiting"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# Read the running version off the chain itself. If the chain is
+# down, defer — restarting a downed chain via an auto-swap risks
+# masking a real outage. The hourly timer retries naturally.
+# ──────────────────────────────────────────────────────────────────────
+if ! INFO=$(curl -fsSL --max-time 5 "$RPC_URL/v1/rollup/info" 2>&1); then
+    warn "chain RPC unreachable at $RPC_URL/v1/rollup/info; deferring"
+    exit 0
+fi
+RUNNING=$(echo "$INFO" | jq -r '.version // empty')
+if [[ -z "$RUNNING" ]]; then
+    warn "couldn't parse .version from /v1/rollup/info response: $INFO"
+    exit 0
+fi
+log "running version: v$RUNNING"
+
+# ──────────────────────────────────────────────────────────────────────
+# Look up the latest release.
+# ──────────────────────────────────────────────────────────────────────
+if ! RELEASE_JSON=$(curl -fsSL --max-time 10 \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/$GH_OWNER_REPO/releases/latest"); then
+    warn "GitHub API unreachable; deferring"
+    exit 0
+fi
+TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name // empty')
+LATEST="${TAG#v}"
+if [[ -z "$LATEST" ]]; then
+    warn "couldn't parse .tag_name from latest release response"
+    exit 0
+fi
+
+if [[ "$RUNNING" == "$LATEST" ]]; then
+    done_ok "already at latest: v$LATEST"
+fi
+log "candidate upgrade: v$RUNNING → v$LATEST"
+
+# ──────────────────────────────────────────────────────────────────────
+# Gate 2: major-version safety. Major bumps stay manual indefinitely;
+# they always imply something interesting (chain_hash, state shape,
+# or genesis schema) that wants an operator in the loop.
+# ──────────────────────────────────────────────────────────────────────
+RUN_MAJOR="${RUNNING%%.*}"
+NEW_MAJOR="${LATEST%%.*}"
+if [[ "$RUN_MAJOR" != "$NEW_MAJOR" ]]; then
+    done_ok "v$RUNNING → v$LATEST is a MAJOR bump; manual upgrade required"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# Gate 3: the chain-hash-unchanged.flag asset. Absent means the release
+# author didn't assert chain_hash is preserved — i.e. either it did
+# change, or the assertion got lost. Either way, manual.
+# ──────────────────────────────────────────────────────────────────────
+HAS_FLAG=$(echo "$RELEASE_JSON" | jq -r --arg n "$SAFE_FLAG_NAME" \
+    '.assets[]? | select(.name == $n) | .name')
+if [[ -z "$HAS_FLAG" ]]; then
+    done_ok "v$LATEST is missing $SAFE_FLAG_NAME asset; treating as chain_hash-changing; manual upgrade required"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# All gates passed. Execute the upgrade through the canonical script;
+# anything that goes wrong there (sha256 mismatch, service stays down,
+# RPC reports the wrong version) auto-rollbacks to .prev and exits
+# non-zero, which surfaces in journald and the next timer tick re-tries.
+# ──────────────────────────────────────────────────────────────────────
+log "all gates passed; invoking $UPGRADE_SCRIPT $LATEST"
+"$UPGRADE_SCRIPT" "$LATEST"
+log "auto-upgrade complete: v$LATEST is now serving"


### PR DESCRIPTION
## Summary

Closes [#503](https://github.com/ligate-io/ligate-chain/issues/503). Closes the manual-upgrade gap surfaced today when v0.3.0 → v0.3.1 shipped with unchanged `chain_hash` but the live VM stayed on v0.3.0 until I ran `upgrade-chain.sh` by hand. Now those swap-safe upgrades land automatically within ~1h of the GitHub Release being published.

## Design

Two pieces, gated by four safety checks:

### 1. Release-time "safe-swap" signal

`release.yml` gains a new step (`Emit chain-hash-unchanged.flag`) that runs between the changelog extraction and the GitHub Release publish. It greps the just-extracted `release-notes.md` for the canonical prose we already write by hand (regex matches both `` `chain_hash` is unchanged `` and `chain_hash unchanged`). If found, it `touch`es `release/chain-hash-unchanged.flag`. The existing `files: release/*` glob in `softprops/action-gh-release` then picks it up as a release asset. Zero-byte sentinel; presence-or-absence is the only semantic.

Anchor was verified against the existing `CHANGELOG.md`: v0.3.1, v0.3.0, v0.2.14 all match (the swap-safe ones). Anchor lives in this PR's comment in `release.yml` so future CHANGELOG style changes can expand it without spelunking.

### 2. VM-side hourly poller

`ops/systemd/ligate-auto-upgrade.{service,timer}` runs `scripts/auto-upgrade.sh` hourly (`OnUnitActiveSec=1h`, `RandomizedDelaySec=10min` jitter, `OnBootSec=10min` first-fire delay so fresh VMs don't race ligate-node startup).

`auto-upgrade.sh` enforces four gates before invoking the existing `upgrade-chain.sh`:

| Gate | What | Failure mode |
|------|------|--------------|
| Kill-switch | `/etc/ligate/auto-upgrade.disabled` absent | `done_ok` log line; timer continues |
| Chain reachable | `/v1/rollup/info` returns 200 | Defer; next tick retries |
| Major-bump guard | Running major == latest major | `done_ok` log line; manual required |
| Safe-swap flag | `chain-hash-unchanged.flag` present in release assets | `done_ok` log line; manual required |

flock prevents concurrent runs. Anything that goes wrong in `upgrade-chain.sh` itself (sha256 mismatch, service stays down, RPC reports wrong version) triggers its existing auto-rollback to `.prev`.

### 3. Cloud-init wiring

`ops/cloud-init/sequencer.yaml` now `install`s both scripts to `/opt/ligate/scripts/` from the cloned chain repo (also automating `upgrade-chain.sh` install, which was previously a one-time manual step per the runbook) and drops the systemd units in place. Final step: `systemctl enable --now ligate-auto-upgrade.timer`.

## Operator notes

**Existing VM (live `ligate-sequencer`, running v0.3.1):** apply by hand after this PR merges:

```bash
git clone --depth 1 https://github.com/ligate-io/ligate-chain.git /tmp/lc
sudo install -m 0755 /tmp/lc/scripts/auto-upgrade.sh   /opt/ligate/scripts/auto-upgrade.sh
sudo install -m 0644 /tmp/lc/ops/systemd/ligate-auto-upgrade.service /etc/systemd/system/
sudo install -m 0644 /tmp/lc/ops/systemd/ligate-auto-upgrade.timer   /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now ligate-auto-upgrade.timer
```

**Pause auto-upgrade on a specific VM** (e.g. during incident response):

```bash
sudo touch /etc/ligate/auto-upgrade.disabled
```

**Resume:** `sudo rm /etc/ligate/auto-upgrade.disabled`. The timer itself never needs to be disabled.

**Trace logs:** `journalctl -u ligate-auto-upgrade.service -n 50`.

## Test plan

- [x] `bash -n scripts/auto-upgrade.sh` syntax check passes.
- [x] Regex anchor matches every existing CHANGELOG section that asserts `chain_hash` unchanged (verified against v0.3.1, v0.3.0, v0.2.14).
- [ ] CI green on this PR.
- [ ] After merge: install on the live `ligate-sequencer` VM per "Operator notes" above. Verify `systemctl status ligate-auto-upgrade.timer` shows scheduled next tick. Optional: trigger a manual run with `sudo systemctl start ligate-auto-upgrade.service && journalctl -u ligate-auto-upgrade -n 50` and confirm the "already at latest" log line (we're on v0.3.1 == latest, so no upgrade should happen).
- [ ] On the next chain_hash-stable release (v0.3.2 candidate, whenever that lands), confirm a `chain-hash-unchanged.flag` asset appears in the GitHub Release and the live VM auto-upgrades within ~1h.