### PR TITLE
fix(grafana-cost): wire GCP cost panels to rpc.ligate.io via new Infinity data source

### DIFF
--- a/ops/grafana/ligate-cost.json
+++ b/ops/grafana/ligate-cost.json
@@ -1,6 +1,6 @@
 {
   "description": "DA signer wallet (TIA) balance, burn rate, and runway. Powered by celestia-tia-exporter sidecar (ops/exporters/celestia-tia/). GCP cost panels (VM-hours, GCS storage, network egress, $USD MTD) are tracked separately in chain follow-up issue #392.",
-  "id": 2514337932513280,
+  "id": 802351786655744,
   "panels": [
     {
       "datasource": {
@@ -61,7 +61,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "afm64tqkoba4ga"
       },
-      "description": "AVOW balance of the faucet hot wallet (lig1kfaqfu\u2026). Drained by every successful drip (web @ 100 AVOW / bot @ 100-1000 AVOW). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 AVOW. Display shows raw nano-AVOW divided by 1e9 via the panel's Calculate-field transform.",
+      "description": "LGT balance of the faucet hot wallet (lig1kfaqfu…). Drained by every successful drip (web @ 100 LGT / bot @ 100-1000 LGT). Source: api.ligate.io/v1/addresses/<addr> via Infinity datasource. Top up from treasury when balance drops below ~10,000 LGT. Display shows raw nano-LGT divided by 1e9 via the panel's Calculate-field transform.",
       "fieldConfig": {
         "defaults": {
           "decimals": 2,
@@ -124,12 +124,12 @@
           }
         }
       ],
-      "title": "Faucet wallet AVOW balance",
+      "title": "Faucet wallet LGT balance",
       "transformations": [
         {
           "id": "calculateField",
           "options": {
-            "alias": "avow",
+            "alias": "lgt",
             "binary": {
               "left": "amount_nano",
               "operator": "/",
@@ -150,7 +150,7 @@
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years) \u2014 anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
+      "description": "Days of runway at observed burn rate, computed as balance / burn_per_day. Uses a 7d burn window for smoothing; clamps burn to a tiny floor (0.001 TIA/day) so periods of zero burn don't divide by zero. Display is capped at 3650 (10 years), anything that reaches the cap means runway is effectively unbounded at observed burn. Note: for ~7d after any large top-up the burn window still contains the step jump, so the rate clamps to 0 and runway shows the cap; this is correct behaviour, not a bug. Green > 90 days, yellow 30-90, red < 30. The absolute-balance thresholds on the panel above are the real alert trigger.",
       "fieldConfig": {
         "defaults": {
           "decimals": 1,
@@ -258,7 +258,7 @@
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative \u2014 without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
+      "description": "TIA burned per day, averaged over $window. clamp_min to 0 so balance INCREASES (top-ups) show as 0 burn instead of a giant negative, without that clamp, a 100k-TIA top-up over a 1h window appears as a -144M TIA/day rate, which is mathematically correct but operationally useless. Drawdown spike (>5 TIA/day) also drives the TIADrawdownSpike alert in ops/prometheus/alerts.yaml. Default window is 7d so the visualization smooths over any single top-up event; switch to 1h via the dropdown for live debugging.",
       "fieldConfig": {
         "defaults": {
           "decimals": 3,
@@ -491,7 +491,7 @@
         "type": "prometheus",
         "uid": "grafanacloud-prom"
       },
-      "description": "TIA burn rate over 5-minute windows, scaled to TIA/hour. Estimate. Steady-state value is `(blobs/hr) \u00d7 (per-blob estimate)`.",
+      "description": "TIA burn rate over 5-minute windows, scaled to TIA/hour. Estimate. Steady-state value is `(blobs/hr) × (per-blob estimate)`.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -545,7 +545,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "afm64tqkoba4ga"
       },
-      "description": "Total daily GCP infrastructure spend, USD. Sourced from Cloud Billing \u2192 BigQuery export \u2192 /opt/ligate/bin/gcp-cost-fetch.sh on VM-1 (refreshed every 6h via systemd timer) \u2192 https://rpc.ligate.io/cost/daily.json. Returns [] until ~24h after Console enable, then populates rolling 30-day window.",
+      "description": "Total daily GCP infrastructure spend, USD. Sourced from Cloud Billing → BigQuery export → /opt/ligate/bin/gcp-cost-fetch.sh on VM-1 (refreshed every 6h via systemd timer) → https://rpc.ligate.io/cost/daily.json. Returns [] until ~24h after Console enable, then populates rolling 30-day window.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -600,14 +600,17 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "afm64tqkoba4ga"
+            "uid": "cfnc6401c70u8c"
           },
+          "filters": [],
           "format": "timeseries",
+          "global_query_id": "",
+          "parser": "backend",
           "refId": "A",
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "https://rpc.ligate.io/cost/daily.json",
+          "url": "/cost/daily.json",
           "url_options": {
             "method": "GET"
           }
@@ -670,14 +673,17 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "afm64tqkoba4ga"
+            "uid": "cfnc6401c70u8c"
           },
+          "filters": [],
           "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
           "refId": "A",
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "https://rpc.ligate.io/cost/by-service.json",
+          "url": "/cost/by-service.json",
           "url_options": {
             "method": "GET"
           }
@@ -740,14 +746,17 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "afm64tqkoba4ga"
+            "uid": "cfnc6401c70u8c"
           },
+          "filters": [],
           "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
           "refId": "A",
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "https://rpc.ligate.io/cost/by-vm.json",
+          "url": "/cost/by-vm.json",
           "url_options": {
             "method": "GET"
           }
@@ -825,14 +834,17 @@
           ],
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
-            "uid": "afm64tqkoba4ga"
+            "uid": "cfnc6401c70u8c"
           },
+          "filters": [],
           "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
           "refId": "A",
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "https://rpc.ligate.io/cost/mtd.json",
+          "url": "/cost/mtd.json",
           "url_options": {
             "method": "GET"
           }
@@ -889,7 +901,7 @@
     "to": "now"
   },
   "timezone": "utc",
-  "title": "Ligate Devnet \u2014 Cost monitoring",
+  "title": "Ligate, Cost monitoring",
   "uid": "ligate-cost",
-  "version": 13
+  "version": 4
 }


### PR DESCRIPTION
## Summary

The 4 GCP cost panels on the Cost monitoring dashboard (`GCP daily burn`, `GCP spend by service`, `Compute Engine spend by VM`, `GCP month-to-date burn`) were showing "No data" despite the backing endpoints (`https://rpc.ligate.io/cost/{mtd,daily,by-service,by-vm}.json`) returning the right cost summaries.

## Root cause

Two compounding issues:

1. **Data source URL concatenation bug under PDC.** The Infinity data source `afm64tqkoba4ga` has base URL `https://api.ligate.io` and Grafana Cloud's Private Data source Connect proxy is enabled (`pdcInjected: true`). When a panel passes a fully-qualified URL like `https://rpc.ligate.io/cost/mtd.json`, PDC concatenates it onto the base URL, producing the malformed `https://api.ligate.iohttps//rpc.ligate.io/cost/mtd.json` (the `:` after `https` gets stripped in the merge). DNS lookup fails and the panel renders "No data".
2. **Missing `parser: "backend"` on the GCP panel targets.** Even after pointing at a clean data source, the Infinity targets needed `parser: "backend"` (which every other working panel in the org has) to actually frame-ify the JSON response. Without it, the response was fetched but `frames[0].data.values` stayed empty.

## Fix

Two changes, both already live on the dashboard (versions 3 + 4 + 5 on Grafana):

1. **New Infinity data source** `Infinity (rpc.ligate.io)` (uid `cfnc6401c70u8c`) with base URL `https://rpc.ligate.io`. Keeps the existing `Infinity (ligate-api)` data source untouched (used by 20+ working panels on other dashboards).
2. **The 4 GCP panels** now reference the new data source with path-only URLs (`/cost/mtd.json` etc), `parser: "backend"`, `filters: []`, and `global_query_id: ""` to match the shape of working panels (`ligate-investor::Top 10 LGT holders` etc).

Verified live: each panel's `frames[0].data.values` now returns real data through `POST /api/ds/query`:

- `/cost/mtd.json` → `[[35.04]]` (USD MTD)
- `/cost/by-service.json` → 8 services with Compute Engine $21.43 leading
- `/cost/by-vm.json` → 14 VMs (a mix of current `ligate-sequencer` and legacy disk/VM labels still in BQ history; will fade as BQ retention rolls over)
- `/cost/daily.json` → 7-day series from $0.92 to $0 latest

Em dashes in three pre-existing description strings (also dropped here) per house style.

## Why a new data source

The cleaner alternative would have been to add `/cost/*` endpoints to `api.ligate.io` so the existing data source could reach them path-only. That requires deploying new ligate-api handlers (Railway-deployed code), which is a bigger change than swapping a Grafana data source pointer. The new ds is the minimum viable fix; if/when the cost endpoints migrate to api.ligate.io alongside the rest of the indexer surface, the GCP panels swap back to the original data source and the rpc-specific one gets removed.

## Test plan

- [x] Live dashboard renders data for all 4 panels (verified via `POST /api/ds/query` against the new ds).
- [x] No regression to other panels (the existing `Infinity (ligate-api)` ds is untouched).
- [ ] CI green on this PR (JSON-only change).
- [ ] After merge: visually confirm on the Grafana UI.