### PR TITLE
test: cover remaining bounty/contract lifecycle guard branches

### DIFF
--- a/crates/modules/bounty/tests/lifecycle.rs
+++ b/crates/modules/bounty/tests/lifecycle.rs
@@ -467,3 +467,66 @@ fn finalise_rejected_with_open_dispute() {
         }),
     });
 }
+
+#[test]
+fn finalise_rejected_before_window_closes() {
+    let mut env = setup();
+    let board = env.board_schema_id;
+    let poster_addr = env.poster.address();
+
+    // Large dispute window so it stays open even after expiry passes.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env
+            .poster
+            .create_plain_message::<RT, Bounty<S>>(post_with(board, 450, 100, 30, 100)),
+        assert: Box::new(|r, _| assert!(r.tx_receipt.is_successful())),
+    });
+    let attestation_id = submit_attestation_via_runner(&mut env, [0xA8u8; 32]);
+    let bounty_id = BountyId::derive(poster_addr.as_ref(), &board, 0);
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.poster.create_plain_message::<RT, Bounty<S>>(CallMessage::ClaimBounty {
+            bounty_id,
+            claims: single_claim(attestation_id),
+        }),
+        assert: Box::new(|r, _| assert!(r.tx_receipt.is_successful())),
+    });
+
+    // Past expiry (so the bounty is finalisable) but the claim's
+    // 100-block dispute window is still open.
+    env.runner.advance_slots(40);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env
+            .poster
+            .create_plain_message::<RT, Bounty<S>>(CallMessage::FinaliseBounty { bounty_id }),
+        assert: Box::new(|result, _| {
+            assert_reverted_with(&result.tx_receipt, "dispute windows still open");
+        }),
+    });
+}
+
+#[test]
+fn finalise_rejected_when_open_and_not_expired() {
+    let mut env = setup();
+    let board = env.board_schema_id;
+    let poster_addr = env.poster.address();
+
+    // Far-future expiry, no claims: the bounty is plain Open, neither
+    // exhausted nor expired, so it cannot be finalised.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env
+            .poster
+            .create_plain_message::<RT, Bounty<S>>(post_with(board, 500, 100, 100_000, 5)),
+        assert: Box::new(|r, _| assert!(r.tx_receipt.is_successful())),
+    });
+    let bounty_id = BountyId::derive(poster_addr.as_ref(), &board, 0);
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env
+            .poster
+            .create_plain_message::<RT, Bounty<S>>(CallMessage::FinaliseBounty { bounty_id }),
+        assert: Box::new(|result, _| {
+            assert_reverted_with(&result.tx_receipt, "cannot be finalised");
+        }),
+    });
+}

--- a/crates/modules/contract/tests/lifecycle.rs
+++ b/crates/modules/contract/tests/lifecycle.rs
@@ -375,3 +375,40 @@ fn cancel_after_expiry_marks_expired_and_refunds() {
         }),
     });
 }
+
+#[test]
+fn finalize_rejected_when_not_delivered() {
+    let mut env = setup();
+    let arbiter_addr = env.arbiter.address();
+    let poster_addr = env.poster.address();
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.poster.create_plain_message::<RT, Contracts<S>>(post_with(
+            arbiter_addr,
+            1_000,
+            100_000,
+            5,
+        )),
+        assert: Box::new(|r, _| assert!(r.tx_receipt.is_successful())),
+    });
+    let contract_id = ContractId::derive(poster_addr.as_ref(), &CRITERIA_DOC_HASH, 0);
+    // Commit but do NOT deliver: status is Committed, not Delivered, so
+    // there is nothing to auto-accept.
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.worker.create_plain_message::<RT, Contracts<S>>(CallMessage::CommitToContract {
+            contract_id,
+            commit_hash: COMMIT_HASH,
+            bond: Amount::new(100),
+        }),
+        assert: Box::new(|r, _| assert!(r.tx_receipt.is_successful())),
+    });
+
+    env.runner.execute_transaction(TransactionTestCase {
+        input: env.worker.create_plain_message::<RT, Contracts<S>>(CallMessage::FinalizeDelivery {
+            contract_id,
+        }),
+        assert: Box::new(|result, _| {
+            assert_reverted_with(&result.tx_receipt, "not valid for this operation");
+        }),
+    });
+}


### PR DESCRIPTION
Test-only fast-follow to #541. No behavior or chain_hash change.

#541 covered every new call message, state transition, and primary guard. This fills the three secondary guard branches that weren't individually exercised, so the lifecycle surface is comprehensively tested:

- **bounty** `FinaliseBounty` rejected when a claim's dispute window is still open (`DisputeWindowsStillOpen`)
- **bounty** `FinaliseBounty` rejected on an Open, non-expired bounty (`NotFinalisable`)
- **contract** `FinalizeDelivery` rejected on a non-Delivered contract (`InvalidStatus`)

## Verified locally
- bounty: 19 integration + 10 lifecycle tests pass
- contract: 6 unit + 6 lifecycle tests pass

## Not covered (tracked separately)
The new REST routes (`/bounties/{id}/disputes/{attestationId}`, `/contracts/{id}/delivery`, `/contracts/{id}/disputes`) have no module-level test, consistent with the existing `route_get_bounty` / `route_get_contract` (REST needs a router harness, separate effort).

## Test plan
- [ ] CI green