### PR TITLE
docs(readme): lead with fee-routing developer pitch (chain#525)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@
 
 ---
 
+## Earn from schema authorship
+
+Schema developers earn a configurable slice of every attestation fee paid against their schema. Set `fee_routing_bps` at schema registration (up to 5000 = 50%, governance-tunable cap) and `fee_routing_addr` to the address you want paid. From that point on, every `SubmitAttestation` against the schema splits `total_fee * fee_routing_bps / 10000` to the routing address; the rest accrues to the protocol treasury.
+
+```rust
+attestation::CallMessage::RegisterSchema {
+    set_id,
+    payload_hash_alg: HashAlg::Sha256,
+    fee_routing_bps: 1000,                       // 10% to the schema author
+    fee_routing_addr: Some(developer_address),   // required when bps > 0
+}
+```
+
+No staking, no inflation, no listing fee. The mechanism is buyer-funded: attestation submitters pay, the schema author gets the cut. The same primitive is what the bounty marketplace ([chain#385](https://github.com/ligate-io/ligate-chain/issues/385)) and post-mainnet schema marketplace fee ([chain#524](https://github.com/ligate-io/ligate-chain/issues/524)) compose on top of. Spec: [`docs/protocol/attestation-v0.md`](docs/protocol/attestation-v0.md) §"Fee distribution". Pre-testnet economics RFC: [`docs/protocol/pre-testnet-economics.md`](docs/protocol/pre-testnet-economics.md).
+
+---
+
 ## Quick start
 
 > **Just want to run a node, not build from source?**


### PR DESCRIPTION
Partial close for [chain#525](https://github.com/ligate-io/ligate-chain/issues/525) (sub-issue 1 of 4 from the [pre-testnet economics RFC](docs/protocol/pre-testnet-economics.md)).

## Summary

Adds a new "Earn from schema authorship" section to README.md, positioned right after the badges and before Quick Start (lines 19-32). Single paragraph that leads with the pitch + a code block showing `RegisterSchema { ..., fee_routing_bps: 1000, fee_routing_addr: Some(developer_address) }`. Closes with pointers to the attestation spec, the bounty RFC ([#385](https://github.com/ligate-io/ligate-chain/issues/385)), and the schema marketplace fee follow-up ([#524](https://github.com/ligate-io/ligate-chain/issues/524)).

## What this PR does NOT do

The #525 issue spans three surfaces; this PR ships the chain-side README portion only:

| Surface | This PR | Owner |
|---------|---------|-------|
| chain README leading paragraph | ✅ shipped here | chain |
| landing.ligate.io developer page | ❌ separate PR | ligate-marketing |
| Dev-facing blog post on blog.ligate.io | ❌ separate PR | ligate-marketing |
| docs.ligate.io quickstart link | ❌ separate PR | ligate-io-docs |

The other three surfaces stay in #525 until the cross-repo PRs land. The chain side is unblocked by this PR.

## Scope hygiene

The 18 pre-existing em dashes in README.md (lines 78, 102, 120, 135, 179, etc) are unchanged. This PR adds 0 em dashes. A README-wide em-dash scrub is a separate cleanup if desired; not bundled here to keep the review surface narrow.

## Test plan
- [ ] Markdown renders cleanly on GitHub
- [ ] New section sits in the first 50 lines as the issue requires
- [ ] Code block compiles as Rust-shaped (it's illustrative, not executed)
- [ ] All cross-references resolve (`attestation-v0.md`, `pre-testnet-economics.md`, #385, #524)