### PR TITLE
chore(runner): save_tx_bodies=true so the ledger API returns tx bodies (#550)

### DIFF
--- a/devnet/celestia.toml
+++ b/devnet/celestia.toml
@@ -125,6 +125,16 @@ pruner_versions_to_keep = 20
 # Celestia produces ~12s blocks; polling 6× per block keeps inclusion
 # latency low without spamming the local light node.
 da_polling_interval_ms = 500
+# Persist the raw signed-transaction body in the ledger DB so the
+# ledger API (`/v1/ledger/txs`) returns it instead of an empty body.
+# ligate-api decodes the body to surface the real per-tx nonce +
+# signer pubkey (and computes the fee), replacing the null/0
+# placeholders that result when bodies are elided. Defaults to false
+# in the SDK (`save_tx_bodies`); we opt in. Modest ledger-size
+# increase, acceptable at devnet scale. Takes effect for txs ingested
+# after the node restarts with this set; pre-existing txs stay
+# body-less. See ligate-chain#550.
+save_tx_bodies = true
 
 [runner.http_config]
 # Localhost only by intent. Caddy (or your reverse proxy of choice)


### PR DESCRIPTION
## Why

Part 1 of #550. Every tx shows `nonce: null` (explorer renders `0`) because `/v1/ledger/txs` returns an empty body, and the per-tx nonce + signer pubkey live in that body.

Root cause: `sov-stf-runner` strips the tx body (`tx.body_to_save = None`) whenever the runner config's `save_tx_bodies` is false (`runner.rs:647`), and our `[runner]` section never set it, so it defaulted off (`#[serde(default)]`). The SDK already saves the body when the flag is on, no fork change needed.

## Change

Set `save_tx_bodies = true` under `[runner]` in `devnet/celestia.toml`. The node then persists the raw signed-tx body, and `populate_tx_response` returns it in every query mode (`StoredTransaction.body` passes straight through `TryFrom`).

## Rollout

- Takes effect on the live chain after the sequencer restarts with this config (brief, no re-genesis, no `chain_hash` change). Pre-existing txs stay body-less; new txs carry the body.
- Follow-ups (separate PRs): ligate-api decodes the body for real `nonce` + `sender_pubkey` (+ computes `fee_paid`); ligate-explorer renders them. The api's `nonce`/`sender_pubkey` columns are already nullable + waiting.

## Test plan
- [ ] CI green
- [ ] Post-deploy: `GET /v1/ledger/txs/{hash}` returns a non-empty `body.data` for a freshly-included tx