### PR TITLE
fix(tests): skip binary-spawn tests under llvm-cov (chain#540 follow-up)

### DIFF
--- a/crates/rollup/tests/binary_spawn_smoke.rs
+++ b/crates/rollup/tests/binary_spawn_smoke.rs
@@ -123,6 +123,23 @@ fn ligate_node_binary() -> &'static str {
     env!("CARGO_BIN_EXE_ligate-node")
 }
 
+/// Binary-spawn tests are skipped under `cargo llvm-cov`. They spawn a
+/// separate `ligate-node` process whose coverage llvm-cov cannot
+/// capture anyway, and the coverage-instrumented binary boots far
+/// slower than [`READY_TIMEOUT`], which reintroduced the chain#540
+/// flake under the coverage job even with the cross-binary fslock
+/// (`file_serial`). The plain `cargo test` CI job still runs these for
+/// real. Detected via `LLVM_PROFILE_FILE`, which cargo-llvm-cov sets
+/// on every instrumented binary.
+fn skip_under_llvm_cov() -> bool {
+    if std::env::var_os("LLVM_PROFILE_FILE").is_some() {
+        eprintln!("skipping binary-spawn test under llvm-cov instrumentation (chain#540)");
+        true
+    } else {
+        false
+    }
+}
+
 /// Allocate an ephemeral port by binding `127.0.0.1:0`, reading the
 /// assigned port, then closing the socket so the spawned node can
 /// reuse it. There's a TOCTOU window between drop and bind by the
@@ -217,6 +234,9 @@ async fn wait_for_ready(base: &str) -> Result<(), String> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[file_serial(node_spawn)]
 async fn binary_spawn_round_trips_register_and_submit() {
+    if skip_under_llvm_cov() {
+        return;
+    }
     // 1. Per-test workspace + port.
     let temp_dir = TempDir::new().expect("temp dir");
     let port = pick_ephemeral_port().await;
@@ -495,6 +515,9 @@ async fn poll_latest_slot_at_least(
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[file_serial(node_spawn)]
 async fn rest_error_envelope_pin() {
+    if skip_under_llvm_cov() {
+        return;
+    }
     let temp_dir = TempDir::new().expect("temp dir");
     let port = pick_ephemeral_port().await;
     let base = format!("http://127.0.0.1:{port}");

--- a/crates/rollup/tests/restart_recovery.rs
+++ b/crates/rollup/tests/restart_recovery.rs
@@ -70,6 +70,23 @@ fn ligate_node_binary() -> &'static str {
     env!("CARGO_BIN_EXE_ligate-node")
 }
 
+/// Binary-spawn tests are skipped under `cargo llvm-cov`. They spawn a
+/// separate `ligate-node` process whose coverage llvm-cov cannot
+/// capture anyway, and the coverage-instrumented binary boots far
+/// slower than [`READY_TIMEOUT`], which reintroduced the chain#540
+/// flake under the coverage job even with the cross-binary fslock
+/// (`file_serial`). The plain `cargo test` CI job still runs these for
+/// real. Detected via `LLVM_PROFILE_FILE`, which cargo-llvm-cov sets
+/// on every instrumented binary.
+fn skip_under_llvm_cov() -> bool {
+    if std::env::var_os("LLVM_PROFILE_FILE").is_some() {
+        eprintln!("skipping binary-spawn test under llvm-cov instrumentation (chain#540)");
+        true
+    } else {
+        false
+    }
+}
+
 /// Allocate an ephemeral port by binding `127.0.0.1:0`, reading the
 /// assigned port, then closing the socket so the spawned node can
 /// reuse it.
@@ -188,6 +205,9 @@ async fn hard_kill(mut child: Child) {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[file_serial(node_spawn)]
 async fn idle_kill_resumes_cleanly() {
+    if skip_under_llvm_cov() {
+        return;
+    }
     // Scenario 1: node starts, sits idle for a brief moment with no
     // tx pressure, gets SIGKILLed, comes back. Tests the simplest
     // restart-safety case: clean idle state must survive.
@@ -228,6 +248,9 @@ async fn idle_kill_resumes_cleanly() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[file_serial(node_spawn)]
 async fn kill_after_blocks_produced_preserves_height() {
+    if skip_under_llvm_cov() {
+        return;
+    }
     // Scenario 2: let the chain produce a handful of blocks, kill,
     // respawn, assert height didn't go backward.
     let temp_dir = TempDir::new().expect("temp dir");
@@ -288,6 +311,9 @@ async fn kill_after_blocks_produced_preserves_height() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[file_serial(node_spawn)]
 async fn respawn_continues_producing_blocks() {
+    if skip_under_llvm_cov() {
+        return;
+    }
     // Scenario 3: kill, respawn, verify the chain keeps producing
     // new blocks (not just preserves old state). The strongest
     // smoke of "we can keep going" rather than "we can stay still".
@@ -341,6 +367,9 @@ async fn respawn_continues_producing_blocks() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[file_serial(node_spawn)]
 async fn double_restart_still_advances() {
+    if skip_under_llvm_cov() {
+        return;
+    }
     // Scenario 4: two kill cycles in a row. Catches "first kill is
     // fine but a second kill on the recovered state corrupts" bugs
     // — a class of restart-safety regressions that wouldn't show


### PR DESCRIPTION
## Problem

The binary-spawn flake (chain#540) recurred, this time only under the `cargo llvm-cov` job. On PR #544 (a docs-only change, code byte-identical to green `main`), `cargo llvm-cov` failed with:

```
thread 'idle_kill_resumes_cleanly' panicked at crates/rollup/tests/restart_recovery.rs:200:
first boot ready: "timeout waiting for http://127.0.0.1:.../v1/rollup/info to return 200"
test result: FAILED. 3 passed; 1 failed; ... finished in 189.00s
```

#540's `file_serial` fix serialised the binary-spawn tests across the two test binaries, which fixed the *parallelism* contention under the normal `cargo test` job. But under `cargo llvm-cov` the spawned `ligate-node` is the **coverage-instrumented** binary, which boots far slower and writes profraw on exit, blowing past even the 180s ready budget. Serialisation doesn't help when a single instrumented boot is itself too slow.

## Fix

The binary-spawn tests skip under llvm-cov via a `skip_under_llvm_cov()` guard (detects `LLVM_PROFILE_FILE`, which cargo-llvm-cov sets on every instrumented binary). Applied to all 6 (`restart_recovery.rs` x4, `binary_spawn_smoke.rs` x2).

This loses no real coverage: these tests spawn a *separate* `ligate-node` process, and llvm-cov measures coverage of the in-process test harness, not the spawned child, so they contribute ~nothing to the coverage report. They still run for real under the plain `cargo test` CI job (which is the job that actually verifies binary-spawn behaviour).

## Verified
- `cargo check -p ligate-rollup --tests`: clean
- `cargo fmt`: clean
- CI here will confirm `cargo llvm-cov` now goes green (the binary-spawn tests skip), and `cargo test` still runs them.

## Test plan
- [ ] `cargo llvm-cov` job green (binary-spawn tests skipped)
- [ ] `cargo test` job still green (binary-spawn tests run for real)