### PR TITLE
chain: devnet-2 to devnet-3 chain-id cutover (v0.4.0 marketplace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This file is human-curated. Every PR adds an entry under `## [Unreleased]`; rele
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- **devnet-2 to devnet-3 chain-id cutover.** Bumps the public-devnet rung from `ligate-devnet-2` to `ligate-devnet-3` to deploy the v0.4.0 bounty + contract marketplace. v0.4.0 shifts `chain_hash` (`eec077f4…` to `60ec4d0b…`) so it is not state-compatible with devnet-2 (no safe in-place binary swap; the `ligate-auto-upgrade` poller correctly skips a flagless release and leaves the live chain on v0.3.1 until this coordinated cutover). Mechanics: the deployed `devnet/` config is snapshotted to `archive/ligate-devnet-2/` (genesis files of the retired network kept for historical reference); `chain_id = "ligate-devnet-3"` in `devnet/celestia.toml`; `genesis_da_height` stays `0` in the committed genesis and the operator pins it to a live Mocha height at boot per `docs/development/runbooks/chain-id-bump.md`; sequencer / treasury / demo operator addresses and the 1B AVOW initial distribution are unchanged from devnet-2. The canonical Themisra schema is re-registered post-genesis. Per-network chain-id-string references across configs, code comments, and operator docs are updated to devnet-3; deployed GCP resource identifiers (`ligate-devnet-2-sequencer` / `-rpc` / `-sequencer-signer`) and Grafana dashboard text are preserved (the latter follows once devnet-3 is live and the new bech32 `chain_hash` is readable). Closes the chain-id ladder bump from rung 2 to 3.
 
 ## [0.4.0] - 2026-05-29
 

--- a/archive/ligate-devnet-2/.gitignore
+++ b/archive/ligate-devnet-2/.gitignore
@@ -1,0 +1,14 @@
+# Filled-in operator key substitution map. Tracked as `keys.toml.example`
+# in repo; the filled-in `keys.toml` stays local to the operator
+# performing the genesis-substitution ceremony (#231).
+keys.toml
+
+# Filled-in canonical-schemas substitution. Tracked as
+# `canonical-schemas.toml.example` in repo; the operator copies it to
+# `canonical-schemas.toml` and substitutes the real federated-quorum
+# pubkeys before running `ligate-bootstrap register-canonical-schemas`.
+# The pubkeys are public information (they go on-chain anyway), but
+# the .example -> filled split keeps the canonical placeholder
+# obvious in repo and the in-flight ceremony state local to the
+# operator host.
+canonical-schemas.toml

--- a/archive/ligate-devnet-2/README.md
+++ b/archive/ligate-devnet-2/README.md
@@ -1,0 +1,159 @@
+# Ligate `ligate-devnet-2` config
+
+Public-devnet artifacts for the canonical first rung of the chain-id ladder. Sibling of `devnet/` (localnet); operators target this directory when bringing up a node that joins the public Ligate Chain devnet on Celestia Mocha.
+
+## Layout
+
+```
+devnet/
+├── celestia.toml      # rollup config (chain identity, DA, storage, sequencer)
+├── genesis/           # one JSON per runtime module
+│   ├── accounts.json
+│   ├── attestation.json
+│   ├── attester_incentives.json
+│   ├── bank.json
+│   ├── chain_state.json
+│   ├── operator_incentives.json
+│   ├── prover_incentives.json
+│   └── sequencer_registry.json
+└── README.md
+```
+
+No `rollup.toml`. Devnet-2 is Celestia-only by design; MockDA only exists in the localnet config (`devnet/`) for local smoke testing. If you want a MockDA flavour, use `devnet/`, not `devnet/`.
+
+## Boot
+
+From the repo root:
+
+```sh
+cargo run --bin ligate-node -- \
+    --da-layer celestia \
+    --rollup-config-path devnet/celestia.toml \
+    --genesis-config-dir devnet/genesis
+```
+
+Production deploys override secrets via env vars; never commit them:
+
+```sh
+SOV_CELESTIA_RPC_URL=ws://127.0.0.1:26658 \
+SOV_CELESTIA_GRPC_URL=http://127.0.0.1:9090 \
+SOV_CELESTIA_SIGNER_KEY=$(pass celestia/devnet-signer) \
+cargo run --bin ligate-node -- \
+    --da-layer celestia \
+    --rollup-config-path devnet/celestia.toml \
+    --genesis-config-dir devnet/genesis
+```
+
+The full deploy runbook lives at [`docs/development/public-devnet-deploy.md`](../docs/development/public-devnet-deploy.md) and covers VM provisioning, the co-located Celestia light node, Caddy + Let's Encrypt, monitoring, and failure-mode triage.
+
+## Differences from `devnet/`
+
+| Field | `devnet/` (localnet) | `devnet/` (public devnet) |
+|---|---|---|
+| `chain_id` | `ligate-localnet` | `ligate-devnet-2` |
+| DA layer | MockDA + Celestia (two flavours) | Celestia only |
+| Default `rpc_url` | `ws://127.0.0.1:26658` | same; pattern assumes co-located light node |
+| `storage.path` | `devnet/data-celestia` | `devnet/data-celestia` (lets a single host run both) |
+| Bind host | `127.0.0.1` | `127.0.0.1` (public TLS via Caddy on same VM) |
+| Genesis allocations | 3 dev wallets, anvil-style keys | placeholder (see "Placeholder addresses" below) |
+
+## Placeholder addresses (read this before you deploy)
+
+The genesis JSONs in this directory carry the **same placeholder addresses as `devnet/`**, which are deterministic test fixtures derived from public string seeds. They exist so the chain boots cleanly for CI parse tests and `cargo run` smoke. **Do not deploy a public node with these addresses unchanged.** The private keys behind those addresses are derivable from a public seed; anyone could impersonate the bootstrap actor, sequencer, treasury, attester, or prover.
+
+For the real public-devnet ceremony (tracked in [#231](https://github.com/ligate-io/ligate-chain/issues/231)):
+
+### 1. Generate operator-controlled keys offline
+
+```sh
+cargo run -p ligate-genesis-tool -- keys generate \
+    --roles operator,demo1,demo2 \
+    --output ~/.ligate-keys/devnet
+```
+
+Each role yields one Ed25519 keypair: `<role>.key` (hex-encoded, chmod 600, **never commit**) and `<role>.address` (the `lig1...` bech32m string ready to paste into `keys.toml`). Address derivation matches the SDK's standard `Address = SHA-256(pubkey)[..28]`.
+
+Pick role labels that reflect your security model:
+
+- **Single key** (simplest): `--roles operator` covers sequencer / treasury / reward / attester / prover all from one address.
+- **Split for security separation**: `--roles sequencer,treasury,operator,demo1,demo2`. Treasury can stay cold (offline), sequencer is necessarily hot (signs continuously).
+
+This subcommand is a stand-in for [`ligate-cli keys generate`](https://github.com/ligate-io/ligate-chain/issues/112); when `ligate-cli` ships in its own repo, the same command moves there.
+
+### 2. Fill in `keys.toml` from the template
+
+```sh
+cp devnet/keys.toml.example devnet/keys.toml
+$EDITOR devnet/keys.toml
+```
+
+`keys.toml` is gitignored. The template enumerates every placeholder address in the current `genesis/` bundle and walks through which roles each one fills.
+
+### 3. Substitute genesis
+
+```sh
+cargo run -p ligate-genesis-tool -- generate \
+    --template devnet/genesis \
+    --substitutions devnet/keys.toml \
+    --output /tmp/ligate-devnet-2-real/genesis
+
+cargo run -p ligate-genesis-tool -- verify \
+    --dir /tmp/ligate-devnet-2-real/genesis
+```
+
+`verify` runs all the cross-module invariants from [#175](https://github.com/ligate-io/ligate-chain/issues/175) (no orphan references, threshold ≤ members, fee routing addresses exist, etc.) and catches typos before the chain refuses to boot.
+
+### 4. Commit the substituted bundle as a ceremony PR
+
+```sh
+rm -rf devnet/genesis
+cp -r /tmp/ligate-devnet-2-real/genesis devnet/genesis
+git add devnet/genesis
+git commit -m "ceremony: substitute devnet genesis with operator-controlled keys (closes #231)"
+```
+
+Public devnet boots from that commit. Private keys never leave your machine.
+
+### 5. Source Mocha TIA for the Celestia hot key
+
+The Celestia hot key (`SOV_CELESTIA_SIGNER_KEY` env var) is **separate** from the genesis substitution above. It signs blob inclusion txs and pays Mocha TIA fees. Generate a Celestia keypair, derive its address, then request ~10-50 TIA from the [Celestia Mocha faucet](https://docs.celestia.org/nodes/mocha-testnet#mocha-testnet-faucet) Discord bot.
+
+Set the env var in `/etc/ligate/env` on the GCP VM (`chmod 600`, root-readable only) per the deploy runbook.
+
+### 6. Register canonical schemas (post-boot)
+
+`devnet/genesis/attestation.json` ships with `initial_attestor_sets: []` and `initial_schemas: []` deliberately. After the node boots and `/v1/rollup/info` returns a non-zero `chain_hash`, register the canonical Themisra schema (`themisra.proof-of-prompt/v1`) by running the `ligate-bootstrap` ceremony:
+
+```sh
+cp devnet/canonical-schemas.toml.example devnet/canonical-schemas.toml
+$EDITOR devnet/canonical-schemas.toml  # fill in real attestor pubkeys
+cargo run --release -p ligate-bootstrap-cli -- register-canonical-schemas \
+    --config devnet/canonical-schemas.toml \
+    --signer-key ~/.ligate-keys/devnet/operator.key \
+    --rpc https://rpc.ligate.io \
+    --chain-id 4242
+```
+
+Idempotent: re-runs skip already-landed registrations. Full runbook (verification, troubleshooting, adding future schemas) at [`docs/development/canonical-schema-registration.md`](../docs/development/canonical-schema-registration.md).
+
+This step is **post-genesis on purpose**: it keeps the chain's "attestation primitive is permissionless from day one" promise honest (Ligate Labs registers the same way any third-party schema would) and avoids baking a placeholder `payload_shape_hash: [0u8; 32]` into permanent chain state. The registered schema is bit-for-bit identical to a genesis-seeded one once Tx 2 lands ~24-36s after the script starts.
+
+## Mocha resets and `devnet-2/`
+
+Mocha (Celestia's testnet) resets occasionally. When it does, the DA-layer references in our chain state become invalid; the cleanest recovery is to spin up a fresh chain id (`ligate-devnet-2`) on the new Mocha epoch with a fresh genesis bundle. The directory naming pattern this template establishes (`devnet/` → `devnet-2/` → ... → `ligate-1/`) supports that without touching the existing artifacts.
+
+## Faucet
+
+[#95](https://github.com/ligate-io/ligate-chain/issues/95) tracks the faucet service. The faucet hot key is intentionally separate from the bootstrap (treasury) key so a faucet drain does not touch the treasury balance. When the genesis ceremony runs, the faucet account is provisioned in `bank.json` with its own balance and a separate `lig1...` address; the faucet service signs from that key.
+
+The placeholder bundle here uses the same bootstrap address everywhere as `devnet/` does, so there is no faucet account in the committed JSONs yet. Real ceremony adds it.
+
+## See also
+
+- [`docs/development/public-devnet-deploy.md`](../docs/development/public-devnet-deploy.md): operator runbook (sequencer + follower flows).
+- [`docs/protocol/attestation-v0.md`](../docs/protocol/attestation-v0.md): the spec, including the chain-id ladder section.
+- [`devnet/README.md`](../devnet/README.md): localnet variant; useful for local smoke testing without Celestia.
+- [`crates/rollup/src/chain_config.rs`](../crates/rollup/src/chain_config.rs): the loader that splits `[chain]` from the SDK's `RollupConfig` and validates the ladder.
+- [#181](https://github.com/ligate-io/ligate-chain/issues/181): the ladder validator.
+- [#188](https://github.com/ligate-io/ligate-chain/issues/188): this directory.
+- [#191](https://github.com/ligate-io/ligate-chain/issues/191): genesis generation tool.

--- a/archive/ligate-devnet-2/canonical-schemas.toml.example
+++ b/archive/ligate-devnet-2/canonical-schemas.toml.example
@@ -1,0 +1,60 @@
+# Canonical schemas registered post-genesis on `ligate-devnet-2`.
+#
+# After `ligate-node` boots and starts producing blocks, the operator
+# runs:
+#
+#   cargo run -p ligate-bootstrap-cli -- register-canonical-schemas \
+#       --config devnet/canonical-schemas.toml \
+#       --signer-key /etc/ligate/keys/themisra-bootstrap.key \
+#       --rpc http://localhost:12346 \
+#       --chain-id <numeric CHAIN_ID from constants.toml>   # devnet: 4242
+#
+# That submits one `RegisterAttestorSet` + one `RegisterSchema` tx per
+# `[[schemas]]` entry below. Idempotent: re-runs skip already-landed
+# registrations.
+#
+# This is the .example template. Copy to `canonical-schemas.toml`
+# (gitignored), fill in the real attestor pubkeys for the federated
+# Themisra quorum, and commit only the .example version of this file.
+# The .example file MUST stay in sync with the in-repo schema specs
+# under `docs/protocol/schemas/` (the `attestor_members` field is the
+# only thing that varies between local dev and public devnet).
+#
+# Tracking issue: #231 (operator key ceremony + post-genesis bootstrap).
+
+# Where the JSON Schema docs live, relative to THIS TOML file's directory.
+# Default points at `docs/protocol/schemas/`.
+schema_root = "../docs/protocol/schemas"
+
+# ---------------------------------------------------------------------
+# themisra.proof-of-prompt v1.0.0
+#
+# First canonical schema for the Themisra Proof-of-Prompt product.
+# Spec: docs/protocol/schemas/themisra.proof-of-prompt-v1.json
+# LIP-5 (#185) iterates the spec; iterations ship as v2+, not as
+# mutations of v1.
+#
+# Attestor set: 3-of-? federated. Replace `attestor_members` with the
+# real ed25519 pubkeys from your operator key ceremony output.
+# ---------------------------------------------------------------------
+[[schemas]]
+name = "themisra.proof-of-prompt"
+version = 1
+spec_file = "themisra.proof-of-prompt-v1.json"
+
+# 2-of-3 quorum. M-of-N: at least `attestor_threshold` of the listed
+# `attestor_members` must sign each attestation.
+attestor_threshold = 2
+attestor_members = [
+  # Replace with real 32-byte ed25519 pubkeys (64-char lowercase hex,
+  # no `0x` prefix). The order is part of the attestor_set_id
+  # derivation, so commit to the order before generating keys.
+  "0000000000000000000000000000000000000000000000000000000000000000",
+  "1111111111111111111111111111111111111111111111111111111111111111",
+  "2222222222222222222222222222222222222222222222222222222222222222",
+]
+
+# Fee-routing share for the schema owner. `0` = no routing (all fees
+# go to the network treasury). When set > 0, requires `fee_routing_addr`.
+fee_routing_bps = 0
+# fee_routing_addr = "lig1..."

--- a/archive/ligate-devnet-2/celestia.toml
+++ b/archive/ligate-devnet-2/celestia.toml
@@ -1,4 +1,4 @@
-# Ligate `ligate-devnet-3` rollup config (Celestia DA, public).
+# Ligate `ligate-devnet-2` rollup config (Celestia DA, public).
 #
 # Boots a single-sequencer node against Celestia Mocha testnet for the
 # canonical public devnet rung of the chain-id ladder. Mock zkVM still
@@ -26,7 +26,7 @@
 #
 # Differences from `devnet/celestia.toml`:
 #
-#   - chain_id is `ligate-devnet-3` (locked ladder rung; #181)
+#   - chain_id is `ligate-devnet-2` (locked ladder rung; #181)
 #   - storage.path differs so a single host can run both localnet and
 #     devnet side by side
 #   - comments emphasise public-devnet hygiene (env-var overrides,
@@ -35,12 +35,12 @@
 # See `devnet/README.md` for the full operator narrative and
 # `docs/development/public-devnet-deploy.md` for the deploy runbook.
 
-# Chain identity. `ligate-devnet-3` is the public-devnet rung of the
+# Chain identity. `ligate-devnet-2` is the public-devnet rung of the
 # locked ladder per `docs/protocol/attestation-v0.md` `Chain id`. The
 # binary refuses to boot with any value outside the ladder; the
 # validator lives in `crates/rollup/src/chain_config.rs` (#181).
 [chain]
-chain_id = "ligate-devnet-3"
+chain_id = "ligate-devnet-2"
 
 [da]
 # Celestia RPC endpoint for reading blobs + headers.

--- a/archive/ligate-devnet-2/genesis/accounts.json
+++ b/archive/ligate-devnet-2/genesis/accounts.json
@@ -1,0 +1,4 @@
+{
+  "accounts": [],
+  "enable_custom_account_mappings": true
+}

--- a/archive/ligate-devnet-2/genesis/attestation.json
+++ b/archive/ligate-devnet-2/genesis/attestation.json
@@ -1,0 +1,10 @@
+{
+  "attestation_fee": "100000",
+  "attestor_set_fee": "50000000",
+  "initial_attestor_sets": [],
+  "initial_schemas": [],
+  "avow_token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
+  "max_builder_bps": 5000,
+  "schema_registration_fee": "100000000",
+  "treasury": "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+}

--- a/archive/ligate-devnet-2/genesis/attester_incentives.json
+++ b/archive/ligate-devnet-2/genesis/attester_incentives.json
@@ -1,0 +1,19 @@
+{
+  "initial_attesters": [
+    [
+      "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac",
+      "1000000000000"
+    ]
+  ],
+  "light_client_finalized_height": 0,
+  "maximum_attested_height": 0,
+  "minimum_attester_bond": [
+    1000,
+    1000
+  ],
+  "minimum_challenger_bond": [
+    1000,
+    1000
+  ],
+  "rollup_finality_period": 5
+}

--- a/archive/ligate-devnet-2/genesis/bank.json
+++ b/archive/ligate-devnet-2/genesis/bank.json
@@ -1,0 +1,24 @@
+{
+  "gas_token_config": {
+    "address_and_balances": [
+      [
+        "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac",
+        "900000000000000000"
+      ],
+      [
+        "lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544",
+        "50000000000000000"
+      ],
+      [
+        "lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz",
+        "50000000000000000"
+      ]
+    ],
+    "admins": [
+      "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+    ],
+    "token_decimals": 9,
+    "token_name": "AVOW"
+  },
+  "tokens": []
+}

--- a/archive/ligate-devnet-2/genesis/chain_state.json
+++ b/archive/ligate-devnet-2/genesis/chain_state.json
@@ -1,0 +1,25 @@
+{
+  "current_time": 0,
+  "genesis_da_height": 0,
+  "inner_code_commitment": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "operating_mode": "zk",
+  "outer_code_commitment": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ]
+}

--- a/archive/ligate-devnet-2/genesis/operator_incentives.json
+++ b/archive/ligate-devnet-2/genesis/operator_incentives.json
@@ -1,0 +1,3 @@
+{
+  "reward_address": "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+}

--- a/archive/ligate-devnet-2/genesis/prover_incentives.json
+++ b/archive/ligate-devnet-2/genesis/prover_incentives.json
@@ -1,0 +1,16 @@
+{
+  "initial_provers": [
+    [
+      "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac",
+      "1000000000000"
+    ]
+  ],
+  "minimum_bond": [
+    1000,
+    1000
+  ],
+  "proving_penalty": [
+    10,
+    10
+  ]
+}

--- a/archive/ligate-devnet-2/genesis/sequencer_registry.json
+++ b/archive/ligate-devnet-2/genesis/sequencer_registry.json
@@ -1,0 +1,9 @@
+{
+  "minimum_bond": "1000000000000",
+  "sequencer_config": {
+    "is_preferred_sequencer": true,
+    "seq_bond": "5000000000000",
+    "seq_da_address": "celestia1mphanjz38a5fvftsdr20ct388gtnxhlq52wr33",
+    "seq_rollup_address": "lig1zd9j2z6x55ydnv9m8f0pdw3vs2j8u0w5sdqeaf478dzp6s998ac"
+  }
+}

--- a/archive/ligate-devnet-2/keys.toml.example
+++ b/archive/ligate-devnet-2/keys.toml.example
@@ -1,0 +1,117 @@
+# devnet genesis substitution template
+#
+# Copy this to `keys.toml` (gitignored), fill in your operator-controlled
+# addresses, then run:
+#
+#   cargo run -p ligate-genesis-tool -- generate \
+#       --template devnet/genesis \
+#       --substitutions devnet/keys.toml \
+#       --output /tmp/ligate-devnet-2-real/genesis
+#
+#   cargo run -p ligate-genesis-tool -- verify \
+#       --dir /tmp/ligate-devnet-2-real/genesis
+#
+# Once `verify` passes, replace `devnet/genesis/` with the contents
+# of the output dir as a one-shot ceremony PR. Public devnet boots
+# from that commit.
+#
+# Tracking issue: #231 (operator key generation + genesis substitution).
+#
+# DO NOT COMMIT `keys.toml` (the filled-in version). It contains the
+# mapping from public placeholder addresses to your real operator
+# addresses; while only public bits live in it, the deploy ceremony
+# is cleaner if the substitution map stays out of repo.
+#
+# DO NOT PUT PRIVATE KEYS IN THIS FILE. This is the *substitution
+# map*, addresses only. Private keys live offline (cold storage,
+# hardware wallet, or `~/.ligate-keys/` with chmod 600 — never in
+# repo, never in env vars committed to repo).
+
+# ---------------------------------------------------------------------
+# [addresses]: placeholder address (left) -> real address (right)
+#
+# All four placeholders below are deterministic test fixtures committed
+# to `devnet/genesis/`. Their private keys are derivable from public
+# seeds, so anyone could impersonate them. Substitute every one.
+# ---------------------------------------------------------------------
+[addresses]
+
+# Multi-role bootstrap address. In the placeholder genesis this single
+# address fills:
+#   - sequencer registry's `seq_rollup_address`
+#   - operator-incentives `reward_address`
+#   - bank `treasury` + minting authority (admins)
+#   - 900M nano-AVOW initial balance
+#
+# For real devnet deploy, you can either:
+#   (a) Map this single placeholder to ONE real address and reuse it
+#       across roles (simplest; one operator key fills everything)
+#   (b) Use the full schema below to split roles across multiple keys
+#       (recommended for security separation; treasury cold, sequencer
+#       hot, etc.)
+#
+# If (a): just substitute this one line. If (b): substitute this AND
+# add per-role overrides via additional substitution rounds, OR run
+# the tool then hand-edit the four JSONs that reference this address.
+"lig1rh9vcu879l36z42xgw78wuksy8ma5vnzkrregmgmka9uqr8fyp8" = "<YOUR_OPERATOR_ADDRESS>"
+
+# Demo wallet 1 (placeholder ships with 50M AVOW). Optional; you can:
+#   - Substitute with a real demo / faucet-source address
+#   - Or set `balances` below to 0 to deactivate it without
+#     substituting
+"lig19tzzufavjqtzgwt58nqjs43gx0j3swsmxcmz9c9uv2suy5hj544" = "<YOUR_DEMO_WALLET_1>"
+
+# Demo wallet 2 (placeholder ships with 50M AVOW). Same notes as above.
+"lig1e0lp7e5tzl49dfe0nz0xx46ks3hv7ehw9af2xy6n22ygjmnj4sz" = "<YOUR_DEMO_WALLET_2>"
+
+# Celestia DA wallet that signs blob-submission transactions. The
+# placeholder bech32 below is the all-zero 20-byte address encoded
+# with the `celestia` HRP (visually obvious it's a placeholder).
+# Substitute with the bech32 form of the wallet that holds your Mocha
+# TIA balance — i.e. the wallet derived from `SOV_CELESTIA_SIGNER_KEY`.
+# This wallet must equal the sequencer that submits blobs, or the chain
+# will reject the registered DA address at startup.
+#
+# Derive the bech32 from your hex private key with any cosmos-sdk
+# keyring tool, or from a celestia-light-node import.
+"celestia1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzf30as" = "<YOUR_CELESTIA_DA_ADDRESS>"
+
+# ---------------------------------------------------------------------
+# [balances]: optional override of nano-AVOW balances post-substitution.
+# Key is the POST-substitution address (the value side of [addresses]).
+# Value is the new balance as a decimal string (matches `Amount` shape
+# in `bank.json`).
+#
+# Defaults from the placeholder genesis (post-#324, 1B total supply):
+#   bootstrap address: 900_000_000_000_000_000 (900M AVOW)
+#   demo wallet 1:      50_000_000_000_000_000 (50M AVOW)
+#   demo wallet 2:      50_000_000_000_000_000 (50M AVOW)
+#
+# Bond requirements at genesis (from `sequencer_registry.json`,
+# `prover_incentives.json`, `attester_incentives.json`):
+#   sequencer bond: 5_000_000_000_000 nano-AVOW (5 AVOW)
+#
+# The bootstrap address must hold at least the sequencer bond + some
+# slack for fees. If you split roles, ensure each role's address holds
+# its bond requirement.
+# ---------------------------------------------------------------------
+[balances]
+# "<YOUR_OPERATOR_ADDRESS>" = "900000000000000000"   # 900M nano-AVOW
+# "<YOUR_DEMO_WALLET_1>"    = "50000000000000000"    # 50M  nano-AVOW
+# "<YOUR_DEMO_WALLET_2>"    = "50000000000000000"    # 50M  nano-AVOW
+
+# ---------------------------------------------------------------------
+# Out of scope for this file (configured separately):
+#
+# - `SOV_CELESTIA_SIGNER_KEY`: the Celestia hot key for blob signing.
+#   Set as env var on the GCP VM (`/etc/ligate/env`, chmod 600).
+#   Funded with Mocha TIA from the Celestia Discord faucet.
+#
+# - First-party schema attestor sets (e.g. for
+#   `themisra.proof-of-prompt/v1`): registered post-genesis via
+#   `RegisterAttestorSet` calls, NOT seeded in the genesis JSONs.
+#   Each first-party schema's attestor org operates its own keys.
+#
+# - First-party schemas themselves: same — registered post-genesis
+#   via `RegisterSchema` calls.
+# ---------------------------------------------------------------------

--- a/constants.toml
+++ b/constants.toml
@@ -26,7 +26,7 @@ freeze       = [1, 1]
 # value finalised at TGE; devnet uses 4242 (distinct from the SDK
 # demo's 4321 so a misconfigured client failing back to demo defaults
 # is obvious in logs). Per #54, the user-facing string identifier is
-# `ligate-devnet-2` / `ligate-1` and lives in the rollup config TOML,
+# `ligate-devnet-3` / `ligate-1` and lives in the rollup config TOML,
 # not here.
 CHAIN_ID = 4242
 CHAIN_NAME = "Ligate"

--- a/crates/bootstrap-cli/src/main.rs
+++ b/crates/bootstrap-cli/src/main.rs
@@ -141,7 +141,7 @@ async fn run(args: Args) -> Result<()> {
                     eprintln!("connected to {} (ligate-node {})", info.chain_id, info.version);
                     let id = chain_id.unwrap_or_else(|| {
                         // `chain_id` in /rollup/info is the human-readable
-                        // string ("ligate-devnet-2"); the chain signs txs
+                        // string ("ligate-devnet-3"); the chain signs txs
                         // against a u64 numeric id defined as `CHAIN_ID`
                         // in `constants.toml`. Until /rollup/info also
                         // exposes the numeric form, operators must pass

--- a/crates/bootstrap-cli/src/register.rs
+++ b/crates/bootstrap-cli/src/register.rs
@@ -62,7 +62,7 @@ pub struct RegisterParams<'a> {
     /// Operator signing key (32-byte ed25519 seed).
     pub signer_key: SovPrivateKey,
     /// Chain id (`/v1/rollup/info -> chain_id`'s numeric form, NOT the
-    /// `ligate-devnet-2` string).
+    /// `ligate-devnet-3` string).
     pub chain_id: u64,
     /// 32-byte build-time `CHAIN_HASH`, from `/v1/rollup/info`.
     pub chain_hash: [u8; 32],

--- a/crates/client-rs/src/submit.rs
+++ b/crates/client-rs/src/submit.rs
@@ -38,8 +38,8 @@
 //!    a [`sov_modules_api::transaction::Transaction`]. The signature
 //!    is domain-separated to the chain's `CHAIN_HASH` constant
 //!    (build-time hash of the runtime composition + spec). A
-//!    transaction for `ligate-devnet-2` does not verify on
-//!    `ligate-devnet-2` even if the signing key is identical.
+//!    transaction for `ligate-devnet-3` does not verify on
+//!    `ligate-devnet-3` even if the signing key is identical.
 //!
 //! 4. **Encode.** Borsh-serialize the signed transaction into raw
 //!    bytes, then wrap in `AuthenticatorInput::Standard(...)` per

--- a/crates/genesis-tool/src/main.rs
+++ b/crates/genesis-tool/src/main.rs
@@ -81,7 +81,7 @@ enum DaFlavor {
     /// integration tests, cross-OS genesis-determinism CI.
     Mock,
     /// Celestia DA (bech32 `celestia1...` `seq_da_address`). Use for
-    /// `ligate-devnet-2` and any production-shape deployment.
+    /// `ligate-devnet-3` and any production-shape deployment.
     #[default]
     Celestia,
 }

--- a/crates/rollup/src/info.rs
+++ b/crates/rollup/src/info.rs
@@ -4,7 +4,7 @@
 //! response:
 //!
 //! - `chain_id`: the Cosmos-style string from the rollup config's
-//!   `[chain]` section (e.g. `ligate-localnet`, `ligate-devnet-2`).
+//!   `[chain]` section (e.g. `ligate-localnet`, `ligate-devnet-3`).
 //!   Bumps on state-breaking restarts only; stable across STF
 //!   upgrades.
 //! - `chain_hash`: the runtime's build-script-generated 32-byte

--- a/crates/rollup/tests/info_smoke.rs
+++ b/crates/rollup/tests/info_smoke.rs
@@ -97,7 +97,7 @@ async fn info_handles_concurrent_requests() {
     // refresh, but a misbehaving load balancer or webhook could fire
     // many parallel reads. Ensure the handler doesn't serialize
     // (would surface as visible latency on a busy node).
-    let addr = spawn_info_server("ligate-devnet-2", [0xABu8; 32]).await;
+    let addr = spawn_info_server("ligate-devnet-3", [0xABu8; 32]).await;
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
@@ -112,7 +112,7 @@ async fn info_handles_concurrent_requests() {
                 client.get(format!("http://{addr}/rollup/info")).send().await.expect("response");
             assert_eq!(resp.status().as_u16(), 200);
             let body: RollupInfo = resp.json().await.expect("json");
-            assert_eq!(body.chain_id, "ligate-devnet-2");
+            assert_eq!(body.chain_id, "ligate-devnet-3");
         }));
     }
     for j in joins {

--- a/crates/rollup/tests/localnet_config.rs
+++ b/crates/rollup/tests/localnet_config.rs
@@ -108,7 +108,7 @@ fn devnet_celestia_toml_parses_against_celestia_blueprint_types() {
     // Pin the committed chain id so a typo (e.g. bumping to
     // `ligate-1` on the devnet config) breaks here rather than at
     // first boot.
-    assert_eq!(chain.chain_id, "ligate-devnet-2");
+    assert_eq!(chain.chain_id, "ligate-devnet-3");
 }
 
 #[test]

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -18,7 +18,7 @@ Read these in roughly this order when standing up a fresh chain instance.
 |---|---|
 | [`quickstart-partner.md`](./quickstart-partner.md) | First-look for a partner or design-partner integrator — what the chain is, how to call it, where to send `register_schema` traffic |
 | [`devnet.md`](./devnet.md) | Localnet bring-up (Mock DA) and the federated-devnet design (attestor orgs, multi-sequencer topology — forward-looking) |
-| [`public-devnet-deploy.md`](./public-devnet-deploy.md) | GCP VM bring-up procedure for `ligate-devnet-2`: project, SA, firewall, systemd unit, first boot |
+| [`public-devnet-deploy.md`](./public-devnet-deploy.md) | GCP VM bring-up procedure for `ligate-devnet-3`: project, SA, firewall, systemd unit, first boot |
 | [`celestia-ops.md`](./celestia-ops.md) | Co-located Celestia light node setup, wallet wiring, TIA funding |
 | [`snapshot-bootstrap.md`](./snapshot-bootstrap.md) | Spin up a read-only sync node that imports from a public snapshot instead of replaying DA from genesis. For design partners, auditors, third-party node operators. |
 | [`canonical-schema-registration.md`](./canonical-schema-registration.md) | Post-genesis schema registration ceremony: bootstrap-cli flow for `themisra.proof-of-prompt/v1` etc. |

--- a/docs/development/canonical-schema-registration.md
+++ b/docs/development/canonical-schema-registration.md
@@ -2,7 +2,7 @@
 
 How Ligate Labs registers `themisra.proof-of-prompt/v1` (and future first-party schemas) on the chain after genesis.
 
-This is **post-genesis** work — runs once on a freshly-booted `ligate-devnet-2` (or any future devnet / mainnet boot), uses the same on-chain `RegisterAttestorSet` + `RegisterSchema` calls any third party would use, costs the registration fees the chain charges (`attestor_set_fee` 0.05 AVOW + `schema_registration_fee` 0.1 AVOW = ~0.15 AVOW total per ceremony in v0). Fees in the genesis JSON are expressed in nano-AVOW (9 decimals).
+This is **post-genesis** work — runs once on a freshly-booted `ligate-devnet-3` (or any future devnet / mainnet boot), uses the same on-chain `RegisterAttestorSet` + `RegisterSchema` calls any third party would use, costs the registration fees the chain charges (`attestor_set_fee` 0.05 AVOW + `schema_registration_fee` 0.1 AVOW = ~0.15 AVOW total per ceremony in v0). Fees in the genesis JSON are expressed in nano-AVOW (9 decimals).
 
 Tracking issue: [#231](https://github.com/ligate-io/ligate-chain/issues/231).
 
@@ -60,12 +60,12 @@ Don't commit the filled-in file. `devnet-1/.gitignore` already excludes it.
     --chain-id 4242
 ```
 
-`--chain-id` is the numeric `CHAIN_ID` defined in `constants.toml` (NOT the human-readable `ligate-devnet-2` string). `--chain-hash` is fetched from `GET /v1/rollup/info` automatically; pass `--chain-hash <64-char-hex>` to override (the flag expects hex, optionally with a `0x` prefix; not the bech32m `lsch1…` form).
+`--chain-id` is the numeric `CHAIN_ID` defined in `constants.toml` (NOT the human-readable `ligate-devnet-3` string). `--chain-hash` is fetched from `GET /v1/rollup/info` automatically; pass `--chain-hash <64-char-hex>` to override (the flag expects hex, optionally with a `0x` prefix; not the bech32m `lsch1…` form).
 
 Expected output (success path):
 
 ```
-connected to ligate-devnet-2 (ligate-node 0.1.0-devnet)
+connected to ligate-devnet-3 (ligate-node 0.1.0-devnet)
 
 Canonical schema registration: 1 schema(s)
 

--- a/docs/development/cost-monitoring.md
+++ b/docs/development/cost-monitoring.md
@@ -1,6 +1,6 @@
 # Cost monitoring — Mocha TIA spend + GCP infra spend
 
-**Status:** v0 — Grafana dashboard + Alertmanager rules for cost visibility on `ligate-devnet-2`. Companion to [`da-signer-rotation.md`](runbooks/da-signer-rotation.md) (TIA wallet management), [`alerts/`](runbooks/alerts/) (alert runbooks), and [`public-devnet-deploy.md`](public-devnet-deploy.md) (the deploy this monitors).
+**Status:** v0 — Grafana dashboard + Alertmanager rules for cost visibility on `ligate-devnet-3`. Companion to [`da-signer-rotation.md`](runbooks/da-signer-rotation.md) (TIA wallet management), [`alerts/`](runbooks/alerts/) (alert runbooks), and [`public-devnet-deploy.md`](public-devnet-deploy.md) (the deploy this monitors).
 
 Two cost surfaces:
 
@@ -49,7 +49,7 @@ Top-up procedure: [`da-signer-rotation.md` "TIA balance monitoring"](runbooks/da
 
 ### Steady-state expectation
 
-`ligate-devnet-2`'s baseline:
+`ligate-devnet-3`'s baseline:
 
 | Resource | Quantity | $/mo |
 |---|---|---|

--- a/docs/development/devnet.md
+++ b/docs/development/devnet.md
@@ -22,10 +22,10 @@ first.
 
 Ligate Chain v0 devnet is a **federated attestation testnet**:
 
-- **Chain id**: `ligate-devnet-2`. The trailing number bumps only on a
+- **Chain id**: `ligate-devnet-3`. The trailing number bumps only on a
   state-breaking restart (full reset, new genesis); soft upgrades via
   the upgrade module ([#42](https://github.com/ligate-io/ligate-chain/issues/42))
-  keep the same id. Full ladder (`ligate-localnet` / `ligate-devnet-2` /
+  keep the same id. Full ladder (`ligate-localnet` / `ligate-devnet-3` /
   `ligate-testnet-1` / `ligate-1`) is locked in
   [the protocol spec](../protocol/attestation-v0.md#chain-id) per
   [#54](https://github.com/ligate-io/ligate-chain/issues/54).

--- a/docs/development/public-devnet-deploy.md
+++ b/docs/development/public-devnet-deploy.md
@@ -1,6 +1,6 @@
 # Public devnet deploy runbook
 
-How to bring up a `ligate-devnet-2` node on GCP, in either operator role:
+How to bring up a `ligate-devnet-3` node on GCP, in either operator role:
 
 - **Sequencer** (the canonical Ligate-Labs node, single-instance in v0).
 - **Follower** (any third-party operator running their own copy of the chain state).
@@ -274,7 +274,7 @@ curl https://rpc.ligate.io/ready
 
 # Chain identity (the network operators are talking to).
 curl https://rpc.ligate.io/v1/rollup/info
-# {"chain_id":"ligate-devnet-2","chain_hash":"<64 hex>","version":"X.Y.Z"}
+# {"chain_id":"ligate-devnet-3","chain_hash":"<64 hex>","version":"X.Y.Z"}
 
 # Followers cross-check chain_hash against the canonical Ligate-Labs node:
 diff <(curl -s https://rpc.ligate.io/v1/rollup/info | jq -r .chain_hash) \
@@ -295,7 +295,7 @@ $EDITOR devnet-1/canonical-schemas.toml  # fill in real attestor pubkeys
 
 # 2. Run the ceremony binary. Auto-fetches chain_hash from /v1/rollup/info.
 #    --chain-id is the numeric u64 CHAIN_ID from constants.toml (NOT
-#    the "ligate-devnet-2" human-readable string).
+#    the "ligate-devnet-3" human-readable string).
 cargo run --release -p ligate-bootstrap-cli -- register-canonical-schemas \
     --config devnet-1/canonical-schemas.toml \
     --signer-key ~/.ligate-keys/devnet-1/operator.key \
@@ -374,7 +374,7 @@ The `ligate-node` systemd unit reads from `/etc/ligate/env`, which on first boot
 | Symptom | Likely cause | First check | Fix |
 |---|---|---|---|
 | `ligate-node` won't start, "missing [chain] section" | Wrong config file passed | `journalctl -u ligate-node` | Check `--rollup-config-path` points at `/opt/ligate/devnet/celestia.toml`, not the localnet one |
-| `ligate-node` won't start, "chain_id 'X' does not match the locked ladder" | Operator typo in `[chain]` | `cat /opt/ligate/devnet/celestia.toml \| grep chain_id` | Fix to `ligate-devnet-2`, restart |
+| `ligate-node` won't start, "chain_id 'X' does not match the locked ladder" | Operator typo in `[chain]` | `cat /opt/ligate/devnet/celestia.toml \| grep chain_id` | Fix to `ligate-devnet-3`, restart |
 | Sequencer cannot reach Celestia | Light node down or wrong endpoint | `systemctl status celestia-light`, `curl ws://127.0.0.1:26658` | Restart `celestia-light`; if persistent, check Mocha bridge availability |
 | `/ready` returns 503 with high target_da_height | Node is catching up | Look at `synced_da_height` over 5 min | Wait; sync rate ~1 block/s on healthy network |
 | `/ready` returns 503 indefinitely | Sequencer can't keep up with DA | Check `block_height` metric and DA polling rate | Increase `da_polling_interval_ms` upward, or check for state-corruption indicators |
@@ -385,13 +385,13 @@ The `ligate-node` systemd unit reads from `/etc/ligate/env`, which on first boot
 
 ## Mocha reset re-genesis playbook
 
-Mocha resets roughly once a year. When it does, our chain's DA-layer references go stale; the cleanest recovery is to spin up a fresh chain id (`ligate-devnet-2`) on the new Mocha epoch.
+Mocha resets roughly once a year. When it does, our chain's DA-layer references go stale; the cleanest recovery is to spin up a fresh chain id (`ligate-devnet-3`) on the new Mocha epoch.
 
 Steps:
 
 1. Wait for the Celestia team's announcement of the new Mocha genesis hash.
 2. In `ligate-chain`, copy `devnet-1/` to `devnet-2/`. Edit:
-   - `celestia.toml`: bump `chain_id = "ligate-devnet-2"`, update `storage.path = "devnet-2/data-celestia"`.
+   - `celestia.toml`: bump `chain_id = "ligate-devnet-3"`, update `storage.path = "devnet-2/data-celestia"`.
    - `genesis/`: regenerate via `ligate-genesis-tool` ([#191](https://github.com/ligate-io/ligate-chain/issues/191)), keeping the same operator-controlled keys.
 3. Add CI test rows in `crates/rollup/tests/localnet_config.rs` for `devnet-2/` (mirror the `devnet_1_*` tests).
 4. Land the PR; tag a new release (`v0.2.0-devnet-2` or similar).

--- a/docs/development/quickstart-partner.md
+++ b/docs/development/quickstart-partner.md
@@ -1,6 +1,6 @@
-# Partner Quickstart — Zero to First Attestation on `ligate-devnet-2`
+# Partner Quickstart — Zero to First Attestation on `ligate-devnet-3`
 
-**Status:** Pre-devnet. The flow below is what `ligate-devnet-2` will support on Day 1 (target Q2 2026). Sections marked with **⚠ Preview** are wired in code but the public infrastructure they depend on (faucet, hosted RPC, canonical schemas, explorer) is still spinning up.
+**Status:** Pre-devnet. The flow below is what `ligate-devnet-3` will support on Day 1 (target Q2 2026). Sections marked with **⚠ Preview** are wired in code but the public infrastructure they depend on (faucet, hosted RPC, canonical schemas, explorer) is still spinning up.
 
 This page takes a partner from "I just heard about Ligate" to "my first attestation landed on the public chain" in one continuous flow. No tribal knowledge, no jumping between three doc sites.
 
@@ -39,7 +39,7 @@ Verify the binary speaks to the public devnet:
 
 ```bash
 $ ligate --rpc https://rpc.ligate.io info
-chain_id:   ligate-devnet-2
+chain_id:   ligate-devnet-3
 chain_hash: lsch1amq80arndh6zehd4gu3kg6x66vh3l45z924dr6pzeevkxp649heqe5c70v
 version:    0.1.3
 ```
@@ -146,7 +146,7 @@ submitted attestation:
   outcome:      committed
 ```
 
-The `--chain-hash` and `--chain-id 4242` bind the signature to the chain so it can't be replayed against testnet or another devnet revision. Pull `chain-hash` from `ligate info --json`; the numeric `chain-id` is fixed (`4242` for ligate-devnet-2; the Cosmos-style string id `ligate-devnet-2` is separate).
+The `--chain-hash` and `--chain-id 4242` bind the signature to the chain so it can't be replayed against testnet or another devnet revision. Pull `chain-hash` from `ligate info --json`; the numeric `chain-id` is fixed (`4242` for ligate-devnet-3; the Cosmos-style string id `ligate-devnet-3` is separate).
 
 ---
 

--- a/localnet/celestia.toml
+++ b/localnet/celestia.toml
@@ -16,7 +16,7 @@
 
 # Chain identity. This file targets the local Celestia smoke flow,
 # which is also the localnet rung of the ladder. Public Celestia
-# devnet bumps this to `ligate-devnet-2`. See #181 and the spec
+# devnet bumps this to `ligate-devnet-3`. See #181 and the spec
 # section `Chain id` in `docs/protocol/attestation-v0.md`.
 [chain]
 chain_id = "ligate-localnet"

--- a/localnet/local-dev-key.json
+++ b/localnet/local-dev-key.json
@@ -1,5 +1,5 @@
 {
-  "_warning": "LOCAL DEVELOPMENT KEY ONLY. DO NOT USE FOR DEVNET, TESTNET, OR MAINNET. The private key is committed to the repo so anyone can sign transactions on a localnet boot. Equivalent of Anvil's account-0 dev key for Ethereum testing. Operators deploying ligate-devnet-2 must remove this key's address from `devnet/genesis/bank.json` before generating the genesis bundle (see crates/genesis-tool).",
+  "_warning": "LOCAL DEVELOPMENT KEY ONLY. DO NOT USE FOR DEVNET, TESTNET, OR MAINNET. The private key is committed to the repo so anyone can sign transactions on a localnet boot. Equivalent of Anvil's account-0 dev key for Ethereum testing. Operators deploying ligate-devnet-3 must remove this key's address from `devnet/genesis/bank.json` before generating the genesis bundle (see crates/genesis-tool).",
   "role": "dev",
   "private_key_hex": "0101010101010101010101010101010101010101010101010101010101010101",
   "public_key_hex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",

--- a/localnet/rollup.toml
+++ b/localnet/rollup.toml
@@ -14,7 +14,7 @@
 # defaults below assume you run from the repo root.
 
 # Chain identity. Locked ladder per docs/protocol/attestation-v0.md
-# `Chain id` section: `ligate-localnet` (this file), `ligate-devnet-2`
+# `Chain id` section: `ligate-localnet` (this file), `ligate-devnet-3`
 # (public devnet), `ligate-testnet-1` (later), `ligate-1` (mainnet).
 # The node refuses to boot with a value outside the ladder; see #181.
 [chain]


### PR DESCRIPTION
## What

Repo-side prep for the **devnet-2 to devnet-3 re-genesis** that brings the v0.4.0 bounty + contract marketplace live. v0.4.0 shifts `chain_hash` (`eec077f4…` to `60ec4d0b…`), so it is not state-compatible with devnet-2 and requires a chain-id ladder bump per `docs/development/runbooks/chain-id-bump.md`.

This PR is **non-destructive** (config + docs only). The live VM halt, state wipe, re-genesis, schema re-registration, and indexer Postgres TRUNCATE are the operational follow-on, executed after this merges.

## Changes

- **Archive** the deployed devnet-2 config to `archive/ligate-devnet-2/` (13 tracked files: `celestia.toml`, 8 genesis JSONs, README, `.gitignore`, `.example` templates). Mirrors the `archive/ligate-devnet-1/` pattern from #493. Raw secrets (`keys.toml`, `canonical-schemas.toml`) excluded.
- **Live chain-id bump**: `devnet/celestia.toml` `chain_id = "ligate-devnet-3"` (plus its header comments).
- **Test pins**: `localnet_config.rs` (parses + asserts the devnet config chain-id) and `info_smoke.rs` fixtures bumped to devnet-3.
- **Prose / comment sweep**: 29 network chain-id-string references across `constants.toml`, `localnet/*`, crate source comments, and `docs/development/*` bumped to devnet-3. Deployed GCP resource identifiers (`ligate-devnet-2-sequencer` / `-rpc` / `-sequencer-signer`) and Grafana UIDs are **preserved** via a negative-lookahead (bump `ligate-devnet-2` only when not followed by `-`).
- **CHANGELOG** `[Unreleased]` entry.

## Out of scope (deliberate)

- **README.md**: owned by the in-flight #544 (chain-first rewrite). The README devnet-status line flips to devnet-3 after both land.
- **Grafana** text panels + embedded `chain_hash`: updated post-cutover, once devnet-3 is live and the new bech32 `chain_hash` is readable from `/v1/rollup/info`. Live dashboards are in Grafana Cloud, separate from the repo JSON.
- `genesis_da_height` stays `0` in the committed genesis; the operator pins it to a live Mocha height at boot (env-override pattern) so devnet-3 does not replay devnet-2 blobs.

## Test plan

- [ ] CI green (cargo test exercises both bumped assertions: `devnet_celestia_toml_parses…` and `info_handles_concurrent_requests`)
- [ ] Boot-time ladder validator accepts `ligate-devnet-3` (accepts `ligate-devnet-N`)
- [ ] Operational cutover (separate, gated): halt VM, wipe state, re-genesis with devnet-3 + live `genesis_da_height`, re-register Themisra schema, TRUNCATE indexer Postgres + redeploy api, verify `/v1/info` shows `ligate-devnet-3`