### PR TITLE
docs(security): key-management RFC (GCP KMS pick) + operator key rotation runbook (chain#514)

### DIFF
--- a/docs/development/runbooks/operator-key-rotation.md
+++ b/docs/development/runbooks/operator-key-rotation.md
@@ -1,0 +1,251 @@
+# Runbook, Operator Wallet Key Rotation
+
+**Status:** v0, covers the procedure for the operator wallet key under two backing stores: the current file + GCP Secret Manager setup (devnet), and the GCP Cloud KMS setup specced in [`key-management.md`](../../protocol/key-management.md) (pre-mainnet target).
+
+This page covers rotating the **operator wallet key**, the bech32m address that holds the treasury balance assigned in genesis and signs operator-level transactions (faucet drips, sequencer registration, fee-routing config). It is distinct from:
+
+- The chain-side ed25519 signing key (batch authorisation), see [`sequencer-key-rotation.md`](./sequencer-key-rotation.md)
+- The Celestia DA signer (blob submission), see [`da-signer-rotation.md`](./da-signer-rotation.md)
+
+In our devnet-2 deployment all three may resolve to the same physical operator, but they are separate keys with separate rotation procedures. Read all three before any rotation event.
+
+**Tracks:** [chain#514](https://github.com/ligate-io/ligate-chain/issues/514)
+
+---
+
+## When does the operator wallet key need rotation?
+
+| Cause | Severity | What it blocks |
+|---|---|---|
+| **Compromise** (private key leaked / exfiltrated) | Critical | Adversary drains the treasury, submits drip txs from the faucet pool, can register/de-register sequencer slots if the operator role overlaps that authority. Rotate immediately. |
+| **Loss** (operator can't recover the key file, KMS access revoked) | High | We can't sign operator-level txs. Treasury is frozen until rotation. |
+| **Pre-mainnet hardening migration** | Planned | Move from file-backed to KMS-backed during the dry run before mainnet. |
+| **Routine policy** | Low | Periodic rotation per operator policy (e.g. annual). |
+
+The first three are forcing functions; the fourth is a planning exercise.
+
+---
+
+## Why this rotation is heavier than the DA rotation
+
+The operator key is treasury-balance-holding in genesis. The chain's `genesis/accounts.json` (or equivalent in the active devnet path) assigns the initial balance to a specific bech32m address. Changing that address means:
+
+1. **Genesis changes.** The new bech32m goes into `accounts.json` in place of the old one. The chain hash recomputes.
+2. **Chain id bump.** Because the chain hash is pinned via `chain_hash_pin.rs`, the deterministic chain identity changes. We bump the chain id ladder (e.g. `ligate-devnet-2` → `ligate-devnet-3`).
+3. **State is invalidated.** Existing nodes can't keep their RocksDB; every full node re-syncs from genesis.
+4. **Every downstream service re-points.** `ligate-cli`, `ligate-api`, `ligate-mneme`, the explorer all have env vars or config files that reference operator addresses or the chain id; each needs updating.
+
+This is closer in shape to [`chain-id-bump.md`](./chain-id-bump.md) than to [`da-signer-rotation.md`](./da-signer-rotation.md), and the procedure below leans on the chain-id-bump runbook for the genesis steps.
+
+---
+
+## Pre-rotation checklist (do this every time)
+
+- [ ] Read this page in full.
+- [ ] Confirm which key is being rotated (operator wallet, NOT sequencer signing, NOT DA signer).
+- [ ] Identify which downstream services reference the current operator address. Inventory: chain genesis, `rollup.toml`, `ligate-api` env vars, `ligate-cli` config, faucet bot config, monitoring dashboards.
+- [ ] Decide which Procedure (A, B, or C) applies.
+- [ ] Snapshot current state for rollback: RocksDB tarball, genesis files, config files, KMS key versions. Run the snapshot procedure from [`backup-restore.md`](./backup-restore.md).
+- [ ] Schedule a maintenance window (Procedure A only).
+- [ ] Pre-stage the replacement key (under operator control, not yet in genesis).
+
+---
+
+## Procedure A, planned rotation, file → file (devnet)
+
+Use case: routine rotation on devnet while we still use the file-backed setup. Acceptable when state is disposable (devnet is allowed to bump chain id).
+
+1. **Generate the replacement key.**
+   ```sh
+   ligate-cli keys generate --output ~/.ligate-keys/devnet-3/operator.key
+   # Records mnemonic, store separately from the node filesystem.
+   ```
+
+2. **Record the new bech32m address.**
+   ```sh
+   ligate-cli keys show ~/.ligate-keys/devnet-3/operator.key
+   # → lid1...
+   ```
+
+3. **Bump the chain id ladder.** Follow [`chain-id-bump.md`](./chain-id-bump.md) for the full procedure. Key steps:
+   - Update `devnet/genesis/accounts.json`: replace the old operator bech32m with the new one in the treasury-balance line.
+   - Update `devnet/genesis/sequencer_registry.json` if the sequencer's `bond_address` is the operator key.
+   - Update `devnet/rollup.toml` `[sequencer].rollup_address` if applicable.
+   - Bump `chain_id` from `ligate-devnet-N` to `ligate-devnet-(N+1)`.
+   - Recompute `CHAIN_HASH` (auto on next build).
+
+4. **Update downstream services in parallel** (before restart):
+   - `ligate-api` (Railway env vars): `LIGATE_OPERATOR_ADDRESS`, `CHAIN_ID`. See `~/.config/ligate/secrets.env` for Railway tokens.
+   - `ligate-cli` (config): operator address in any `~/.ligate-cli/config.toml`.
+   - `faucet-bot` (Railway env vars): operator address, if it submits drips from this key.
+   - Monitoring dashboards (Grafana): any panels filtering by operator address need the new bech32m.
+   - Explorer (`ligate-explorer`): hardcoded operator address constants in `ENV` or `wrangler.toml`.
+
+5. **TRUNCATE indexer Postgres** on `ligate-devnet-N-api` Railway service. Stale rows from the old chain id will cause merge conflicts when the new chain replays. Procedure: see [`backup-restore.md`](./backup-restore.md) §"Indexer state reset across chain id bump."
+
+6. **Re-genesis the sequencer.**
+   ```sh
+   systemctl stop ligate-node
+   rm -rf /var/lib/ligate/devnet-N/data/*
+   # Deploy new genesis + new key file (mode 0600)
+   systemctl start ligate-node
+   ```
+
+7. **Verify.**
+   ```sh
+   ligate-cli info             # should report new chain id
+   ligate-cli balance lid1...  # new operator address holds treasury balance
+   curl -s https://rpc.ligate.io/v1/rollup/info | jq .chain_id
+   ```
+
+8. **Revoke the old key.** Cryptographically you cannot un-sign historical state; the old key remains valid in the old genesis. What you do:
+   - Delete the file from laptop + Secret Manager + Keychain.
+   - Document the rotation event with timestamp + reason in `docs/development/runbooks/key-rotation-log.md` (create on first event).
+   - If the rotation was a compromise-driven event, publish a public attestation event so external observers know the old key is retired.
+
+**Estimated downtime:** ~30 minutes (genesis edit + downstream config updates + restart + verification). Schedule a maintenance window.
+
+---
+
+## Procedure B, emergency rotation under compromise
+
+Adversary has the operator private key. Time is the loss surface; every additional minute the adversary can sign treasury draws.
+
+1. **Drain the treasury to a cold address** (NOT the new operator key, a separate offline-only address). The adversary will try the same move; race them.
+   ```sh
+   ligate-cli send --from operator --to lid1...cold --amount <treasury - fees>
+   ```
+   If the adversary already drained, skip to step 2 and accept the loss; this is now a post-mortem exercise.
+
+2. **Pre-staged key on hand?** If yes, swap directly. If no, generate per Procedure A step 1 as fast as possible.
+
+3. **Run Procedure A steps 3-7** with no maintenance-window niceties. Bump the chain id, update genesis, restart. Every minute the old chain id is live, the adversary's key still works on it.
+
+4. **Public attestation event.** Post the rotation to the chain status page, the @ligate_io X account, and the official channels. Coordinate with partners (Mneme, anchor-buyer LOI holders) before they discover it themselves.
+
+5. **Post-mortem within 24 hours.** How did the key leak? Filesystem? Backup tarball? Logged crash dump? Whatever the gap was, tighten it before mainnet. This is exactly why we want KMS-backed keys before mainnet, so a single-laptop compromise is not a single-key compromise.
+
+The compromise window, from leak to chain-id-bump, is what determines actual loss. Pre-staging a replacement key and practicing this procedure on devnet keeps the window minutes, not hours.
+
+---
+
+## Procedure C, planned rotation, file → KMS (the pre-mainnet dry run)
+
+Use case: the migration described in [`key-management.md`](../../protocol/key-management.md) §6 step 3. This is the test of the KMS-backed path on devnet before mainnet ships.
+
+1. **Stand up `ligate-signer-proxy`.** Follow the deployment notes that will land in the new `crates/signer-proxy/README.md`. Service runs as a systemd unit on the sequencer VM.
+
+2. **Create the KMS keyring and operator key.**
+   ```sh
+   # One-time, done via gcloud (operator running with appropriate IAM):
+   gcloud kms keyrings create ligate-devnet-keys \
+     --location=us-central1
+   gcloud kms keys create operator-v1 \
+     --location=us-central1 \
+     --keyring=ligate-devnet-keys \
+     --purpose=asymmetric-signing \
+     --default-algorithm=ec-sign-ed25519 \
+     --protection-level=hsm
+   ```
+
+3. **Export the new public key + derive the bech32m address.**
+   ```sh
+   gcloud kms keys versions get-public-key 1 \
+     --key=operator-v1 \
+     --keyring=ligate-devnet-keys \
+     --location=us-central1 \
+     --output-file=operator-v1.pub
+   ligate-cli keys import-public --pub-file operator-v1.pub
+   # → derives lid1...
+   ```
+
+4. **Bind the signer-proxy service account to the key.**
+   ```sh
+   gcloud kms keys add-iam-policy-binding operator-v1 \
+     --location=us-central1 \
+     --keyring=ligate-devnet-keys \
+     --member="serviceAccount:ligate-signer@<project>.iam.gserviceaccount.com" \
+     --role=roles/cloudkms.signer
+   ```
+
+5. **Run Procedure A steps 3-5** to bump the chain id ladder with the new bech32m. The genesis edits are identical; only the backing store of the private key differs.
+
+6. **Switch `rollup.toml` to proxy mode.**
+   ```toml
+   [signer]
+   mode = "proxy"
+   socket_path = "/run/ligate-signer-proxy.sock"
+   ```
+
+7. **Start the proxy + the sequencer.** Confirm the chain signs its first batch successfully via the proxy. Check audit logs in Cloud Logging:
+   ```
+   resource.type="cloudkms_cryptokey" AND protoPayload.methodName="AsymmetricSign"
+   ```
+
+8. **Verify the steady state for at least 72 hours** before declaring the migration done. Watch:
+   - Signing latency p50/p99 (target: p50 < 50ms, p99 < 150ms per `key-management.md` R2)
+   - Error rate at the proxy
+   - Chain block production cadence (no slot-budget overrun)
+
+9. **Decommission the old file-backed key.** Delete from laptop + Secret Manager + Keychain. The KMS-backed key is now canonical.
+
+---
+
+## What chain-side observers see during rotation
+
+- **`/v1/rollup/info`**: `chain_id` changes (e.g. `ligate-devnet-2` → `ligate-devnet-3`).
+- **`/v1/ledger/slots/latest`**: resets to slot 0 of the new chain. Operators of full nodes re-sync from new genesis.
+- **All historical txs from the old chain are abandoned** at the consumer-API layer. The indexer Postgres is truncated and re-fills from the new genesis. Partner-facing notice required: see Procedure A step 4.
+
+If a partner queries the old chain id post-rotation, they get an empty result, not a redirect. The chain id is the namespace. Communication ahead of time prevents support load post-event.
+
+---
+
+## Verification checklist (post-rotation)
+
+```sh
+# 1. Chain identity reflects the bump
+curl -s https://rpc.ligate.io/v1/rollup/info | jq .chain_id
+
+# 2. Operator balance loaded from new genesis
+ligate-cli balance lid1...  # the new operator address
+
+# 3. Old operator address shows zero (or doesn't exist on the new chain)
+ligate-cli balance lid1...old  # not found
+
+# 4. Indexer ingestion caught up to current slot
+curl -s https://api.ligate.io/v1/stats/health | jq
+
+# 5. Faucet drip works end-to-end
+curl -X POST https://api.ligate.io/v1/drip/lid1...somenewaddr
+
+# 6. Sequencer is producing blocks at expected cadence
+curl -s https://rpc.ligate.io/v1/ledger/slots/latest | jq .height
+# Wait 30s, query again, height should advance.
+
+# 7. (KMS mode only) Cloud Audit Logs show signing events
+gcloud logging read 'resource.type="cloudkms_cryptokey"' --limit=5
+```
+
+If any check fails, halt and investigate before declaring the rotation complete. Rollback procedure: restore the snapshot from the pre-rotation checklist step.
+
+---
+
+## Open follow-ups
+
+1. **`docs/development/runbooks/key-rotation-log.md`.** Append-only log of every rotation event (date, reason, procedure used). Create on first rotation event.
+2. **Automate Procedure A steps 4-5 (downstream config updates + indexer truncate).** Currently a hand-edit across multiple repos. Filed as a follow-up to #514 once we've done one rotation by hand and know which env vars hurt most.
+3. **Test Procedure C end-to-end on localnet** before running it on devnet-2. Filed as a follow-up to #514.
+4. **HSM-tier signer-proxy crate** at `crates/signer-proxy`. Tracked separately per `key-management.md` §7 item 1.
+
+---
+
+## Cross-references
+
+- [`key-management.md`](../../protocol/key-management.md): the RFC that picks GCP Cloud KMS and specs the signer-proxy
+- [`sequencer-key-rotation.md`](./sequencer-key-rotation.md): chain-side ed25519 signing key rotation (different key, similar genesis impact)
+- [`da-signer-rotation.md`](./da-signer-rotation.md): Celestia DA wallet rotation (different key, no genesis impact)
+- [`chain-id-bump.md`](./chain-id-bump.md): the genesis + chain id bump procedure this runbook leans on for Procedure A steps 3-5
+- [`backup-restore.md`](./backup-restore.md): snapshot + restore procedures for the rollback path
+- [chain#514](https://github.com/ligate-io/ligate-chain/issues/514): tracking issue for this runbook + key-management RFC
+- [chain#360](https://github.com/ligate-io/ligate-chain/issues/360): parent pre-mainnet security gap tracker

--- a/docs/protocol/key-management.md
+++ b/docs/protocol/key-management.md
@@ -1,0 +1,199 @@
+# Key Management, Design Decision
+
+**Status:** decision recorded for pre-mainnet implementation; devnet stays on file-backed keys
+**Scope:** how Ligate Chain stores and uses the operator + DA wallet keys for `ligate-sequencer` and downstream services
+**Applies to:** the operator key at `~/.ligate-keys/devnet-2/operator.key`, the Celestia DA signer key in GCP Secret Manager (`ligate-celestia-signer-key`), and any future per-validator keys once the staking module ([#50](https://github.com/ligate-io/ligate-chain/issues/50)) ships
+**Tracks:** [chain#514](https://github.com/ligate-io/ligate-chain/issues/514), child of [chain#360](https://github.com/ligate-io/ligate-chain/issues/360)
+
+---
+
+## TL;DR
+
+**Pick GCP Cloud KMS with HSM-tier protection** for operator + DA keys. Stand up a thin local signer-proxy (`ligate-signer-proxy`) that wraps `crypto.signAsymmetric()` calls against a KMS keyring. The chain binary speaks to the proxy over a Unix domain socket, never sees the private key material.
+
+**Migrate devnet-2 keys as the dry run** before mainnet. Devnet stays on the existing file + Secret Manager setup until the proxy is hardened.
+
+**Out of scope:** AWS CloudHSM (cross-cloud, too expensive for this stage), HashiCorp Vault (more ops surface for marginal gain), YubiHSM (physical-device model does not fit remote VMs).
+
+---
+
+## 1. What we have today
+
+| Key | Stored | Used by | Blast radius if compromised |
+|-----|--------|---------|------------------------------|
+| Operator key (`operator.key`) | Laptop filesystem, macOS Keychain, GCP Secret Manager | `ligate-sequencer`, `ligate-cli` (faucet drip), genesis treasury holder | Adversary signs faucet drips, drains treasury balance, can sign batches if the operator role overlaps the sequencer signing key |
+| Celestia DA signer | GCP Secret Manager (`ligate-celestia-signer-key`) | `ligate-sequencer` blob-submission path | Adversary drains TIA balance, blocks DA submission via fee-bidding wars. Chain state is safe. |
+| Faucet signer | Faucet repo's own Secret Manager binding | `faucet-bot` only | Faucet-only loss surface; tracked separately in the faucet repo |
+
+The devnet-2 setup is fine for "we are the only operator and we control the laptop." It is not fine for mainnet, where a key compromise should require the adversary to break a hardware boundary, not exfiltrate a file.
+
+## 2. Requirements
+
+The chosen backing store must satisfy:
+
+**R1. Hardware-rooted protection of private key material.** Private bytes never leave the secure boundary in cleartext. Signing happens inside the boundary; what comes out is the signature.
+
+**R2. Latency budget for hot signing.** Sequencer signs every batch (~1 batch per slot, ~1s on devnet). DA signer signs every blob submission. KMS round-trip needs to be well under the slot budget. Target: p50 < 50ms, p99 < 150ms.
+
+**R3. Audit-grade access logs.** Every signing operation produces a log line with caller identity, key id, timestamp. Required for IR forensics post-incident.
+
+**R4. Survives single-VM loss.** Key material is not VM-local. A wiped sequencer VM can spin up a replacement, authenticate to the KMS, resume signing.
+
+**R5. Same-cloud + same-IAM-plane as the rest of our infra.** Everything else is GCP. Adding a second cloud's IAM model for a single key store is operational overhead with no security gain.
+
+**R6. Migration path from the current file + Secret Manager setup.** Drop-in for the signer abstraction inside `ligate-sequencer`; no breaking change for downstream consumers.
+
+## 3. Options considered
+
+### Option 1, GCP Cloud KMS (recommended)
+
+Native GCP service. Software-backed by default; HSM-backed available as a key option (`PROTECTION_LEVEL=HSM`, FIPS 140-2 Level 3, the bytes physically live in a Google-operated HSM).
+
+**Cost:** $1.00/key/month (HSM tier, asymmetric ed25519) + $0.06/10k signing operations. For operator + DA at one signing op per second: ~$3/month per key. Plus a few cents per million ops on signing volume. Effectively negligible.
+
+**Latency:** Median 30-40ms from a GCP VM in the same region. Well inside R2.
+
+**Ops surface:** IAM-managed, audit-logged via Cloud Audit Logs. Granular per-key permissions. No service to run; KMS is fully managed.
+
+**Migration shape:** Generate ed25519 key in KMS, export public key, register the new public key in genesis (re-genesis event), rotate downstream services to call the signer-proxy. See `docs/development/runbooks/operator-key-rotation.md` for the procedure.
+
+**Risks:** Cloud-provider lock-in for the signing API. Mitigated because the signer-proxy abstraction sits between the chain and KMS; swapping providers later is a proxy-side change, not a chain-side change.
+
+### Option 2, AWS CloudHSM
+
+Dedicated HSM instance, FIPS 140-2 Level 3. Higher assurance than KMS HSM-tier, also higher cost.
+
+**Cost:** $1.50/hour per HSM, ~$1,080/month minimum. HA setup needs at least 2 HSMs across AZs for ~$2,160/month.
+
+**Latency:** Inside AWS region: ~10-20ms. From GCP via cross-cloud: 80-150ms; that pushes against R2 for the slot budget.
+
+**Ops surface:** Self-managed cluster (`cloudhsmv2` SDK), key backup procedures, AZ rebalancing. More day-2 work than KMS.
+
+**Verdict:** Too expensive for current stage. Reconsider post-mainnet if (a) we move to AWS-native infra, or (b) regulatory pressure forces dedicated-HSM assurance over multi-tenant HSM.
+
+### Option 3, HashiCorp Vault
+
+Open source secret manager. Can use cloud HSM for auto-unseal; signs via Transit secrets engine.
+
+**Cost:** OSS is free; HCP Vault starts at $0.03/hour/cluster = ~$22/month for a single dev-tier cluster. Self-host adds VM + ops time.
+
+**Latency:** Vault server within the same VPC: 20-50ms. Acceptable.
+
+**Ops surface:** Vault server itself (HA, backups, unseal procedures), Transit engine policies, IAM integration. Adds a moving part the team has to learn and run.
+
+**Why we are not picking this:** We are GCP-only. Vault shines when you need a multi-cloud abstraction or want to keep secrets out of the cloud provider's KMS. Neither applies. KMS does the same job with less ops surface for our setup.
+
+**Reconsider trigger:** if we go multi-cloud (e.g. AWS-side ZK prover infrastructure that needs the same signing key), Vault becomes the right shape.
+
+### Option 4, YubiHSM 2
+
+Physical USB device, $650 per HSM, FIPS 140-2 Level 3.
+
+**Cost:** $650 per device, no recurring fee. Two devices for redundancy = $1,300 one-time.
+
+**Latency:** Microseconds (USB-local) on the host that owns the device.
+
+**Ops surface:** Physical presence at the signing host. Does not fit a remote-VM-only operator model. To use a YubiHSM with a GCP VM, you would need either (a) a self-hosted machine somewhere that talks to GCP, or (b) a remote-attestation setup, neither of which we currently have.
+
+**Verdict:** Wrong model for our deployment. Useful for a self-hosted prover in v2+ if we go that route.
+
+### Option 5, Status quo (file + GCP Secret Manager)
+
+Current devnet setup. Keys live as files on disk, mirrored into GCP Secret Manager. Chain binary loads via env var pointing at a path.
+
+**Why this is unacceptable for mainnet:** R1 fails. A laptop compromise, a leaked crash dump, a misconfigured backup, or an exfiltrated Secret Manager export gives the adversary the raw bytes. There is no hardware boundary.
+
+**Why this is acceptable for devnet:** the threat model is "we have to dogfood the runtime before mainnet"; key compromise on devnet is a redo cost, not a real loss.
+
+## 4. Recommendation
+
+**Pick GCP Cloud KMS with HSM-tier protection.**
+
+| Criterion | KMS verdict |
+|-----------|-------------|
+| R1 hardware-rooted | ✅ HSM-tier keys |
+| R2 latency budget | ✅ p50 ~35ms, p99 well under 150ms |
+| R3 audit logs | ✅ Cloud Audit Logs admin + data access |
+| R4 survives VM loss | ✅ Keys are not VM-resident |
+| R5 same cloud + IAM | ✅ Native GCP |
+| R6 migration path | ✅ Signer-proxy abstraction |
+| Cost | $3-5/month per key, lowest of the hardware-backed options |
+| Ops surface | Lowest |
+
+## 5. Signer-proxy design sketch
+
+A small Rust binary `ligate-signer-proxy` runs alongside `ligate-sequencer` on the same VM. The chain talks to the proxy over a Unix domain socket (no TCP, no remote auth needed):
+
+```
+ligate-sequencer  ────[uds]────►  ligate-signer-proxy  ────[grpc]────►  GCP Cloud KMS
+                                  (ADC via VM service account)
+```
+
+### Why the proxy exists
+
+- Isolates the KMS SDK + retry logic + circuit breaker from the chain binary.
+- Lets us swap KMS for Vault / CloudHSM / file later without touching `ligate-sequencer`.
+- Per-request audit logging happens in one place.
+- Restart of the proxy does not restart the chain.
+
+### Wire shape
+
+The proxy exposes a tiny RPC:
+
+```rust
+service Signer {
+  rpc Sign(SignRequest) returns (SignResponse);
+  rpc Pubkey(PubkeyRequest) returns (PubkeyResponse);
+}
+
+message SignRequest {
+  string key_id = 1;       // e.g. "operator" | "da"
+  bytes payload = 2;       // raw bytes to sign
+}
+
+message SignResponse {
+  bytes signature = 1;
+}
+```
+
+The chain calls `Sign(key_id="operator", payload=batch_hash)` once per batch. The proxy maps `key_id` to a fully-qualified KMS resource and calls `asymmetricSign`.
+
+### Config shape
+
+```toml
+# rollup.toml
+[signer]
+mode = "proxy"                # "file" for devnet, "proxy" for mainnet
+socket_path = "/run/ligate-signer-proxy.sock"
+```
+
+### Failure semantics
+
+- Proxy down → chain refuses to start (no fallback to file in proxy mode).
+- KMS unreachable → proxy returns a transient error; chain retries up to N times then halts batch production with a clear log line.
+- Proxy crashes mid-batch → chain aborts the batch, logs, retries next slot.
+
+## 6. Migration plan (devnet-2 dry run, then mainnet)
+
+1. **Build `ligate-signer-proxy`.** New crate at `crates/signer-proxy`. Reuses the existing `Signer` trait in `crates/rollup/src/signer.rs` with a `Proxy` variant alongside `File`.
+2. **KMS keyring setup.** Create `ligate-mainnet-keys` keyring with two HSM-tier keys: `operator-v1` and `da-signer-v1`. Document the `gcloud kms` commands in the rotation runbook.
+3. **Devnet-2 dry run.** Migrate devnet-2 to proxy mode behind a feature flag. Run for one week. Watch metrics: signing latency p50/p99, error rate, audit log volume.
+4. **Operator key rotation runbook end-to-end test.** Generate a fresh KMS key, run Procedure A from the runbook on the devnet, confirm chain stays healthy across the switch.
+5. **Mainnet bootstrap with proxy mode from day 0.** No mainnet binary ever ships with `signer.mode = "file"`.
+
+## 7. Open follow-ups
+
+This RFC unblocks these issues but does not close them:
+
+1. **Implement `crates/signer-proxy`.** New crate, ~500-1000 lines of Rust. Filed as a follow-up to #514.
+2. **`gcloud kms` keyring + IAM bindings as Terraform.** Infra-as-code lives in `ops/terraform/keys.tf` (to be created). Filed as a follow-up to #514.
+3. **Signer-proxy alerting.** Latency p99, error rate, audit-log-volume drop. Lives in `docs/development/runbooks/alerts/` once the alerting wiring from [#318](https://github.com/ligate-io/ligate-chain/issues/318) is in place.
+4. **Per-validator key model post-#50.** Once the staking module ships and external validators come online, each operator needs their own key-management story. This RFC is for Ligate-Labs-operated keys; the per-validator model is its own design pass.
+
+## 8. Cross-references
+
+- [chain#360](https://github.com/ligate-io/ligate-chain/issues/360): parent security gap tracker (pre-mainnet umbrella)
+- [chain#514](https://github.com/ligate-io/ligate-chain/issues/514): this RFC's tracking issue
+- [`operator-key-rotation.md`](../development/runbooks/operator-key-rotation.md): the rotation procedure that builds on this RFC
+- [`sequencer-key-rotation.md`](../development/runbooks/sequencer-key-rotation.md): chain-side ed25519 signing key rotation (distinct from operator wallet key)
+- [`da-signer-rotation.md`](../development/runbooks/da-signer-rotation.md): Celestia DA wallet rotation


### PR DESCRIPTION
Closes [chain#514](https://github.com/ligate-io/ligate-chain/issues/514) (child of [chain#360](https://github.com/ligate-io/ligate-chain/issues/360) pre-mainnet security gap tracker).

## Summary

Two coupled docs, the issue specifically calls out that the HSM/Vault decision is a fork-in-the-road before the rotation procedure differs by backing store:

1. **`docs/protocol/key-management.md`** (199 lines): RFC picking GCP Cloud KMS (HSM-tier) for operator + DA keys. Stand up a thin `ligate-signer-proxy` (Unix-socket-only) so the chain binary never sees private key material. Compares KMS vs AWS CloudHSM vs Vault vs YubiHSM vs status quo against 6 explicit requirements.
2. **`docs/development/runbooks/operator-key-rotation.md`** (251 lines): three procedures (planned file → file, emergency under compromise, file → KMS pre-mainnet dry run). Cross-references the existing `chain-id-bump.md`, `sequencer-key-rotation.md`, `da-signer-rotation.md`, `backup-restore.md`. Includes pre-rotation checklist + post-rotation verification queries.

## Why this matters

Today the operator key sits at `~/.ligate-keys/devnet-2/operator.key` (laptop + Keychain + Secret Manager). Devnet is fine on this; mainnet is not, because a laptop compromise is a single-laptop key compromise. This RFC unblocks the migration to hardware-backed protection with a clear procedure for the dry run.

## What this PR does NOT do (filed as follow-ups inside the RFC)

- Implementation of `crates/signer-proxy` (Rust crate)
- `ops/terraform/keys.tf` IAM bindings
- Signer-proxy alerting (lives in #318's alerting wiring)
- Per-validator key model post-#50 staking module

## Test plan
- [ ] Markdown renders cleanly on GitHub
- [ ] No em dashes (style rule)
- [ ] All cross-doc links resolve (sequencer-key-rotation, da-signer-rotation, chain-id-bump, backup-restore)
- [ ] All cross-issue links resolve (#50, #318, #360, #514)