### PR TITLE
ci(bump-versions): pre-empt Node 20 EOL by bumping peter-evans/create-pull-request v6 to v8

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           # actions/checkout@v6 persists its own `Authorization` header in
-          # the local git config. When `peter-evans/create-pull-request@v6`
+          # the local git config. When `peter-evans/create-pull-request@v8`
           # later pushes the auto-PR branch, it adds its own header too,
           # producing `Duplicate header: "Authorization"` and a git HTTP
           # 400. Disable persistence; the create-pull-request action
@@ -83,7 +83,7 @@ jobs:
 
       - name: Open auto-PR
         if: steps.bump.outputs.changed == '1'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: bump internal chain pins to v${{ steps.latest.outputs.chain }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
+### Changed
+
+- **Bump `peter-evans/create-pull-request@v6` → `@v8` in `.github/workflows/bump-versions.yml`.** v6 runs on Node.js 20, which GitHub forces to Node.js 24 on 2026-06-02 and removes from runners entirely on 2026-09-16. v8 is the latest line and ships Node 24 compatibility. The auto-PR semantics are unchanged across the bump (same inputs, same `Authorization`-header collision fix from [#501](https://github.com/ligate-io/ligate-chain/pull/501)). No other Actions in chain's workflow tree show the Node-20 deprecation warning today.
+
 ### Added
 
 - **Auto-upgrade VMs on chain_hash-stable releases.** Closes the manual-upgrade gap surfaced when v0.3.0 → v0.3.1 shipped with unchanged `chain_hash` but the live VM stayed on v0.3.0 until a human ran `upgrade-chain.sh`. Two pieces. (1) `release.yml` emits a `chain-hash-unchanged.flag` release asset when the matching `CHANGELOG` section asserts that `chain_hash` is unchanged from the prior release (regex matches the canonical prose we already write by hand). (2) `ops/systemd/ligate-auto-upgrade.{service,timer}` polls the GitHub Releases API hourly: if a new tag is published AND the flag is present AND the bump isn't major-version AND the operator hasn't set `/etc/ligate/auto-upgrade.disabled` as a kill-switch sentinel, the timer invokes `upgrade-chain.sh <tag>` to do the binary swap. Anything that fails any gate is a no-op log line in journald — nothing destructive happens implicitly. Cloud-init installs the timer + service + script automatically on fresh VMs; existing VMs pick it up via `install -m 0755 scripts/auto-upgrade.sh /opt/ligate/scripts/auto-upgrade.sh` + `install -m 0644 ops/systemd/ligate-auto-upgrade.* /etc/systemd/system/` + `systemctl enable --now ligate-auto-upgrade.timer`. Closes [#503](https://github.com/ligate-io/ligate-chain/issues/503).


### PR DESCRIPTION
## Summary

Pre-emptive Node 20 deprecation fix. `peter-evans/create-pull-request@v6` runs on Node.js 20, which GitHub forces to Node 24 on **2026-06-02** and removes from runners entirely on **2026-09-16** (per the deprecation warnings emitted by every workflow run today). v8 is the latest line and ships Node 24.

## Scope

One file (`bump-versions.yml`), two-line change:

- `uses: peter-evans/create-pull-request@v6` → `@v8`
- Comment in the `actions/checkout` block updated to reference v8 in the explanation of the `persist-credentials: false` workaround (no semantic change; the workaround is identical between v6 and v8).

## Why only this one action

Surveyed all action references in `.github/workflows/*.yml`. Every other action is on a Node-24-compatible version already:

- `actions/checkout@v6`, `actions/download-artifact@v8`, `actions/upload-artifact@v7`, current
- `codecov/codecov-action@v6`, `docker/build-push-action@v6`, `docker/login-action@v4`, `docker/setup-buildx-action@v4`, current
- `dorny/paths-filter@v4`, `softprops/action-gh-release@v3`, `Swatinem/rust-cache@v2`, `taiki-e/install-action@<task>`, current
- `contributor-assistant/github-action@v2.6.1`, community action, latest
- `dtolnay/rust-toolchain@{stable,master}`, rolling-tag action, current

The actions-runner annotation has only flagged `peter-evans/create-pull-request@v6` in chain's workflow runs.

## Test plan

- [x] Auto-PR semantics unchanged between v6 and v8 (same inputs, same `persist-credentials: false` collision fix from [#501](https://github.com/ligate-io/ligate-chain/pull/501)).
- [ ] CI green on this PR.
- [ ] After merge: next `chain-released` repository_dispatch (the chain self-bump on a future release) runs the v8 step. Or trigger manually via `workflow_dispatch` if we want to validate sooner.

Companion items in the same hygiene batch: cli env-var rename, docs `.md` URL convention (closes #218, Mintlify already serves it, just needs the doc note), `gh secret set DOWNSTREAM_DISPATCH_PAT` on cli (cli#46).
