### PR TITLE
ci(mocha-smoke): bump celestia-node to v0.31.1-mocha + switch GRPC fallback to pops.one (v9 fork)

### DIFF
--- a/.github/workflows/mocha-smoke.yml
+++ b/.github/workflows/mocha-smoke.yml
@@ -74,8 +74,14 @@ jobs:
       # `signer_private_key`). The runner has no co-located
       # `celestia-appd`, so this points at a public Mocha consensus
       # endpoint; override via the `MOCHA_GRPC_URL` repo variable to
-      # switch providers (e.g. during celestia-mocha.com maintenance).
-      SOV_CELESTIA_GRPC_URL: ${{ vars.MOCHA_GRPC_URL || 'http://full.consensus.mocha-4.celestia-mocha.com:9090' }}
+      # switch providers (e.g. during pops.one maintenance).
+      #
+      # 2026-06-01: the previous fallback (`full.consensus.mocha-4.celestia-mocha.com:9090`)
+      # went unreachable around the v9 fork. `rpc-mocha.pops.one:9090` is
+      # what the production sequencer + every other surviving Mocha
+      # operator points at; matching that here keeps the smoke and prod
+      # paths on the same consensus core.
+      SOV_CELESTIA_GRPC_URL: ${{ vars.MOCHA_GRPC_URL || 'http://rpc-mocha.pops.one:9090' }}
       # `celestia1...` bech32 of the operator's TIA wallet. Public
       # value (derived from the public key of `MOCHA_TIA_SIGNER_KEY`),
       # so it lives in a repo variable rather than a secret. Used to
@@ -138,9 +144,17 @@ jobs:
       # Install + initialize the Celestia light node. Pin to a known
       # version; bump as upstream releases land. Asset name is the
       # tarball; extract the `celestia` binary out of it.
+      #
+      # 2026-06-01: Mocha hard-forked to celestia-app v9; v0.30.2 and
+      # earlier reject every new header ("version 9, this node supports
+      # up to version 8") and freeze the light node. v0.31.0-mocha was
+      # the first release with v9 support; v0.31.1-mocha is the current
+      # patch. Same fork is what took down the public sequencer VM the
+      # week of 06-01 -- runbook `docs/development/runbooks/mocha-smoke.md`
+      # carries the operator-side note.
       - name: Install Celestia light node
         run: |
-          CELESTIA_VERSION=v0.30.2
+          CELESTIA_VERSION=v0.31.1-mocha
           curl -fL "https://github.com/celestiaorg/celestia-node/releases/download/${CELESTIA_VERSION}/celestia-node_Linux_x86_64.tar.gz" \
             -o /tmp/celestia.tar.gz
           tar -xzf /tmp/celestia.tar.gz -C /usr/local/bin celestia


### PR DESCRIPTION
## Summary

The nightly mocha-smoke CI has been failing every night since the 2026-06-01 Mocha v9 hard-fork — same root cause that took down the public sequencer last week. Bumps the two breakages:

- **`CELESTIA_VERSION=v0.30.2` → `v0.31.1-mocha`** (line 143). `v0.30.2` rejects every v9 header (`"version 9, this node supports up to version 8"`), so the light node starts but never catches up; the 10-min "Light node caught up" gate fires and the smoke fails (`FAIL: light node didn't catch up within 10 min, gap=0`). `v0.31.0-mocha` was the first release with v9 support; `v0.31.1-mocha` is the current patch.
- **`SOV_CELESTIA_GRPC_URL` fallback default** (line 78): `full.consensus.mocha-4.celestia-mocha.com:9090` → `rpc-mocha.pops.one:9090`. The old endpoint went unreachable from the runner around the v9 fork; `rpc-mocha.pops.one` is what the production sequencer + every other surviving Mocha operator uses, and it's the consensus core our own light node already trusts (`celestia light start --core.ip rpc-mocha.pops.one`). The `vars.MOCHA_GRPC_URL` override is preserved, so an operator can switch providers without another code change.

Inline comments document both bumps with the 06-01 v9-fork context, so the next time someone sees this they know why.

## Verification

- `python3 -c 'yaml.safe_load(...)'` → parses
- Production sequencer has been running v0.31.1-mocha + pops.one for ~17 hours: stable, producing slots, submitting to Celestia (`~1.43 TIA` spent on real PayForBlobs since the upgrade), zero crashes. So we're not guessing at the right pin.

## Failed nightlies fixed (all same root cause)

- 27267189482 (2026-06-10, 1h04m)
- 27195085622 (2026-06-09, 15m42s)
- 27130668194 (2026-06-08, 15m35s)

## Test plan

- [x] Diff renders cleanly + YAML parses
- [ ] CI on this PR green
- [ ] Next nightly (tomorrow ~09:35 UTC) passes