### PR TITLE
docs(opsec): GCP audit logs + incident response + disaster recovery runbooks (chain#513)

### DIFF
--- a/docs/development/runbooks/disaster-recovery.md
+++ b/docs/development/runbooks/disaster-recovery.md
@@ -1,0 +1,201 @@
+# Runbook, Disaster Recovery
+
+**Status:** v0, the "after" half of [`incident-response.md`](./incident-response.md). Procedures for the four failure modes that escape routine ops.
+**Tracks:** [chain#513](https://github.com/ligate-io/ligate-chain/issues/513), child of [chain#360](https://github.com/ligate-io/ligate-chain/issues/360)
+
+A written DR runbook that has never been exercised is theatre. Each scenario below has a "rehearsal checklist" indicating whether we have actually run the procedure end-to-end. Anything marked unrehearsed must be rehearsed on `ligate-localnet` (or a throwaway VM) before mainnet.
+
+---
+
+## Scenarios at a glance
+
+| Scenario | Trigger | RTO (target) | Rehearsed? |
+|----------|---------|--------------|------------|
+| RocksDB corruption | Chain detects invariant violation; node refuses to start with corruption error | <1h | ✅ via [`backup-restore.md`](./backup-restore.md) drill |
+| Total VM loss | Sequencer VM unrecoverable (cloud-side failure, ransomware, instance deletion) | <4h | ❌ pre-mainnet rehearsal required |
+| Celestia DA outage >N hours | Celestia mocha-4 down past our patience threshold | depends on duration | ❌ pre-mainnet rehearsal required |
+| Sequencer / operator / DA key compromise | See [`incident-response.md`](./incident-response.md) Scenario 4 | <30min contain, <8h rotate | ❌ pre-mainnet rehearsal required |
+
+RTO = Recovery Time Objective. The time from "we declare disaster" to "chain healthy again."
+
+---
+
+## Scenario A, RocksDB corruption
+
+The most common DR scenario, the chain detects state-machine invariant violations (an attestation that fails verification, a transition that contradicts on-chain state). The chain refuses to advance and logs a clear error.
+
+### Detection
+
+- `ligate-node` exits with `state corruption detected at slot X`
+- Restart loop with the same error
+- `journalctl -u ligate-node` shows RocksDB read failure or assertion failure
+
+### Procedure
+
+1. **Confirm the corruption is in state, not in the binary.** Try a previous binary version via [`chain-upgrade.md`](./chain-upgrade.md) auto-rollback. If the previous binary also fails on the same RocksDB, the corruption is on the state side.
+
+2. **Stop the node.**
+   ```sh
+   sudo systemctl stop ligate-node
+   ```
+
+3. **Snapshot the corrupted state for forensics** (NOT for restoration, the forensics matter for the post-mortem). Tarball `/var/lib/ligate/rocksdb` to a different path before overwriting.
+
+4. **Restore from the latest known-good snapshot.** Follow [`backup-restore.md`](./backup-restore.md) §"Restore procedure." This brings the chain back to the slot of the snapshot.
+
+5. **Replay forward from the snapshot.** The chain catches up to current Celestia tip automatically once the node restarts; the canonical batch stream lives on Celestia. Watch `/v1/ledger/slots/latest` advance.
+
+6. **Verify integrity.** Run the rollup-info + slot-advance + light-node-sync checks from `incident-response.md` Scenario 1 "declare resolved when" list.
+
+### What we cannot do
+
+If all snapshots are corrupt (the corruption predates the oldest snapshot), the only remaining option is **rebuild from DA from genesis**. This is hours of replay. The state-snapshot-publishing follow-up at [#273](https://github.com/ligate-io/ligate-chain/issues/273) makes this faster post-ship.
+
+### Rehearsal
+
+The quarterly restore drill in [`backup-restore.md`](./backup-restore.md) covers steps 4-6. The "snapshot the corrupted state" step (3) is the only step not in the drill; add a synthetic dirty-RocksDB step to the next drill iteration to cover it.
+
+---
+
+## Scenario B, total VM loss
+
+The sequencer VM is unrecoverable. Possible causes: cloud-provider hardware failure, accidental `gcloud compute instances delete`, ransomware on the VM, region-wide GCP outage.
+
+The chain's persistent state is on a separate persistent disk (`/dev/sdb`, RocksDB on `/var/lib/ligate/rocksdb`), so disk loss is a different story from VM loss. This scenario assumes the disk is also gone or unrecoverable.
+
+### Procedure (rebuild from GCS snapshot + Celestia DA)
+
+1. **Provision a new VM** via [`public-devnet-deploy.md`](../public-devnet-deploy.md). Same machine type (`e2-standard-2` for devnet, larger for mainnet), same OS, same disk size.
+
+2. **Cloud-init bootstrap** installs the `ligate-node` binary, Caddy, log-shipping agent, etc. Per [`public-devnet-deploy.md`](../public-devnet-deploy.md).
+
+3. **Restore RocksDB from the latest GCS snapshot.** [`backup-restore.md`](./backup-restore.md) procedure. Determines the slot the chain restarts from.
+
+4. **Re-attach DNS + Cloudflare.** Update Cloudflare A record for `rpc.ligate.io` to the new VM's external IP. Confirm CF cache purged (`cloudflare-cli purge`). Status page update for the brief downtime.
+
+5. **Restore the operator key + DA signer** from GCP Secret Manager (or KMS once #514 ships). The keys live outside the VM exactly so this step is "fetch and configure," not "regenerate and re-genesis."
+
+6. **Restart `ligate-node`.** Catches up from snapshot slot to current Celestia tip.
+
+7. **Verify** via the standard healthcheck panel + a synthetic transaction (drip from the faucet, check it lands).
+
+### Common failure modes during rebuild
+
+| Failure | Mitigation |
+|---------|------------|
+| Cloud-init fails (network, package install) | Inspect `/var/log/cloud-init-output.log`, run failed steps manually, file infra bug |
+| Latest GCS snapshot is corrupt | Fall back to previous snapshot (drift by snapshot interval) |
+| All GCS snapshots are corrupt | Replay from DA, see Scenario A "What we cannot do" |
+| Cloudflare propagation slow | Set CF TTL low (60s) on the A record so failover is bounded; document in `public-devnet-deploy.md` |
+
+### Rehearsal
+
+**Not rehearsed.** Pre-mainnet must-have: spin up a parallel test VM, follow steps 1-7 end-to-end, time the result. Target RTO 4h; if the rehearsal takes longer, automate the bottleneck. Filed as a follow-up to #513.
+
+---
+
+## Scenario C, Celestia DA outage extending beyond N hours
+
+Celestia mocha-4 testnet is down. We can't post blobs. The chain stalls.
+
+This is the scenario where N matters most. Short outages (<1h) are routine and need no DR; we wait. Long outages (>4h) start hurting partners. Indefinite outages force a hard choice.
+
+### Detection
+
+- `ligate-node` logs `failed to submit blob to celestia` repeatedly
+- Celestia community channels confirm a network-wide issue
+- `celestia-appd query block latest` from a separate Celestia node times out or returns very stale heights
+
+### Step 1, wait (the first N hours)
+
+Set N based on partner tolerance. Devnet: 4 hours (waited an hour once and recovered cleanly; longer would have triggered a comms cycle). Mainnet: TBD, depends on the SLA we commit to in the testnet launch post.
+
+During the wait:
+- Status page update: "DA layer is degraded; chain block production paused. Monitoring."
+- No X post yet; Celestia community channels are the source of truth for resolution time.
+- Do NOT make any chain-side changes. Resumption is a Celestia-side event; preserve our state to resume cleanly.
+
+### Step 2, if the outage exceeds N (the hard call)
+
+Three options, in escalating commitment:
+
+| Option | Trigger | Reversibility |
+|--------|---------|---------------|
+| **Wait longer** | Celestia ETA shows resolution in <24h | Always reversible |
+| **Fork to MockDa for a known operator-only window** | Partner pressure + Celestia ETA >48h | Reversible only by replaying-and-discarding the MockDa segment when Celestia recovers; messy |
+| **Switch DA provider mid-chain** | Celestia announces multi-week outage | Effectively re-genesis; chain id bumps |
+
+We do not have a MockDa fork procedure in v0. Reaching this step on mainnet is a chain-level emergency; for devnet it's an experiment. The hard call is the IC's call (see [`incident-response.md`](./incident-response.md) Scenario 5 step 1 for the framing).
+
+### Step 3, resume after Celestia recovers
+
+If we waited: `ligate-node` automatically resumes blob submission. No DR action needed beyond a status page update.
+
+If we forked: rebuild from Celestia, see [`chain-id-bump.md`](./chain-id-bump.md). Coordinate with partners; the MockDa-segment txs are not on Celestia and need re-submission (if they're worth preserving) or are forfeit.
+
+### Rehearsal
+
+**Not rehearsed.** Short-outage waits have happened; long-outage MockDa-fork has not. Hard to rehearse without an artificial Celestia outage; the rehearsal here is a tabletop exercise (walk through the options with a 48h hypothetical) rather than a live drill. Tabletop noted as a follow-up to #513.
+
+---
+
+## Scenario D, sequencer / operator / DA key compromise
+
+See [`incident-response.md`](./incident-response.md) Scenario 4 for the immediate-containment procedure. This section covers the DR-side recovery after containment.
+
+### The chain id bumps
+
+Operator + sequencer rotation are coupled to chain-id-bump (the new pubkey becomes part of the chain hash). See [`operator-key-rotation.md`](./operator-key-rotation.md) Procedure B + [`chain-id-bump.md`](./chain-id-bump.md).
+
+DA key rotation does NOT bump chain id (it's a DA-layer key, not a chain-state key). See [`da-signer-rotation.md`](./da-signer-rotation.md) Procedure B.
+
+### Recovery steps post-rotation
+
+1. **Verify the new keys are signing correctly.** Watch a few batches land with the new chain-side signing key and a few DA blobs land from the new wallet.
+2. **Indexer Postgres TRUNCATE.** Stale rows from the pre-rotation chain id will not merge into the new chain id's data. Procedure in [`backup-restore.md`](./backup-restore.md) §"Indexer state reset across chain id bump."
+3. **Downstream service config update.** Every env var or config file that references the old operator address or chain id needs updating. Inventory in [`operator-key-rotation.md`](./operator-key-rotation.md) Procedure A step 4.
+4. **Public post-mortem within 7 days.** Format in [`incident-response.md`](./incident-response.md) Scenario 4 step 4.
+
+### Rehearsal
+
+**Not rehearsed.** Key rotation has not been run end-to-end against a partner-facing chain. Filed as a follow-up to #514, the operator-key-rotation runbook explicitly requires a localnet rehearsal before any mainnet rotation event.
+
+---
+
+## Recovery-time accounting
+
+The Recovery Time Objectives in the table at the top are targets, not commitments. Real recovery time depends on which scenario, how far the corruption propagated, how much state needs replay, how cold the rebuild path is.
+
+For mainnet, we publish committed RTOs only after each scenario has been rehearsed at least twice with consistent timing. Pre-mainnet, the RTOs above are targets to aim at while rehearsing.
+
+---
+
+## Post-DR checklist
+
+After every disaster-recovery event:
+
+- [ ] Chain producing blocks at expected cadence
+- [ ] All partner integrations confirmed working (drip endpoint, attestation submission, indexer reads)
+- [ ] Status page reflects "resolved"
+- [ ] Cloud Audit Log evidence preserved in the retention sink (see [`gcp-audit-logs.md`](./gcp-audit-logs.md))
+- [ ] Post-mortem started; published within timeline (72h for SEV-1, 7d for SEV-2)
+- [ ] Runbook updates filed as PRs for procedure gaps discovered during the event
+- [ ] Next quarterly drill scheduled (so the muscle memory does not atrophy)
+
+---
+
+## Cross-references
+
+- [`incident-response.md`](./incident-response.md): the "in the moment" playbook this runbook continues from
+- [`backup-restore.md`](./backup-restore.md): RocksDB snapshot + restore procedure (used by Scenarios A and B)
+- [`chain-upgrade.md`](./chain-upgrade.md): in-place binary swap with auto-rollback (used by Scenario A step 1)
+- [`chain-id-bump.md`](./chain-id-bump.md): genesis + chain id ladder bump (used by Scenarios C and D)
+- [`operator-key-rotation.md`](./operator-key-rotation.md): operator wallet key rotation (used by Scenario D)
+- [`sequencer-key-rotation.md`](./sequencer-key-rotation.md): chain-side ed25519 signing key rotation (used by Scenario D)
+- [`da-signer-rotation.md`](./da-signer-rotation.md): Celestia DA wallet rotation (used by Scenario D)
+- [`gcp-audit-logs.md`](./gcp-audit-logs.md): forensic trail (used by post-DR evidence preservation)
+- [`multi-sequencer-failover.md`](./multi-sequencer-failover.md): cluster failover (post-#82 future state)
+- [`public-devnet-deploy.md`](../public-devnet-deploy.md): full deploy procedure (referenced by Scenario B rebuild)
+- [chain#513](https://github.com/ligate-io/ligate-chain/issues/513): this runbook's tracking issue
+- [chain#360](https://github.com/ligate-io/ligate-chain/issues/360): pre-mainnet security gap tracker
+- [chain#273](https://github.com/ligate-io/ligate-chain/issues/273): state-snapshot publishing (improves Scenario A's worst case)

--- a/docs/development/runbooks/gcp-audit-logs.md
+++ b/docs/development/runbooks/gcp-audit-logs.md
@@ -1,0 +1,180 @@
+# Runbook, GCP Cloud Audit Logs
+
+**Status:** v0, the procedure for enabling project-wide Cloud Audit Logs + a retention-tier logging sink so audit trails survive a project compromise.
+**Tracks:** [chain#513](https://github.com/ligate-io/ligate-chain/issues/513), child of [chain#360](https://github.com/ligate-io/ligate-chain/issues/360)
+
+This is the forensic trail layer. Without it, "who SSH'd to the sequencer at 03:00?" and "what IAM bindings changed last week?" have no answer.
+
+---
+
+## What we enable
+
+| Log type | Default | Cost | What it captures |
+|----------|---------|------|------------------|
+| Admin Activity | On (most services) | Free | IAM changes, resource creation/deletion, console + gcloud actions that mutate state |
+| System Event | On | Free | GCE automatic actions (live migration, automatic restart) |
+| Data Access | Off (most services) | Storage + ingestion at standard logging rates | SSH session start, reads against Secret Manager, KMS access |
+| Policy Denied | Optional | Storage | IAM denials (interesting for "someone tried to access X but lacked perm") |
+
+We turn on **Data Access** for the services we care about: Compute Engine (SSH), Secret Manager (key reads), Cloud KMS (signing operations, once #514 ships the KMS migration), Cloud Storage (snapshot bucket access).
+
+---
+
+## Procedure
+
+### Step 1, verify Admin Activity logs are flowing (5 min)
+
+```sh
+gcloud logging read 'logName=~"cloudaudit.googleapis.com%2Factivity"' \
+  --limit=5 \
+  --format=json | jq '.[] | {timestamp, protoPayload: .protoPayload | {methodName, resourceName}}'
+```
+
+Should return five recent Admin Activity events. If empty, Cloud Audit Logs are disabled at the project level, contact GCP support (this would be unusual; default is on).
+
+### Step 2, enable Data Access logs for the services we care about (15 min)
+
+Via the Console: IAM & Admin → Audit Logs → check Data Read + Data Write for: Compute Engine, Secret Manager, Cloud KMS, Cloud Storage. Save.
+
+Via gcloud (idempotent, scripted form):
+
+```sh
+PROJECT=ligate-mainnet  # or ligate-devnet-2
+
+cat > /tmp/audit-config.yaml <<EOF
+auditConfigs:
+- service: compute.googleapis.com
+  auditLogConfigs:
+  - logType: DATA_READ
+  - logType: DATA_WRITE
+- service: secretmanager.googleapis.com
+  auditLogConfigs:
+  - logType: DATA_READ
+  - logType: DATA_WRITE
+- service: cloudkms.googleapis.com
+  auditLogConfigs:
+  - logType: DATA_READ
+  - logType: DATA_WRITE
+- service: storage.googleapis.com
+  auditLogConfigs:
+  - logType: DATA_READ
+  - logType: DATA_WRITE
+EOF
+
+# Merge into existing project IAM policy (do NOT overwrite, the
+# `etag` flow below preserves IAM bindings):
+gcloud projects get-iam-policy $PROJECT --format=yaml > /tmp/policy.yaml
+# Hand-merge auditConfigs from /tmp/audit-config.yaml into /tmp/policy.yaml
+# (yq is fine for this; or just paste under the existing root key)
+gcloud projects set-iam-policy $PROJECT /tmp/policy.yaml
+```
+
+**Cost expectation:** ~$0.50/GB for storage past the free tier. Our SSH + Secret Manager + KMS traffic at devnet scale is single-digit GB/month. Negligible.
+
+### Step 3, configure a retention-tier sink to a dedicated bucket (10 min)
+
+The default Cloud Logging retention is 30 days for `_Default`, 400 days for `_Required` (Admin Activity). For audit work we want a separate bucket with a long retention policy and locked IAM, so a project-level compromise can not wipe the trail.
+
+```sh
+PROJECT=ligate-mainnet
+REGION=us-central1
+SINK_BUCKET=ligate-audit-logs-$(date +%Y)
+
+# 1. Create a logging bucket dedicated to audit trail, with 7-year retention
+gcloud logging buckets create $SINK_BUCKET \
+  --location=$REGION \
+  --retention-days=2557 \
+  --description="Audit-log retention bucket, locked policy"
+
+# 2. Lock the retention policy (immutable; deletion fails until policy expires)
+gcloud logging buckets update $SINK_BUCKET \
+  --location=$REGION \
+  --locked
+
+# 3. Create the sink. Includes both Admin Activity AND Data Access logs.
+gcloud logging sinks create ligate-audit-sink \
+  logging.googleapis.com/projects/$PROJECT/locations/$REGION/buckets/$SINK_BUCKET \
+  --log-filter='logName=~"cloudaudit.googleapis.com"'
+
+# 4. Grant the sink's auto-created service account write access to the bucket
+SINK_WRITER=$(gcloud logging sinks describe ligate-audit-sink \
+  --format='value(writerIdentity)')
+gcloud logging buckets add-iam-policy-binding $SINK_BUCKET \
+  --location=$REGION \
+  --member=$SINK_WRITER \
+  --role=roles/logging.bucketWriter
+```
+
+After this, every audit log line lands in TWO places: the default `_Required` bucket (400-day retention) AND `ligate-audit-logs-<year>` (7-year retention, locked policy). A project compromise that wipes the default bucket cannot touch the locked one.
+
+### Step 4, verify with a known event (5 min)
+
+```sh
+# Trigger a known event
+gcloud compute ssh ligate-sequencer --zone=us-central1-a --command="echo verify"
+
+# Wait ~30s for log propagation, then check the sink bucket
+gcloud logging read \
+  'logName=~"cloudaudit.googleapis.com" AND protoPayload.methodName=~"v1.compute.instances.getSerialPortOutput|ssh"' \
+  --bucket=$SINK_BUCKET \
+  --location=$REGION \
+  --limit=3 \
+  --format=json | jq '.[] | {timestamp, authenticationInfo: .protoPayload.authenticationInfo.principalEmail, methodName: .protoPayload.methodName}'
+```
+
+If the SSH event shows up in the bucket query, the sink is working.
+
+---
+
+## Day-2 operations
+
+### Query the audit log from incident response
+
+The incident-response runbook references this. Common queries:
+
+```sh
+# Who SSH'd to the sequencer in the last 24h?
+gcloud logging read \
+  'resource.type="gce_instance" AND resource.labels.instance_id="ligate-sequencer" AND protoPayload.methodName=~"ssh"' \
+  --freshness=1d --format=json | jq '.[] | {ts: .timestamp, who: .protoPayload.authenticationInfo.principalEmail}'
+
+# Who read Secret Manager keys in the last 7 days?
+gcloud logging read \
+  'resource.type="secretmanager.googleapis.com/Secret" AND protoPayload.methodName=~"AccessSecret"' \
+  --freshness=7d --format=json | jq '.[] | {ts: .timestamp, who: .protoPayload.authenticationInfo.principalEmail, secret: .protoPayload.resourceName}'
+
+# Any IAM policy changes this week?
+gcloud logging read \
+  'protoPayload.methodName=~"SetIamPolicy"' \
+  --freshness=7d --format=json | jq '.[] | {ts: .timestamp, who: .protoPayload.authenticationInfo.principalEmail, resource: .protoPayload.resourceName}'
+```
+
+### Alerting on suspicious patterns
+
+Once the Alertmanager wiring from [#318](https://github.com/ligate-io/ligate-chain/issues/318) is in place, the high-value alerts to wire on top of the audit log:
+
+- IAM role grant outside business hours
+- Secret Manager access from an IP outside Stefan's known range
+- More than N SSH sessions in a 1-hour window
+- Any `delete` on the ligate-sequencer VM
+
+Each becomes a log-based metric + Alertmanager rule. Filed as a follow-up to #513.
+
+---
+
+## Acceptance for this runbook
+
+- [x] Doc lands at `docs/development/runbooks/gcp-audit-logs.md`
+- [ ] Procedure executed on devnet-2 (Stefan's task; this doc is the spec)
+- [ ] Verification step (SSH triggers an entry) passes
+- [ ] Sink bucket exists with locked 7-year retention
+
+---
+
+## Cross-references
+
+- [chain#513](https://github.com/ligate-io/ligate-chain/issues/513): this runbook's tracking issue
+- [chain#360](https://github.com/ligate-io/ligate-chain/issues/360): pre-mainnet security gap tracker
+- [chain#318](https://github.com/ligate-io/ligate-chain/issues/318): Alertmanager wiring (where the audit-log-based alerts will land)
+- [`incident-response.md`](./incident-response.md): IR runbook that queries the audit log during incidents
+- [`disaster-recovery.md`](./disaster-recovery.md): DR runbook that pulls audit-log evidence into post-mortems

--- a/docs/development/runbooks/incident-response.md
+++ b/docs/development/runbooks/incident-response.md
@@ -1,0 +1,307 @@
+# Runbook, Incident Response
+
+**Status:** v0, pre-mainnet single-operator playbook. Roles consolidate to Stefan today; named-role split lands once a second operator joins.
+**Tracks:** [chain#513](https://github.com/ligate-io/ligate-chain/issues/513), child of [chain#360](https://github.com/ligate-io/ligate-chain/issues/360)
+
+This is the "what we do in the moment" playbook. The "what we do after" playbook is [`disaster-recovery.md`](./disaster-recovery.md). The "what we do before any of this" preparation is in [`backup-restore.md`](./backup-restore.md) (quarterly restore drill), [`gcp-audit-logs.md`](./gcp-audit-logs.md) (forensic trail enabled), and [`operator-key-rotation.md`](./operator-key-rotation.md) (rotation procedure rehearsed).
+
+---
+
+## Roles (single-operator stage)
+
+Until a second operator joins, all four roles below collapse to Stefan. The role names exist so the procedure scales when more operators come online.
+
+| Role | Responsibility | Today |
+|------|----------------|-------|
+| **Incident Commander (IC)** | Drives the incident: declares severity, picks the procedure, calls the all-clear | Stefan |
+| **Comms** | External status page + X + partner DMs | Stefan |
+| **Forensics** | Pulls audit logs, RocksDB state, chain-side evidence | Stefan |
+| **Ops Lead** | Executes the mechanical fix steps (restart, restore, rotate) | Stefan |
+
+The IC is the single point of decision-making during an incident. If the IC needs to step into a fix-step, hand off the IC role explicitly before doing so. The IC role is never silently empty.
+
+---
+
+## Severity ladder
+
+| Sev | Definition | Response time target | Comms |
+|-----|------------|----------------------|-------|
+| **SEV-1** | Chain stopped, key compromised, treasury at risk, or any state-integrity issue | <15 min ack, declare publicly within 1h | Status page + X post + partner DMs |
+| **SEV-2** | Service degraded but chain healthy (RPC errors, faucet drained, indexer lag) | <1h ack, fix in same business day | Status page update, no public X |
+| **SEV-3** | Cosmetic or single-partner impact, no broader user impact | Next business day | Internal note, no public update |
+
+Default toward upgrading severity if uncertain. Downgrading mid-incident is fine; not noticing a SEV-1 because it looked SEV-2 is not.
+
+---
+
+## Comms templates
+
+### Status page (SEV-1, initial)
+
+```
+[Investigating] Ligate Chain devnet-2 is experiencing <one-sentence symptom>.
+We are investigating. Updates every 30 minutes.
+Last update: <timestamp UTC>
+```
+
+### Status page (SEV-1, root cause known)
+
+```
+[Identified] Ligate Chain devnet-2 incident root cause: <one sentence>.
+Mitigation in progress: <one sentence on what we are doing>.
+ETA to resolution: <best-effort estimate, do not over-promise>.
+Last update: <timestamp UTC>
+```
+
+### Status page (resolved)
+
+```
+[Resolved] The Ligate Chain devnet-2 incident from <start UTC> to <end UTC>
+was caused by <one-sentence root cause>. Mitigation: <one sentence>.
+Post-mortem to follow within 72 hours.
+```
+
+### X post (SEV-1, single tweet)
+
+> Ligate Chain devnet-2 had an incident from <start> to <end> UTC. Root cause: <X>. Mitigation: <Y>. Detailed write-up coming this week.
+
+Don't tweet during the incident unless we have something to say. Silence is better than speculation.
+
+### Partner DM (SEV-1)
+
+> Hey, heads up, devnet-2 had a <X-type> incident at <UTC>. We've mitigated; chain is healthy now. <If they have on-chain dependencies>: your <integration name> may have seen <specific impact, e.g. failed transactions between time A and time B>. Happy to dig in if you saw issues; otherwise we'll share the full post-mortem in <N> days.
+
+Be specific about impact. Vague reassurance reads as cover.
+
+---
+
+## Scenario 1, sequencer hard-down
+
+Symptoms: `/v1/ledger/slots/latest` not advancing, `systemctl status ligate-node` shows failed or dead, no batches landing on Celestia.
+
+### Diagnosis (5 min)
+
+```sh
+# On the sequencer VM
+sudo systemctl status ligate-node
+sudo journalctl -u ligate-node -n 200 --no-pager
+df -h /var/lib/ligate  # disk full?
+free -h                # OOM?
+```
+
+External view:
+```sh
+curl -s https://rpc.ligate.io/v1/ledger/slots/latest | jq .height
+# Compare to height 5 minutes ago in Grafana
+```
+
+### Mitigation by failure mode
+
+| Cause | Fix | Reference |
+|-------|-----|-----------|
+| Process crashed cleanly | `sudo systemctl restart ligate-node`, watch logs | [`chain-upgrade.md`](./chain-upgrade.md) |
+| Crash loop on start | Roll back to previous binary, file bug with stacktrace | [`chain-upgrade.md`](./chain-upgrade.md) auto-rollback path |
+| Disk full | Free space (`/var/log` rotation, old snapshots in `/tmp`), restart | One-off |
+| RocksDB corruption | Restore from snapshot | [`backup-restore.md`](./backup-restore.md) |
+| VM dead | Failover to standby (when multi-sequencer ships) or rebuild | [`multi-sequencer-failover.md`](./multi-sequencer-failover.md) + [`disaster-recovery.md`](./disaster-recovery.md) |
+
+### Declare resolved when
+
+- `/v1/ledger/slots/latest` advances at expected cadence for 5 consecutive minutes
+- No `error`-level entries in `journalctl -u ligate-node -n 100` since restart
+- Light-node sync gauge healthy in Grafana
+
+---
+
+## Scenario 2, RPC degraded (chain healthy)
+
+Symptoms: `rpc.ligate.io` returns 5xx or high latency, but the sequencer is producing blocks normally.
+
+### Diagnosis (5 min)
+
+```sh
+# Is the chain healthy?
+curl -s https://rpc.ligate.io/v1/ready
+curl -s https://rpc.ligate.io/v1/ledger/slots/latest | jq .height
+
+# Latency from outside
+time curl -s https://rpc.ligate.io/v1/rollup/info > /dev/null
+
+# Cloudflare edge state
+curl -sI https://rpc.ligate.io/v1/rollup/info | grep -i cf-cache-status
+```
+
+Look in Grafana:
+- HTTP error rate panel on `rpc-edge` dashboard
+- Per-IP rate-limit hit count (Cloudflare WAF panel)
+
+### Mitigation by failure mode
+
+| Cause | Fix |
+|-------|-----|
+| Burst of legitimate traffic | Cloudflare auto-handles via rate limit; monitor and consider raising the per-IP limit |
+| DDoS-shaped pattern | Cloudflare Under Attack Mode (one click in the CF dashboard) |
+| Origin overwhelmed (CPU at 100%) | Restart `ligate-node`, scale VM up via [`upgrade-chain.sh`](./chain-upgrade.md) on a larger instance |
+| Caddy / reverse proxy down | `sudo systemctl restart caddy` on the sequencer VM |
+| Cloudflare DNS or routing issue | Status page update; no fix from our side; wait for CF resolution |
+
+### Declare resolved when
+
+- p99 RPC latency back under 500ms (per Grafana panel)
+- HTTP error rate under 1% for 10 consecutive minutes
+
+---
+
+## Scenario 3, faucet drained
+
+Symptoms: `faucet-bot` Discord channel reports empty, `/v1/drip` returns "insufficient balance," operator wallet balance near zero.
+
+### Diagnosis (10 min)
+
+```sh
+# Operator balance
+ligate-cli balance lid1...operator
+
+# Recent drip txs (look for anomalous pattern)
+curl -s "https://api.ligate.io/v1/drip/recent?limit=100" | jq
+
+# Cloudflare per-IP rate limit hit pattern in Grafana
+```
+
+Look for:
+- A single IP responsible for many drips (rate-limit bypass)
+- A small set of recipient addresses receiving repeated drips (drain attack)
+- An unexplained large outbound tx from the operator wallet (compromise)
+
+### Mitigation by failure mode
+
+| Cause | Fix |
+|-------|-----|
+| Routine exhaustion (legitimate demand) | Refill the operator wallet from the cold treasury, document the burn rate in the cost dashboard |
+| Drain attack via rate-limit bypass | Tighten Cloudflare rate limit; consider adding captcha or proof-of-work on `/v1/drip`; raise the issue on faucet-bot repo |
+| Compromise (large outbound to unknown address) | **Stop, this is SEV-1.** See Scenario 4 below; do NOT refill the wallet until rotation completes |
+
+The key distinction: a slow drain from many addresses is a rate-limit problem. A single large outbound tx is a key compromise. Treat differently.
+
+### Declare resolved when
+
+- Operator wallet balance back above the configured floor
+- Cloudflare logs show no anomalous IP pattern in the last hour
+- `/v1/drip` returns success for new requests
+
+---
+
+## Scenario 4, suspected operator or DA key compromise
+
+Symptoms: any of (a) large unexplained outbound tx from the operator wallet, (b) signing operation in Cloud Audit Logs that we did not initiate, (c) third-party reports finding our private key material in a leak, (d) an investigator confirms a backup tarball was exfiltrated.
+
+This is SEV-1. Wake up. Do not finish your coffee.
+
+### Step 0, before doing anything irreversible
+
+- **Snapshot the current state** (RocksDB + genesis + config + Secret Manager state). [`backup-restore.md`](./backup-restore.md) procedure. The post-mortem needs the as-of state.
+- **Pull the audit log evidence** from the locked retention sink ([`gcp-audit-logs.md`](./gcp-audit-logs.md)). Queries by service, by actor, by time window.
+
+### Step 1, contain (the next 15 minutes)
+
+- **Operator key compromised**: drain the treasury to the cold address per [`operator-key-rotation.md`](./operator-key-rotation.md) Procedure B step 1. Even seconds matter; the adversary is racing you.
+- **DA key compromised**: drain the Celestia TIA balance per [`da-signer-rotation.md`](./da-signer-rotation.md) Procedure B.
+- Revoke IAM bindings on any compromised service account (`gcloud projects remove-iam-policy-binding`).
+- If the compromise traces to a specific VM or laptop, isolate it: `gcloud compute instances stop ligate-sequencer` (for the VM), or revoke SSH keys (for the laptop).
+
+### Step 2, rotate
+
+- Operator: [`operator-key-rotation.md`](./operator-key-rotation.md) Procedure B (emergency under compromise; bumps chain id).
+- DA: [`da-signer-rotation.md`](./da-signer-rotation.md) Procedure B.
+- Sequencer signing key: [`sequencer-key-rotation.md`](./sequencer-key-rotation.md) Procedure A (re-genesis) for pre-mainnet, Procedure B once that primitive ships.
+
+The rotation procedures are coupled to chain-id-bump. Update downstream services in parallel per the rotation runbook.
+
+### Step 3, comms (within 60 minutes of containment)
+
+- Status page update (template above)
+- X post (template above; can wait for full root-cause clarity)
+- Partner DMs (the LOI buyer, any active integrators)
+- Internal post-mortem doc started immediately, finalised within 72h
+
+### Step 4, post-mortem
+
+Lives at `docs/development/postmortems/<date>-<one-word>.md`. Format:
+- Timeline (UTC, every action)
+- Root cause analysis (the 5 whys, not "user error")
+- What worked in this runbook
+- What didn't work (file as a follow-up to update this runbook)
+- Action items with owners
+
+---
+
+## Scenario 5, suspected on-chain exploit
+
+Symptoms: an attestation, a schema registration, a transfer, or a bounty interaction that the chain accepts but should have rejected. Discovered via partner report, an alert from the indexer, or a difference between expected and observed module state.
+
+This is SEV-1 and structurally different from Scenarios 1-4: there is nothing wrong with the operator's machine; the chain itself accepted something it shouldn't have.
+
+### Step 0, evidence
+
+- Snapshot the chain state. Same as Scenario 4 step 0.
+- Pull the specific tx + the slot it landed in + the attestor / sequencer that included it.
+
+### Step 1, decide whether to halt
+
+This is the IC's hardest call.
+
+| Decide to halt if | Decide not to halt if |
+|-------------------|------------------------|
+| Continuing harms partners (e.g. token loss in flight, schema being misused at scale) | Exploit is theoretical or limited (a single weird tx with no downstream effect) |
+| Fix requires a chain-side patch + restart | Fix can land via a downstream config or module governance call |
+| Trust in the chain depends on stopping NOW | Pausing causes more harm than the exploit |
+
+**No protocol-level halt switch ships today.** Halting means stopping `ligate-node` on the sequencer VM. Chain stalls until restart. Be sure before doing this; the comms cost is real.
+
+### Step 2, patch
+
+- Identify the chain-side bug (state machine, module logic, signature verification, etc.)
+- Write the fix on a branch, ship a patch release, deploy via [`chain-upgrade.md`](./chain-upgrade.md)
+- If the fix changes state machine or genesis, treat as a chain-hash bump (rebuild from DA, see [`chain-id-bump.md`](./chain-id-bump.md))
+
+### Step 3, decide whether to roll back
+
+For mainnet (future): chain-side rollback is a credibility-destroying operation; reserve for actual fund-loss-scale events. For devnet: state is replayable; rollback is "stop, edit genesis or state machine, replay."
+
+### Step 4, comms (within 24h)
+
+- Status page + X post + partner DMs
+- Public post-mortem within 7 days
+- Bug bounty payout if applicable (program lives at #313 once that ships)
+
+---
+
+## Post-incident checklist (every incident)
+
+After the all-clear:
+
+- [ ] Update the status page to "resolved"
+- [ ] X post (within 24h for SEV-1, within 7d for SEV-2)
+- [ ] Partner DMs sent
+- [ ] Post-mortem started in `docs/development/postmortems/`
+- [ ] Action items filed as GitHub issues with the `incident-followup` label (create the label if not present)
+- [ ] This runbook updated with any procedure gap discovered (PR + merge before the next incident)
+- [ ] Audit log retention sink confirmed populated with the incident's events
+
+The runbook gets better only if we update it after every incident. Don't skip the update step because the incident felt small.
+
+---
+
+## Cross-references
+
+- [`disaster-recovery.md`](./disaster-recovery.md): step-by-step recovery for the failure modes touched on above
+- [`backup-restore.md`](./backup-restore.md): RocksDB snapshot + restore procedure
+- [`chain-upgrade.md`](./chain-upgrade.md): in-place binary swap with auto-rollback
+- [`chain-id-bump.md`](./chain-id-bump.md): genesis + chain id ladder bump
+- [`operator-key-rotation.md`](./operator-key-rotation.md): operator wallet key rotation
+- [`sequencer-key-rotation.md`](./sequencer-key-rotation.md): chain-side ed25519 signing key rotation
+- [`da-signer-rotation.md`](./da-signer-rotation.md): Celestia DA wallet rotation
+- [`gcp-audit-logs.md`](./gcp-audit-logs.md): forensic trail queries during the incident
+- [`multi-sequencer-failover.md`](./multi-sequencer-failover.md): cluster failover (multi-VM future state)
+- [chain#513](https://github.com/ligate-io/ligate-chain/issues/513): this runbook's tracking issue
+- [chain#360](https://github.com/ligate-io/ligate-chain/issues/360): pre-mainnet security gap tracker


### PR DESCRIPTION
Closes [chain#513](https://github.com/ligate-io/ligate-chain/issues/513) (child of [chain#360](https://github.com/ligate-io/ligate-chain/issues/360) pre-mainnet security gap tracker).

Three coupled docs, the forensic trail + the named-role playbooks for the two failure modes that escape routine ops:

1. **`gcp-audit-logs.md`** (180 lines): procedure for enabling Cloud Audit Logs (Admin Activity verified, Data Access enabled for compute / KMS / Secret Manager / GCS) + a locked 7-year-retention logging sink so audit trails survive a project compromise.
2. **`incident-response.md`** (307 lines): "what we do in the moment" playbook. Four roles (IC / Comms / Forensics / Ops Lead, all Stefan today). Severity ladder (SEV-1/2/3 with response targets). Comms templates (status page, X, partner DM). Five scenarios: sequencer hard-down, RPC degraded, faucet drained, key compromise, on-chain exploit.
3. **`disaster-recovery.md`** (201 lines): "what we do after" playbook. Four scenarios: RocksDB corruption (rehearsed), VM loss (unrehearsed), Celestia DA outage (unrehearsed), key compromise (unrehearsed). Each scenario marks RTO + rehearsal status; unrehearsed scenarios get follow-up filings.

## Why now
chain#360 is the pre-mainnet security gap tracker. #514 (key management RFC + rotation runbook) just landed. This PR completes the documentation side of #360, three runbooks left, all docs-only. Real-world execution of the procedures is operator work tracked under #318 (alertmanager) + on-issue checklist items in #513 (audit logs enablement).

## What this PR does NOT do (intentionally)
- Execute the audit-log enablement on devnet-2 GCP project (separate gcloud session; tracked as a checklist item in #513)
- Stand up the alerts that wrap the audit log (covered by #318 wiring)
- Rehearse the unrehearsed DR scenarios (filed as follow-ups inside the doc)

## Test plan
- [ ] All three docs render cleanly on GitHub
- [ ] No em dashes (style rule, 0 across all three)
- [ ] Cross-references resolve (`backup-restore.md`, `chain-upgrade.md`, `chain-id-bump.md`, `operator-key-rotation.md`, `sequencer-key-rotation.md`, `da-signer-rotation.md`, `multi-sequencer-failover.md`, `public-devnet-deploy.md`)
- [ ] All cross-issue links resolve (#82, #273, #313, #318, #360, #513, #514)