### PR TITLE
docs(runbook) + chore(deny): bump celestia-node to v0.31.1-mocha + advisory ignores hygiene

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -312,11 +312,13 @@ ignore = [
   # --- Vulnerability ignores (synced with audit.toml) ---
   "RUSTSEC-2023-0071", # rsa Marvin attack via sqlx-mysql (no MySQL in our path)
   "RUSTSEC-2025-0055", # tracing-subscriber ANSI escape via deep risc0 chain
-  "RUSTSEC-2025-0134", # rustls-pemfile unmaintained, jsonrpsee transitive
   "RUSTSEC-2025-0141", # bincode 1.x unmaintained via sov-db
-  "RUSTSEC-2026-0066", # astral-tokio-tar dir-traversal via sov-test-utils dev-dep
-  "RUSTSEC-2026-0112", # astral-tokio-tar PAX header desync, same dep path
-  "RUSTSEC-2026-0113", # astral-tokio-tar chmod via symlinks, same dep path
+  # 2026-06-10: RustSec advisory DB upstream rotated/withdrew 4 advisories
+  # we used to ignore (RUSTSEC-2025-0134 rustls-pemfile, RUSTSEC-2026-0066 /
+  # -0112 / -0113 astral-tokio-tar); cargo-deny then errors with
+  # "advisory was not encountered" on ignore entries that no longer match
+  # any crate. Removed; -0145 (the surviving astral-tokio-tar PAX desync)
+  # is still detected so it stays.
   "RUSTSEC-2026-0145", # astral-tokio-tar 0.6.1 PAX desync, same dep path (fix >= 0.6.2)
 
   # --- Unmaintained-crate advisories ---
@@ -327,6 +329,7 @@ ignore = [
   "RUSTSEC-2024-0388", # derivative, archived, transitive via SDK proc-macros
   "RUSTSEC-2024-0436", # paste, archived (still works), transitive deep
   "RUSTSEC-2025-0057", # fxhash, archived, transitive via SDK dep graph
+  "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained, transitive via sov-mock-da -> sea-orm-macros -> sea-bae
 ]
 
 [bans]

--- a/docs/development/runbooks/mocha-smoke.md
+++ b/docs/development/runbooks/mocha-smoke.md
@@ -225,7 +225,7 @@ Wiring:
 Workflow flow:
 
 1. Build `ligate-node` + `ligate-genesis-tool` (cold cache ~50 min; warm ~10-15).
-2. Install celestia-node v0.30.2, start it against `${MOCHA_BRIDGE}` (default `rpc-mocha.pops.one`).
+2. Install celestia-node v0.31.1-mocha or later (required for celestia-app v9 support; the 2026-06-01 Mocha v9 fork makes v0.30.2 and earlier reject all new headers). Start it against `${MOCHA_BRIDGE}` (default `rpc-mocha.pops.one`).
 3. Generate ephemeral keys (operator + demo1 + demo2), substitute all four placeholder addresses (3 `lig1` + 1 `celestia1`), run `ligate-genesis-tool generate --da celestia` to produce + verify a valid genesis, then anchor `genesis_da_height` to a live Mocha block.
 4. Boot `ligate-node --da-layer celestia` against the ephemeral genesis.
 5. Run steps 1-7 of the manual procedure (chain identity, slot encoding, DA metrics) against the running node.


### PR DESCRIPTION
## Summary

Bumps the celestia-node version pin in the mocha-smoke runbook from `v0.30.2` to `v0.31.1-mocha` (or later) and adds a one-line note about the 2026-06-01 Mocha v9 fork that made the old version reject all new headers.

## Why

On 2026-06-01 the Mocha testnet hard-forked to celestia-app v9. The Celestia light node `v0.30.2` we'd pinned only supports up to app v8, so post-fork it rejected every new header with:

> `header received at height 11789641 has version 9, this node supports up to version 8. Please upgrade to support new version.`

…which froze our light node, which froze our rollup, which crash-looped because a sequencer can't operate against a frozen DA layer. The runbook still pointed people at `v0.30.2`, so any future operator following it would have walked into the same trap.

The v0.31.0-mocha release notes are explicit: *"This release adds support for celestia-app v9... Once the v9 activation height takes place, upgrading to this version is required."*

## Live verification

Already applied to the production sequencer VM:
- Light node swapped to `v0.31.1-mocha` + `celestia light config-update --p2p.network mocha` → accepting v9 headers, tracking live Mocha tip
- Rollup restarted, `NRestarts=0`, sync caught up, **rollup head advancing past the previous stuck slot 98,601** (now well into production)
- **TIA wallet balance dropping** — confirms real PayForBlob submissions are landing on Celestia
- BetterStack chain-RPC monitor re-added (was missing, which is why nobody got paged for the week-long outage)

## Test plan

- [x] Diff renders cleanly
- [x] Live sequencer running v0.31.1-mocha + producing + submitting